### PR TITLE
fix: clean up openapi yaml files

### DIFF
--- a/docs/openapi/components/schemas/common/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/common/CTPATCertificate.yml
@@ -103,9 +103,7 @@ example: |-
     ],
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      {
-        "@vocab": "https://w3id.org/traceability/v1/vocab#"
-      }
+      "https://w3id.org/traceability/v1"
     ],
     "id": "did:key:z6LSpdSReUHCjYcQb1243aF1vS7sd9ArK585Mm4ktARQxatd",
     "name": "CTPAT Certificate",
@@ -115,12 +113,10 @@ example: |-
       "name": "United States Customs Trade Partnership Against Terrorism",
       "description": "Your Supply Chain's Strongest Link",
       "email": "ctpathelpdesk@cbp.dhs.gov",
-      "phoneNumber": "1-800-927-8729",
-      "id": "did:key:z6MkjArXVLoKSmFgBXNpug5eehrwpy9hLLbBq7rT2wYamdDr"
+      "phoneNumber": "1-800-927-8729"
     },
     "issuanceDate": "2022-01-13T09:16:46Z",
     "credentialSubject": {
-      "id": "did:key:z6MkhfZ7sNYEJ8vFSpwJaeyN7zNUaTxS4TBxW3y6R9ZKRaQ4",
       "type": "Organization",
       "name": "Trans-Atlantic Shipping Co. Ltd.",
       "address": {

--- a/docs/openapi/components/schemas/common/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/common/CTPATCertificate.yml
@@ -115,10 +115,12 @@ example: |-
       "name": "United States Customs Trade Partnership Against Terrorism",
       "description": "Your Supply Chain's Strongest Link",
       "email": "ctpathelpdesk@cbp.dhs.gov",
-      "phoneNumber": "1-800-927-8729"
+      "phoneNumber": "1-800-927-8729",
+      "id": "did:key:z6MkjArXVLoKSmFgBXNpug5eehrwpy9hLLbBq7rT2wYamdDr"
     },
     "issuanceDate": "2022-01-13T09:16:46Z",
     "credentialSubject": {
+      "id": "did:key:z6MkhfZ7sNYEJ8vFSpwJaeyN7zNUaTxS4TBxW3y6R9ZKRaQ4",
       "type": "Organization",
       "name": "Trans-Atlantic Shipping Co. Ltd.",
       "address": {

--- a/docs/openapi/components/schemas/common/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/common/CTPATCertificate.yml
@@ -20,7 +20,7 @@ properties:
     type: array
     const:
       - 'https://www.w3.org/2018/credentials/v1'
-      - 'https://w3id.org/traceability/v1'
+      - '@vocab': 'https://w3id.org/traceability/v1/vocab#'
   type:
     type: array
     const:
@@ -103,7 +103,9 @@ example: |-
     ],
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/traceability/v1"
+      {
+        "@vocab": "https://w3id.org/traceability/v1/vocab#"
+      }
     ],
     "id": "did:key:z6LSpdSReUHCjYcQb1243aF1vS7sd9ArK585Mm4ktARQxatd",
     "name": "CTPAT Certificate",

--- a/docs/openapi/components/schemas/common/Context.yml
+++ b/docs/openapi/components/schemas/common/Context.yml
@@ -1,3 +1,6 @@
+$linkedData:
+  term: Context
+  '@id': https://w3id.org/traceability#Context
 type: object
 description: Context objects define JSON-LD terms.
 properties:
@@ -8,7 +11,7 @@ properties:
         type: number
       '@vocab':
         type: string
-example:
+example: |-
   {
     '@context':
       {

--- a/docs/openapi/components/schemas/common/DCSAShippingInstruction.yml
+++ b/docs/openapi/components/schemas/common/DCSAShippingInstruction.yml
@@ -275,16 +275,17 @@ example: |-
         "numberOfPackages": 245
       }
     ],
-    "utilizedTransportEquipments": {
-      "type": "TransportEquipment",
-      "id": "urn:epc:id:bic:YMLU3380910",
-      "equipmentReference": "YMLU3380910",
-      "ISOEquipmentCode": "20G1",
-      "seals": [
-        {
-          "type": "Seal",
-          "sealNumber": "YMAI715692"
-        }
-      ]
-    }
+    "utilizedTransportEquipments": [
+      {
+        "type": "TransportEquipment",
+        "equipmentReference": "YMLU3380910",
+        "ISOEquipmentCode": "20G1",
+        "seals": [
+          {
+            "type": "Seal",
+            "sealNumber": "YMAI715692"
+          }
+        ]
+      }
+    ]
   }

