### PR TITLE
Add related link property as root term in traceability context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docs/traceability-openapi-v1.json
 docs/intermediate.json
 docs/sections/vocab.html
 packages/traceability-schemas/index.js
+
+docs/testsuite/index.html

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ After you have the dependencies, the first time setup is as follows:
 3. After the repository is checked out, and all dependencies have been installed, then you can build the vocabulary itself
 
    ```
-   $ npm runbuild:all
+   $ npm run build:all
    ```
 
    This can take a while, as it will run through the entire process of merging the individual schemas, creating test vectors, and ultimately creating a signed verifiable credential for each vocabulary item. If you would like to view details on the build process, please see the [README](https://github.com/w3c-ccg/traceability-vocab/tree/main/packages/traceability-schemas) located in the actual schemas build project folder.

--- a/packages/traceability-schemas/package.json
+++ b/packages/traceability-schemas/package.json
@@ -18,7 +18,8 @@
     "build:vocab": "node ./scripts/build-vocab.js ",
     "build:open-api": "node ./scripts/build-open-api.js ",
     "build:all": "npm run build:schemas && npm run build:intermediate && npm run build:context && npm run build:test-vectors && npm run build:credentials && npm run build:validate && npm run build:vocab && npm run build:open-api && npm run lint",
-    "test:schemas": "jest"
+    "test:schemas": "jest",
+    "test": "npm run test:schemas"
   },
   "dependencies": {
     "@transmute/credentials-context": "^0.0.4-unstable.2",

--- a/packages/traceability-schemas/rootTerms.json
+++ b/packages/traceability-schemas/rootTerms.json
@@ -1,0 +1,9 @@
+{
+  "name": "https://schema.org/name",
+  "description": "https://schema.org/description",
+  "identifier": "https://schema.org/identifier",
+  "image": {
+    "@id": "https://schema.org/image",
+    "@type": "@id"
+  }
+}

--- a/packages/traceability-schemas/rootTerms.json
+++ b/packages/traceability-schemas/rootTerms.json
@@ -5,5 +5,8 @@
   "image": {
     "@id": "https://schema.org/image",
     "@type": "@id"
+  },
+  "relatedLink": {
+    "@id": "https://w3id.org/traceability#LinkRole"
   }
 }

