### PR TITLE
Add vocab for undefined terms

### DIFF
--- a/packages/traceability-schemas/scripts/getContextFromIntermediate.js
+++ b/packages/traceability-schemas/scripts/getContextFromIntermediate.js
@@ -26,6 +26,7 @@ const getContextFromIntermediate = (intermediate) => {
   return {
     '@context': {
       '@version': 1.1,
+      '@vocab': 'https://w3id.org/traceability/#undefinedTerm',
       id: '@id',
       type: '@type',
       ...rootTerms,

--- a/packages/traceability-schemas/scripts/getVocabFromIntermediate.js
+++ b/packages/traceability-schemas/scripts/getVocabFromIntermediate.js
@@ -24,7 +24,11 @@ const getVocabFromIntermediate = (intermediate) => {
       classPropertySections += `
             <section id="${classProperty.$comment.term}">
               <h3>${classProperty.title}</h3>
-              ${classProperty.description ? `<p>${classProperty.description}</p>` : ''}
+              ${
+                classProperty.description
+                  ? `<p>${classProperty.description}</p>`
+                  : ''
+              }
 
               <table class="simple">
                   <tbody>
@@ -33,7 +37,9 @@ const getVocabFromIntermediate = (intermediate) => {
 <a href="https://json-ld.org/spec/latest/json-ld/#dfn-terms">Term</a>
                       </td>
                       <td>
-          <a href="${classProperty.$comment['@id']}">${classProperty.$comment.term}</a>
+          <a href="${classProperty.$comment['@id']}">${
+        classProperty.$comment.term
+      }</a>
                       </td>
                       </tr>
                       <tr>
@@ -41,7 +47,9 @@ const getVocabFromIntermediate = (intermediate) => {
 <a href="https://json-ld.org/spec/latest/json-ld/#dfn-iris">Full IRI</a>
                       </td>
                       <td>
-          <a href="${classProperty.$comment['@id']}">${classProperty.$comment['@id']}</a>
+          <a href="${classProperty.$comment['@id']}">${
+        classProperty.$comment['@id']
+      }</a>
                       </td>
                       </tr>
                   </tbody>
@@ -53,7 +61,11 @@ const getVocabFromIntermediate = (intermediate) => {
     vocabularyString += `
           <section id="${classDefinition.$comment.term}">
           <h2>${classDefinition.title}</h2>
-          ${classDefinition.description ? `<p>${classDefinition.description}</p>` : ''}
+          ${
+            classDefinition.description
+              ? `<p>${classDefinition.description}</p>`
+              : ''
+          }
 
           <table class="simple">
                   <tbody>
@@ -125,6 +137,14 @@ const getVocabFromIntermediate = (intermediate) => {
       https://github.com/w3c-ccg/traceability-vocab/tree/main/docs/schemas
     </a>
   </p>
+
+  <section>
+  <h3 id="undefinedTerm">Undefined terms</h3>
+  <p>This vocabulary uses <code> '@vocab': 'https://w3id.org/traceability/#undefinedTerm' </code>, 
+    to disable JSON-LD related errors associated with Verifiable Credentials issued over 
+    terms that have not yet been added here. 
+  </p>
+</section>
   
   
   ${vocabularyString}

--- a/packages/traceability-schemas/scripts/getVocabFromIntermediate.js
+++ b/packages/traceability-schemas/scripts/getVocabFromIntermediate.js
@@ -140,8 +140,8 @@ const getVocabFromIntermediate = (intermediate) => {
 
   <section>
   <h3 id="undefinedTerm">Undefined terms</h3>
-  <p>This vocabulary uses <code> '@vocab': 'https://w3id.org/traceability/#undefinedTerm' </code>, 
-    to disable JSON-LD related errors associated with Verifiable Credentials issued over 
+  <p>This vocabulary uses <code> '@vocab': 'https://w3id.org/traceability/#undefinedTerm' </code>
+    to disable JSON-LD related errors associated with Verifiable Credentials, issued about
     terms that have not yet been added here. 
   </p>
 </section>


### PR DESCRIPTION
Schema.org does the same thing, so I think its a good idea...

See also: https://github.com/w3c/vc-data-model/issues/753

Here is a poc showing the potential problems with this approach: 

https://github.com/acarnagey/verify-credential-test

Notice this unfortunate typo:

https://github.com/acarnagey/verify-credential-test/blob/865a1af971efa8f696b0e36bf9fe4b1611632a1a/documentLoader.js

In this case, the developer thought they were using the traceability context, but they were not.... all terms were being dropped.

If credentials v1 had an `@vocab`, this would not be possible.