--- a/docs/openapi/components/schemas/common/DCSAShippingInstructionCertificate.yml
+++ b/docs/openapi/components/schemas/common/DCSAShippingInstructionCertificate.yml
@@ -35,9 +35,7 @@ example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      {
-        "@vocab": "https://w3id.org/traceability/v1/vocab#"
-      }
+      "https://w3id.org/traceability/v1"
     ],
     "id": "did:key:z6MkheSarjLFMn8QkJENopCr1ryPSSdKGHQfHtPinkb516kG",
     "type": [

--- a/docs/openapi/components/schemas/common/DCSAShippingInstructionCertificate.yml
+++ b/docs/openapi/components/schemas/common/DCSAShippingInstructionCertificate.yml
@@ -9,7 +9,7 @@ properties:
     type: array
     const:
       - 'https://www.w3.org/2018/credentials/v1'
-      - 'https://w3id.org/traceability/v1'
+      - '@vocab': 'https://w3id.org/traceability/v1/vocab#'
   type:
     type: array
     const:
@@ -35,7 +35,9 @@ example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/traceability/v1"
+      {
+        "@vocab": "https://w3id.org/traceability/v1/vocab#"
+      }
     ],
     "id": "did:key:z6MkheSarjLFMn8QkJENopCr1ryPSSdKGHQfHtPinkb516kG",
     "type": [

--- a/docs/openapi/components/schemas/common/DCSATransportDocument.yml
+++ b/docs/openapi/components/schemas/common/DCSATransportDocument.yml
@@ -286,51 +286,54 @@ example: |-
           "numberOfPackages": 245
         }
       ],
-      "utilizedTransportEquipments": {
-        "type": "TransportEquipment",
-        "id": "urn:epc:id:bic:YMLU3380910",
-        "equipmentReference": "YMLU3380910",
-        "ISOEquipmentCode": "20G1",
-        "seals": [
-          {
-            "type": "Seal",
-            "sealNumber": "YMAI715692"
-          }
-        ]
-      }
+      "utilizedTransportEquipments": [
+        {
+          "type": "TransportEquipment",
+          "equipmentReference": "YMLU3380910",
+          "ISOEquipmentCode": "20G1",
+          "seals": [
+            {
+              "type": "Seal",
+              "sealNumber": "YMAI715692"
+            }
+          ]
+        }
+      ]
     },
-    "transports": {
-      "type": "Transport",
-      "loadLocation": {
-        "type": "Place",
-        "address": {
-          "type": "PostalAddress",
-          "addressRegion": "Xiamen",
-          "addressCountry": "CN"
-        }
-      },
-      "dischargeLocation": {
-        "type": "Place",
-        "address": {
-          "type": "PostalAddress",
-          "addressRegion": "Antwerp",
-          "addressCountry": "BE"
-        }
-      },
-      "modeOfTransport": "Vessel",
-      "carrier": {
-        "type": "Organization",
-        "name": "MULTI CONTAINER LINE",
-        "address": {
-          "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
-          "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-          "addressLocality": "Kowloon Bay",
-          "addressRegion": "Hong Kong",
-          "addressCountry": "Hong Kong SAR"
-        }
-      },
-      "vesselNumber": "HMM Algeciras",
-      "voyageNumber": "V.0004W"
-    }
+    "transports": [
+      {
+        "type": "Transport",
+        "loadLocation": {
+          "type": "Place",
+          "address": {
+            "type": "PostalAddress",
+            "addressRegion": "Xiamen",
+            "addressCountry": "CN"
+          }
+        },
+        "dischargeLocation": {
+          "type": "Place",
+          "address": {
+            "type": "PostalAddress",
+            "addressRegion": "Antwerp",
+            "addressCountry": "BE"
+          }
+        },
+        "modeOfTransport": "Vessel",
+        "carrier": {
+          "type": "Organization",
+          "name": "MULTI CONTAINER LINE",
+          "address": {
+            "type": "PostalAddress",
+            "organizationName": "MCL Multi Container Line LTD.",
+            "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
+            "addressLocality": "Kowloon Bay",
+            "addressRegion": "Hong Kong",
+            "addressCountry": "Hong Kong SAR"
+          }
+        },
+        "vesselNumber": "HMM Algeciras",
+        "voyageNumber": "V.0004W"
+      }
+    ]
   }