--- a/packages/traceability-schemas/schemas/BillOfLadingCertificate.json
+++ b/packages/traceability-schemas/schemas/BillOfLadingCertificate.json
@@ -39,7 +39,6 @@
       "type": "object"
     },
     "relatedLink": {
-      "$comment": "{\"term\": \"relatedLink\", \"@id\": \"https://w3id.org/traceability#LinkRole\"}",
       "title": "Related Link",
       "description": "Links related to this verifiable credential",
       "type": "array",

--- a/packages/traceability-schemas/schemas/CommercialInvoiceCertificate.json
+++ b/packages/traceability-schemas/schemas/CommercialInvoiceCertificate.json
@@ -39,7 +39,6 @@
       "type": "object"
     },
     "relatedLink": {
-      "$comment": "{\"term\": \"relatedLink\", \"@id\": \"https://w3id.org/traceability#LinkRole\"}",
       "title": "Related Link",
       "description": "Links related to this verifiable credential",
       "type": "array",

--- a/packages/traceability-schemas/schemas/MillTestReportCertificate.json
+++ b/packages/traceability-schemas/schemas/MillTestReportCertificate.json
@@ -39,7 +39,6 @@
       "type": "object"
     },
     "relatedLink": {
-      "$comment": "{\"term\": \"relatedLink\", \"@id\": \"https://w3id.org/traceability#LinkRole\"}",
       "title": "Related Link",
       "description": "Links related to this verifiable credential",
       "type": "array",

--- a/packages/traceability-schemas/scripts/getContextFromIntermediate.js
+++ b/packages/traceability-schemas/scripts/getContextFromIntermediate.js
@@ -1,3 +1,5 @@
+const rootTerms = require('../rootTerms.json');
+
 const getContextFromIntermediate = (intermediate) => {
   let partialContext = {};
   Object.values(intermediate).forEach((classDefinition) => {
@@ -24,15 +26,9 @@ const getContextFromIntermediate = (intermediate) => {
   return {
     '@context': {
       '@version': 1.1,
-      name: 'https://schema.org/name',
-      description: 'https://schema.org/description',
-      identifier: 'https://schema.org/identifier',
-      image: {
-        '@id': 'https://schema.org/image',
-        '@type': '@id',
-      },
       id: '@id',
       type: '@type',
+      ...rootTerms,
       ...partialContext,
     },
   };

--- a/packages/traceability-schemas/src/__fixtures__/BillOfLadingCertificate/bad.json
+++ b/packages/traceability-schemas/src/__fixtures__/BillOfLadingCertificate/bad.json
@@ -4,7 +4,7 @@
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/traceability/v1"
     ],
-    "name": "Commercial Invoice Certificate",
+    "name": "Bill Of Lading Certificate",
     "issuanceDate": "2019-12-11T03:50:55Z",
     "program": "synthesize"
   },

--- a/packages/traceability-schemas/src/__fixtures__/BillOfLadingCertificate/credential.json
+++ b/packages/traceability-schemas/src/__fixtures__/BillOfLadingCertificate/credential.json
@@ -19,7 +19,7 @@
       "VerifiableCredential",
       "BillOfLadingCertificate"
     ],
-    "name": "Commercial Invoice Certificate",
+    "name": "Bill Of Lading Certificate",
     "description": "This document includes recommended bill of lading fields.",
     "relatedLink": [
       {

--- a/packages/traceability-schemas/src/__fixtures__/BillOfLadingCertificate/good.json
+++ b/packages/traceability-schemas/src/__fixtures__/BillOfLadingCertificate/good.json
@@ -9,7 +9,7 @@
       "VerifiableCredential",
       "BillOfLadingCertificate"
     ],
-    "name": "Commercial Invoice Certificate",
+    "name": "Bill Of Lading Certificate",
     "description": "This document includes recommended bill of lading fields.",
     "relatedLink": [
       {
@@ -111,7 +111,7 @@
       "VerifiableCredential",
       "BillOfLadingCertificate"
     ],
-    "name": "Commercial Invoice Certificate",
+    "name": "Bill Of Lading Certificate",
     "description": "This document includes recommended bill of lading fields.",
     "relatedLink": [
       {
@@ -213,7 +213,7 @@
       "VerifiableCredential",
       "BillOfLadingCertificate"
     ],
-    "name": "Commercial Invoice Certificate",
+    "name": "Bill Of Lading Certificate",
     "description": "This document includes recommended bill of lading fields.",
     "relatedLink": [
       {

--- a/packages/traceability-schemas/src/__fixtures__/BillOfLadingCertificate/vc.json
+++ b/packages/traceability-schemas/src/__fixtures__/BillOfLadingCertificate/vc.json
@@ -8,7 +8,7 @@
     "VerifiableCredential",
     "BillOfLadingCertificate"
   ],
-  "name": "Commercial Invoice Certificate",
+  "name": "Bill Of Lading Certificate",
   "description": "This document includes recommended bill of lading fields.",
   "relatedLink": [
     {
@@ -102,7 +102,7 @@
   "proof": {
     "type": "Ed25519Signature2018",
     "created": "2019-12-11T03:50:55Z",
-    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..dAyp-iy0ATeAI6BTI3bQyzHV3JJOYdn5Fp0oGgNF-jh_1mBgkL_A2PjtdXP5YZtZJf-DsEa9vsBb6VAUU_xaAQ",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..KBXFCbBBEGB1TRHfgllZFrg57iHP5-IESDPXFrbepY_K2Eu7KmurVvniutQRSe_Gfwci4m0C1Mbk73x2ujmZBQ",
     "proofPurpose": "assertionMethod",
     "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U"
   }

--- a/packages/traceability-schemas/src/__fixtures__/EcommercePackageRegistrationEvidenceDocument/bad.json
+++ b/packages/traceability-schemas/src/__fixtures__/EcommercePackageRegistrationEvidenceDocument/bad.json
@@ -134,7 +134,7 @@
   {
     "type": "EcommercePackageRegistrationEvidenceDocument",
     "deliveryStatus": "EventMovedOnline",
-    "expectedArrivalFrom": "Sun Dec 31 2034 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Mon Jan 01 2035 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#DeliveryModePickUp",
     "deliveryAddress": {
       "type": "PostalAddress",

--- a/packages/traceability-schemas/src/__fixtures__/EcommercePackageRegistrationEvidenceDocument/credential.json
+++ b/packages/traceability-schemas/src/__fixtures__/EcommercePackageRegistrationEvidenceDocument/credential.json
@@ -15,7 +15,7 @@
     ],
     "type": "EcommercePackageRegistrationEvidenceDocument",
     "deliveryStatus": "EventPostponed",
-    "expectedArrivalFrom": "Mon Dec 31 2035 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Tue Jan 01 2036 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#UPS",
     "deliveryAddress": {
       "type": "PostalAddress",

--- a/packages/traceability-schemas/src/__fixtures__/EcommercePackageRegistrationEvidenceDocument/good.json
+++ b/packages/traceability-schemas/src/__fixtures__/EcommercePackageRegistrationEvidenceDocument/good.json
@@ -5,7 +5,7 @@
     ],
     "type": "EcommercePackageRegistrationEvidenceDocument",
     "deliveryStatus": "EventPostponed",
-    "expectedArrivalFrom": "Mon Dec 31 2035 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Tue Jan 01 2036 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#UPS",
     "deliveryAddress": {
       "type": "PostalAddress",
@@ -142,7 +142,7 @@
     ],
     "type": "EcommercePackageRegistrationEvidenceDocument",
     "deliveryStatus": "EventMovedOnline",
-    "expectedArrivalFrom": "Sun Dec 31 2034 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Mon Jan 01 2035 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#DeliveryModePickUp",
     "deliveryAddress": {
       "type": "PostalAddress",
@@ -255,7 +255,7 @@
     ],
     "type": "EcommercePackageRegistrationEvidenceDocument",
     "deliveryStatus": "EventPostponed",
-    "expectedArrivalFrom": "Mon Dec 31 2035 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Tue Jan 01 2036 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#DeliveryModePickUp",
     "deliveryAddress": {
       "type": "PostalAddress",

--- a/packages/traceability-schemas/src/__fixtures__/EcommercePackageRegistrationEvidenceDocument/vc.json
+++ b/packages/traceability-schemas/src/__fixtures__/EcommercePackageRegistrationEvidenceDocument/vc.json
@@ -15,7 +15,7 @@
     ],
     "type": "EcommercePackageRegistrationEvidenceDocument",
     "deliveryStatus": "EventPostponed",
-    "expectedArrivalFrom": "Mon Dec 31 2035 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Tue Jan 01 2036 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#UPS",
     "deliveryAddress": {
       "type": "PostalAddress",
@@ -149,7 +149,7 @@
   "proof": {
     "type": "Ed25519Signature2018",
     "created": "2019-12-11T03:50:55Z",
-    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xzg1DznvIqGFI0v3hJOqlXR9oanRJ-uf6BXjC3wTt-lW0GwFid1nN9ahE_qKWeHdcuGQqjv96uTDfsdUGgVTBw",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wLoh4Vf8pW8COrfFBV55XWVDw_3t-aiImPaTevzgzDz05Tm6E77UoI4cvz5hdeihqjrKJavoEiKFCIw3jfqLAA",
     "proofPurpose": "assertionMethod",
     "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U"
   }

--- a/packages/traceability-schemas/src/__fixtures__/EcommercePackingListRegistrationEvidenceDocument/bad.json
+++ b/packages/traceability-schemas/src/__fixtures__/EcommercePackingListRegistrationEvidenceDocument/bad.json
@@ -118,7 +118,7 @@
   },
   {
     "deliveryStatus": "EventCancelled",
-    "expectedArrivalFrom": "Thu Dec 31 2037 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Fri Jan 01 2038 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#DeliveryModeMail",
     "originAddress": {
       "type": "PostalAddress",

--- a/packages/traceability-schemas/src/__fixtures__/EcommercePackingListRegistrationEvidenceDocument/credential.json
+++ b/packages/traceability-schemas/src/__fixtures__/EcommercePackingListRegistrationEvidenceDocument/credential.json
@@ -15,7 +15,7 @@
     ],
     "type": "EcommercePackingListRegistrationEvidenceDocument",
     "deliveryStatus": "EventScheduled",
-    "expectedArrivalFrom": "Sat Dec 31 2039 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Sun Jan 01 2040 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#DHL",
     "deliveryAddress": {
       "type": "PostalAddress",

--- a/packages/traceability-schemas/src/__fixtures__/EcommercePackingListRegistrationEvidenceDocument/good.json
+++ b/packages/traceability-schemas/src/__fixtures__/EcommercePackingListRegistrationEvidenceDocument/good.json
@@ -5,7 +5,7 @@
     ],
     "type": "EcommercePackingListRegistrationEvidenceDocument",
     "deliveryStatus": "EventScheduled",
-    "expectedArrivalFrom": "Sat Dec 31 2039 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Sun Jan 01 2040 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#DHL",
     "deliveryAddress": {
       "type": "PostalAddress",
@@ -111,7 +111,7 @@
     ],
     "type": "EcommercePackingListRegistrationEvidenceDocument",
     "deliveryStatus": "EventScheduled",
-    "expectedArrivalFrom": "Sat Dec 31 2033 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Sun Jan 01 2034 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#DeliveryModeFreight",
     "deliveryAddress": {
       "type": "PostalAddress",
@@ -163,7 +163,7 @@
     ],
     "type": "EcommercePackingListRegistrationEvidenceDocument",
     "deliveryStatus": "EventCancelled",
-    "expectedArrivalFrom": "Thu Dec 31 2037 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Fri Jan 01 2038 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#DeliveryModeMail",
     "deliveryAddress": {
       "type": "PostalAddress",

--- a/packages/traceability-schemas/src/__fixtures__/EcommercePackingListRegistrationEvidenceDocument/vc.json
+++ b/packages/traceability-schemas/src/__fixtures__/EcommercePackingListRegistrationEvidenceDocument/vc.json
@@ -15,7 +15,7 @@
     ],
     "type": "EcommercePackingListRegistrationEvidenceDocument",
     "deliveryStatus": "EventScheduled",
-    "expectedArrivalFrom": "Sat Dec 31 2039 19:00:00 GMT-0500 (Eastern Standard Time)",
+    "expectedArrivalFrom": "Sun Jan 01 2040 00:00:00 GMT+0000 (Coordinated Universal Time)",
     "hasDeliveryMethod": "http://purl.org/goodrelations/v1#DHL",
     "deliveryAddress": {
       "type": "PostalAddress",
@@ -118,7 +118,7 @@
   "proof": {
     "type": "Ed25519Signature2018",
     "created": "2019-12-11T03:50:55Z",
-    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2z1m2G_BeNuT3xNamAh58kd6EVZPrmUau5dZUJmc9XFFpj_GNSERxw9ej5NqbeRDt0XZNwMGbcfFvn54kc7QAA",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..P03_cYrZzSy0Yqv1r89019L7vL-mu5QmkIYdO0BUMWBhesly8KhIggKtOLQ6bENx7DHD_0cNRxmuDkVfrNQWDg",
     "proofPurpose": "assertionMethod",
     "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U"
   }


### PR DESCRIPTION
As part of our anchoring process, we need the `relatedLink` property for all kinds of credentials, not just for `BillOfLadingCertificate`, `CommercialInvoiceCertificate`, `MillTestReportCertificate` as the context is currently defined.

Therefore this PR makes `relatedLink` a root term in the context:

- Add a `rootTerms` file that contains all terms not defined in the context of a type
- Add `relatedLink` as a rootTerm

Cleanup:
- Fix typo in README
- Update fixtures