### PR TITLE
chore: added usmca product specifier example

### DIFF
--- a/docs/openapi/components/schemas/common/UsmcaProductSpecifier.yml
+++ b/docs/openapi/components/schemas/common/UsmcaProductSpecifier.yml
@@ -64,5 +64,22 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "issue": "https://github.com/w3c-ccg/traceability-vocab/issues/239"
+    "type": "UsmcaProductSpecifier",
+    "product": {
+      "type": [
+        "Product"
+      ],
+      "sku": "323050346937",
+      "description": "Non-alloy steel rolls",
+      "commodity": {
+        "type": [
+          "Commodity"
+        ],
+        "commodityCode": "721320",
+        "commodityCodeType": "HS",
+        "description": "Steel Coils"
+      }
+    },
+    "originCriterion": "A",
+    "countryOfOrigin": "MX"
   }


### PR DESCRIPTION
https://github.com/w3c-ccg/traceability-vocab/issues/239