--- a/docs/openapi/components/schemas/common/DCSATransportDocumentCertificate.yml
+++ b/docs/openapi/components/schemas/common/DCSATransportDocumentCertificate.yml
@@ -41,9 +41,7 @@ example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      {
-        "@vocab": "https://w3id.org/traceability/v1/vocab#"
-      }
+      "https://w3id.org/traceability/v1"
     ],
     "id": "did:key:z6MkfX5oKE8vuuftWn7mZJRZqpPTxGk9oK94gnCztcEkb7Vd",
     "type": [

--- a/docs/openapi/components/schemas/common/DCSATransportDocumentCertificate.yml
+++ b/docs/openapi/components/schemas/common/DCSATransportDocumentCertificate.yml
@@ -9,7 +9,7 @@ properties:
     type: array
     const:
       - 'https://www.w3.org/2018/credentials/v1'
-      - 'https://w3id.org/traceability/v1'
+      - '@vocab': 'https://w3id.org/traceability/v1/vocab#'
   type:
     type: array
     const:
@@ -41,7 +41,9 @@ example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/traceability/v1"
+      {
+        "@vocab": "https://w3id.org/traceability/v1/vocab#"
+      }
     ],
     "id": "did:key:z6MkfX5oKE8vuuftWn7mZJRZqpPTxGk9oK94gnCztcEkb7Vd",
     "type": [

--- a/docs/openapi/components/schemas/common/FreightManifestCertificate.yml
+++ b/docs/openapi/components/schemas/common/FreightManifestCertificate.yml
@@ -9,7 +9,7 @@ properties:
     type: array
     const:
       - 'https://www.w3.org/2018/credentials/v1'
-      - 'https://w3id.org/traceability/v1'
+      - '@vocab': 'https://w3id.org/traceability/v1/vocab#'
   type:
     type: array
     const:
@@ -34,7 +34,9 @@ example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/traceability/v1"
+      {
+        "@vocab": "https://w3id.org/traceability/v1/vocab#"
+      }
     ],
     "id": "did:key:z6Mkki9HaBA2cB5kETPzsKSR661Erzw13joNt4HqhhAY7Nqi",
     "type": [

--- a/docs/openapi/components/schemas/common/FreightManifestCertificate.yml
+++ b/docs/openapi/components/schemas/common/FreightManifestCertificate.yml
@@ -34,9 +34,7 @@ example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      {
-        "@vocab": "https://w3id.org/traceability/v1/vocab#"
-      }
+      "https://w3id.org/traceability/v1"
     ],
     "id": "did:key:z6Mkki9HaBA2cB5kETPzsKSR661Erzw13joNt4HqhhAY7Nqi",
     "type": [

--- a/docs/openapi/components/schemas/common/SIMASteelImportLicenseApplication.yml
+++ b/docs/openapi/components/schemas/common/SIMASteelImportLicenseApplication.yml
@@ -41,8 +41,7 @@ properties:
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exporterParty
   manufacturer:
     title: Manufacturer
-    description: Name of manufacturer(s) of the product(s) or shipper(s). May list multiple
-manufacturers or as unknown.
+    description: Name of manufacturer(s) of the product(s) or shipper(s). May list multiple manufacturers or as unknown.
     type: array
     items:
       $ref: ./Organization.yml
@@ -58,7 +57,7 @@ manufacturers or as unknown.
       '@id': https://schema.org/addressCountry
   countryOfExportation:
     title: Country of Exportation
-    description: Country of Exportation: Country from which the product(s) were exported. The two-letter ISO 3166-1 alpha-2 country code.
+    description: Country from which the product(s) were exported. The two-letter ISO 3166-1 alpha-2 country code.
     type: string
     $linkedData:
       term: countryOfExportation
@@ -71,14 +70,6 @@ manufacturers or as unknown.
       term: expectedPortOfEntry
       '@id': >-
         https://service.unece.org/trade/uncefact/vocabulary/uncefact/#UNECELOCODE
-  expectedDateOfExport: 
-    title: Expected Date of Export
-    description: Date product(s) expected to be shipped from the country of exportation.
-    type: string
-    $linkedData:
-      term: expectedDateOfExport
-      '@id': >-
-        http://www.w3.org/2001/XMLSchema#dateTime
   expectedDateOfExport: 
     title: Expected Date of Export
     description: Date product(s) expected to be shipped from the country of exportation.
@@ -101,13 +92,15 @@ manufacturers or as unknown.
     type: array
     items:
       $ref: ./SIMASteelImportProductSpecifier.yml
+    $linkedData:
+      term: productInformation
+      '@id': https://w3id.org/traceability#SIMASteelImportProductSpecifier
 additionalProperties: true
 example: |-
   {
-    "type": "SIMASteelImportLicenseApplication", 
+    "type": "SIMASteelImportLicense", 
     "applicantCompany": {
       "type": "Organization",
-      "id": "did:key:z6Mkj8LpyahD8sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",
       "name": "Maxi Acero Mexicano",
       "description": "Fusión y fabricación de acero sólido",
       "address": {
@@ -121,7 +114,7 @@ example: |-
       "email": "info@example.net",
       "phoneNumber": "555-127-7813"
     }, 
-    "customsEntryNumber": 34001239, 
+    "customsEntryNumber": "34001239", 
     "importer": {
       "type": "Organization",
       "name": "American Prime Steel Inc.",
@@ -152,21 +145,23 @@ example: |-
       "email": "info@example.net",
       "phoneNumber": "555-127-7813"
     }, 
-    "manufacturer": {
-      "type": "Organization",
-      "name": "Maxi Acero Mexicano",
-      "description": "Fusión y fabricación de acero sólido",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Avenida Carlos 100",
-        "addressLocality": "Hernádez de Mara",
-        "addressRegion": "Nuevo Leon",
-        "postalCode": "32200",
-        "addressCountry": "Mexico"
-      },
-      "email": "info@example.net",
-      "phoneNumber": "555-127-7813"
-    }, 
+    "manufacturer": [
+      {
+        "type": "Organization",
+        "name": "Maxi Acero Mexicano",
+        "description": "Fusión y fabricación de acero sólido",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "Avenida Carlos 100",
+          "addressLocality": "Hernádez de Mara",
+          "addressRegion": "Nuevo Leon",
+          "postalCode": "32200",
+          "addressCountry": "Mexico"
+        },
+        "email": "info@example.net",
+        "phoneNumber": "555-127-7813"
+      }
+    ], 
     "countryOfOrigin": "MX", 
     "countryOfExportation": "MX", 
     "expectedPortOfEntry": "USMOB", 
@@ -192,7 +187,7 @@ example: |-
             "description": "Steel Coils"
           }
         },
