### PR TITLE
[Chore] Readme cleanups

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
     <script type="text/javascript" class="remove">
       var respecConfig = {
         // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
-        specStatus: 'UNOFFICIAL',
+        specStatus: 'unofficial',
 
         // the specification's short name, as in http://www.w3.org/TR/short-name/
         shortName: 'traceability-vocab',

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,10 @@
         // if you wish the publication date to be other than today, set this
         // publishDate:  "2009-08-06",
 
+        //subtitle
+        subtitle: 'A vocabulary for traceability in supply chains',
+
+
         // if there is a previously published draft,
         // uncomment this and set its YYYY-MM-DD date
         // and its maturity status

--- a/packages/traceability-schemas/scripts/getVocabFromIntermediate.js
+++ b/packages/traceability-schemas/scripts/getVocabFromIntermediate.js
@@ -24,7 +24,7 @@ const getVocabFromIntermediate = (intermediate) => {
       classPropertySections += `
             <section id="${classProperty.$comment.term}">
               <h3>${classProperty.title}</h3>
-              <p>${classProperty.description}</p>
+              ${classProperty.description ? `<p>${classProperty.description}</p>` : ''}
 
               <table class="simple">
                   <tbody>
@@ -53,7 +53,7 @@ const getVocabFromIntermediate = (intermediate) => {
     vocabularyString += `
           <section id="${classDefinition.$comment.term}">
           <h2>${classDefinition.title}</h2>
-          <p>${classDefinition.description}</p>
+          ${classDefinition.description ? `<p>${classDefinition.description}</p>` : ''}
 
           <table class="simple">
                   <tbody>


### PR DESCRIPTION
* fixes #174 by simply skipping description fields when generating the template for vocab.
this does not actually validate if the schema actually has a description field ( do we need that as a separate issue?)
* fixes Subtitle/Unofficial designation of the spec.