### PR TITLE
gitignore now ignores contentx of __Fixtures__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,6 @@ docs/traceability-openapi-v1.json
 docs/intermediate.json
 docs/sections/vocab.html
 packages/traceability-schemas/index.js
-packages/traceability-schemas/__fixtures__
+packages/traceability-schemas/src/__fixtures__/*
 
 docs/testsuite/index.html


### PR DESCRIPTION
The last push didn't actually fix the .gitignore to ignore the fixtures file. 
Mea culpa