-        "customsValue": "4450"
+        "customsValue": 4450
       }
     ]
   }

--- a/docs/openapi/components/schemas/common/SIMASteelImportProductSpecifier.yml
+++ b/docs/openapi/components/schemas/common/SIMASteelImportProductSpecifier.yml
@@ -33,3 +33,7 @@ properties:
     $linkedData:
       term: value
       '@id': https://schema.org/MonetaryAmount
+example: |-
+  {
+    "issue": "https://github.com/w3c-ccg/traceability-vocab/issues/298"
+  }

--- a/docs/openapi/components/schemas/common/TraceablePresentation.yml
+++ b/docs/openapi/components/schemas/common/TraceablePresentation.yml
@@ -1,14 +1,16 @@
+$linkedData:
+  term: TraceablePresentation
+  '@id': https://w3id.org/traceability#TraceablePresentation
 title: TraceablePresentation
 type: object
 description: A JSON-LD Presentation which establishes traceability linkage to a workflow instance and workflow type. 
-  - type: object
-    properties:
-      workflow:
-        $ref: "./Workflow.yml"
-        description: Establishes a traceable link from the presentation to a workflow.
-    required: 
-      - workflow
-example:
+properties:
+  workflow:
+    $ref: "./Workflow.yml"
+    description: Establishes a traceable link from the presentation to a workflow.
+required: 
+  - workflow
+example: |-
   {
     "@context":
       [
@@ -91,6 +93,6 @@ example:
         "verificationMethod": "did:example:123#key-2",
         "proofPurpose": "authentication",
         "challenge": "123",
-        "jws": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Q0J7CcbM19fvfLdBZ44MlndvNACnmb0x1SM0cGnECye_-JC3Of29eroksqsVDTyXGAaQ_gnvcB4cqefK0jLIOg",
-      },
+        "jws": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Q0J7CcbM19fvfLdBZ44MlndvNACnmb0x1SM0cGnECye_-JC3Of29eroksqsVDTyXGAaQ_gnvcB4cqefK0jLIOg"
+      }
   }

--- a/docs/openapi/components/schemas/common/Transport.yml
+++ b/docs/openapi/components/schemas/common/Transport.yml
@@ -5,9 +5,7 @@ title: Transport
 description: A transport which can be a leg of a journey.
 type: object
 required:
-  - shippingStopAddress
   - carrier
-  - stopType
 properties:
   loadLocation:
     title: Load Location

--- a/docs/openapi/components/schemas/common/USMCACertificateOfOrigin.yml
+++ b/docs/openapi/components/schemas/common/USMCACertificateOfOrigin.yml
@@ -14,7 +14,7 @@ properties:
     type: array
     const:
       - 'https://www.w3.org/2018/credentials/v1'
-      - 'https://w3id.org/traceability/v1'
+      - '@vocab': 'https://w3id.org/traceability/v1/vocab#'
   type:
     type: array
     const:
@@ -122,7 +122,9 @@ example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/traceability/v1"
+      {
+        "@vocab": "https://w3id.org/traceability/v1/vocab#"
+      }
     ],
     "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
     "type": [

--- a/docs/openapi/components/schemas/common/USMCACertificateOfOrigin.yml
+++ b/docs/openapi/components/schemas/common/USMCACertificateOfOrigin.yml
@@ -119,7 +119,7 @@ properties:
 additionalProperties: true
 required: []
 example: |-
-{
+  {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/traceability/v1"
@@ -200,28 +200,26 @@ example: |-
         "phoneNumber": "555-127-7813"
       }
     ],
-    "credentialSubject": [
-      {
-        "type": "USMCAProductSpecifier",
-        "product": {
+    "credentialSubject": {
+      "type": "USMCAProductSpecifier",
+      "product": {
+        "type": [
+          "Product"
+        ],
+        "sku": "323050346937",
+        "description": "Non-alloy steel rolls",
+        "commodity": {
           "type": [
-            "Product"
+            "Commodity"
           ],
-          "sku": "323050346937",
-          "description": "Non-alloy steel rolls",
-          "commodity": {
-            "type": [
-              "Commodity"
-            ],
-            "commodityCode": "721320",
-            "commodityCodeType": "HS",
-            "description": "Steel Coils"
-          }
-        },
-        "originCriterion": "A",
-        "countryOfOrigin": "MX"
-      }
-    ],
+          "commodityCode": "721320",
+          "commodityCodeType": "HS",
+          "description": "Steel Coils"
+        }
+      },
+      "originCriterion": "A",
+      "countryOfOrigin": "MX"
+    },
     "blanketPeriodFrom": "2021-06-22",
     "blanketPeriodTo": "2022-06-21",
     "proof": {

--- a/docs/openapi/components/schemas/common/USMCACertificateOfOrigin.yml
+++ b/docs/openapi/components/schemas/common/USMCACertificateOfOrigin.yml
@@ -119,12 +119,10 @@ properties:
 additionalProperties: true
 required: []
 example: |-
-  {
+{
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      {
-        "@vocab": "https://w3id.org/traceability/v1/vocab#"
-      }
+      "https://w3id.org/traceability/v1"
     ],
     "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
     "type": [

--- a/docs/openapi/components/schemas/common/USMCACertifier.yml
+++ b/docs/openapi/components/schemas/common/USMCACertifier.yml
@@ -47,7 +47,6 @@ example: |-
     "role": "Exporter",
     "certifierDetails": {
       "type": "Organization",
-      "id": "did:key:z6Mkj8LpyahD8sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",
       "name": "Maxi Acero Mexicano",
       "description": "Fusión y fabricación de acero sólido",
       "address": {

--- a/docs/openapi/components/schemas/common/Workflow.yml
+++ b/docs/openapi/components/schemas/common/Workflow.yml
@@ -1,19 +1,21 @@
+$linkedData:
+  term: Workflow
+  '@id': https://w3id.org/traceability#Workflow
 title: Workflow
 type: object
 description: A workflow instance and definition. 
-  - type: object
-    properties:
-      definition: 
-        description: Identifier of a particular type of workflow. 
-        type: array
-        items:
-          type: string
-      instance:
-        description: Identifier of an instance of a workflow type. 
-        type: array
-        items:
-          type: string
-example:
+properties:
+  definition: 
+    description: Identifier of a particular type of workflow. 
+    type: array
+    items:
+      type: string
+  instance:
+    description: Identifier of an instance of a workflow type. 
+    type: array
+    items:
+      type: string
+example: |-
   {
     "definition": [
       "n1552885-cc91-4bb3-91f1-5466a0be084e"

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -1040,6 +1040,18 @@ paths:
                 $ref: './components/schemas/common/SIMASteelImportLicenseCertification.yml'
     
 
+  /schemas/common/SIMASteelImportProductSpecifier.yml:
+    get:
+      tags:
+      - Common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/SIMASteelImportProductSpecifier.yml'
+    
+
   /schemas/common/Seal.yml:
     get:
       tags:


### PR DESCRIPTION
This PR cleans up a number of minor issues with the YAML schema files.

Of these changes, a few are pretty much guesses and definitely need review:
- There were a handful of examples where additional properties were passed to entities with `additionalProperties: false` (often "ID" to Organization instances). I chose to remove the additional parameters being passed in.
  - in CTPATCertificate.yml
  - in DCSATransportDocument.yml
  - in USMCACertifier.yml
- Several example `@context`s listed something like:
  ```
      "@context": [
        "https://www.w3.org/2018/credentials/v1",
        {
          "@vocab": "https://w3id.org/traceability/v1/vocab#"
        }
      ],
  ```
  which conflicted with `@context` defined as a const:
  ```
    '@context':
      type: array
      const:
        - 'https://www.w3.org/2018/credentials/v1'
        - 'https://w3id.org/traceability/v1'
  ```
  In these cases I changed the const to:
  ```
    const:
      - 'https://www.w3.org/2018/credentials/v1'
      - '@vocab': 'https://w3id.org/traceability/v1/vocab#'
  ```
- A few schemas were missing `$linkedData`. I filled these in with best guesses:
  - Context.yml
  - TraceablePresentation.yml
  - Workflow.yml
- In one case a `$linkedData` was similarly missing from a property:
  - SIMASteelImportLicenseApplication.yml (`productInformation` property)
- In Transport.yml there were two required properties that weren't actually present as properties, which I removed.

(Changes I'm more confident about not mentioned)