### PR TITLE
Add Placeholder `PurchaseOrder` and `PurchaseOrderCertificate`

### DIFF
--- a/docs/openapi/components/schemas/common/PurchaseOrder.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrder.yml
@@ -1,3 +1,6 @@
+$linkedData:
+  term: PurchaseOrder
+  '@id': https://w3id.org/traceability#PurchaseOrder
 title: PurchaseOrder
 type: object
 description: A statement issued by a buyer for the sale of products or services to be delivered at a later date

--- a/docs/openapi/components/schemas/common/PurchaseOrder.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrder.yml
@@ -1,0 +1,8 @@
+title: PurchaseOrder
+type: object
+description: A statement issued by a buyer for the sale of products or services to be delivered at a later date
+additionalProperties: true
+example: |-
+  {
+    "type": "PurchaseOrder"
+  }

--- a/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
@@ -1,0 +1,82 @@
+$linkedData:
+  term: PurchaseOrderCertificate
+  '@id': https://w3id.org/traceability#PurchaseOrderCertificate
+title: Commercial Invoice Certificate
+description: Certifications made about a purchase order
+type: object
+properties:
+  '@context':
+    type: array
+    const:
+      - 'https://www.w3.org/2018/credentials/v1'
+      - 'https://w3id.org/traceability/v1'
+  type:
+    type: array
+    const:
+      - VerifiableCredential
+      - PurchaseOrderCertificate
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  issuer:
+    type: object
+  credentialSubject:
+    $ref: ./PurchaseOrder.yml
+  proof:
+    type: object
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ./LinkRole.yml
+additionalProperties: false
+required: []
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "https://example.com/credential/123",
+    "type": [
+      "VerifiableCredential",
+      "PurchaseOrderCertificate"
+    ],
+    "name": "Purchase Order Certificate",
+    "description": "This document includes recommended purchase order fields.",
+    "relatedLink": [],
+    "issuanceDate": "2019-12-11T03:50:55Z",
+    "issuer": {
+      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "type": "Organization",
+      "name": "Waters Inc",
+      "description": "Stand-alone executive benchmark",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "027 Brakus Knoll",
+        "addressLocality": "East Johnniemouth",
+        "addressRegion": "Arizona",
+        "postalCode": "25780-5840",
+        "addressCountry": "Grenada"
+      },
+      "email": "Kendrick.Spinka57@example.org",
+      "phoneNumber": "555-322-9464",
+      "faxNumber": "555-766-1744"
+    },
+    "credentialSubject": {
+      "type": "PurchaseOrder"
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2022-03-01T17:54:40Z",
+      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ySb9Cw-uQVuh40QKMWRrJ8OKJC1uyg3VmyKuNiR5WnLhILVI2Wy07IcBkQe0w926A8NdmcQKwGTZIN4TKyzWCQ"
+    }
+  }

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -968,6 +968,30 @@ paths:
                 $ref: './components/schemas/common/Purchase.yml'
     
 
+  /schemas/common/PurchaseOrder.yml:
+    get:
+      tags:
+      - Common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/PurchaseOrder.yml'
+    
+
+  /schemas/common/PurchaseOrderCertificate.yml:
+    get:
+      tags:
+      - Common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/PurchaseOrderCertificate.yml'
+    
+
   /schemas/common/Qualification.yml:
     get:
       tags:

--- a/packages/traceability-schemas/data/README.md
+++ b/packages/traceability-schemas/data/README.md
@@ -2,24 +2,28 @@ This directory is reserved for testing credentials that will only work with:
 
 ##### LOCAL JSON-LD `@context` changes.
 
-Without this directory and the associated tooling scripts, authors would need to publish examples in a 2 step process, as seen [here](https://github.com/w3c-ccg/traceability-vocab/pull/262).
-Linking to this issue does not describe how to add context.
+Without this directory and the associated tooling scripts, authors would need to publish examples in a 2 step process,
+as described in this document.
 
 ## Usage
+
+In order to add a Verifiable Credential schema with a signed JSON example,
+you must first run `npm run build` to create a new local JSON-LD context file which is located at
+`docs/context/traceability-v1.jsonld` relative to the root of this repository.
+
+From there you should take the example Credential JSON without the proof,
+and replace the `credential.json` file in this directory with the Credential you intend to sign.
+
+From there run the following command in this directory.
 
 ```
 npm run create:future:vc:example ./data/credential.json
 ```
 
-This will result in a new file `./data/credential.verifiable.json`
-
-This file will contain a linked data proof which was generated over the LOCAL JSON-LD Context.
-
-This credential will not verify remotely until the remote context is published:
-
-```
-./docs/contexts/traceability-v1.jsonld -> after publish -> https://w3id.org/traceability/v1
-```
+The signed Credential will be written to this directory as `credential.verifiable.json`.
+Open the file and copy the content JSON into the `example:` section of your YML schema
+definition. Run `npm run test` from the root of this repository to make sure that the
+Verifiable Credential passes verification before commiting and opening a Pull Request.
 
 These files can be added to Schemas as examples because the CI system uses the local context to verify them.
 

--- a/packages/traceability-schemas/data/README.md
+++ b/packages/traceability-schemas/data/README.md
@@ -2,53 +2,22 @@ This directory is reserved for testing credentials that will only work with:
 
 ##### LOCAL JSON-LD `@context` changes.
 
-Without this directory and the associated tooling scripts, authors would need to publish examples in a 2 step process,
-as described in this document.
+Without this directory and the associated tooling scripts, authors would need to publish examples in a 2 step process, as seen [here](https://github.com/w3c-ccg/traceability-vocab/pull/262).
 
 ## Usage
-
-In order to add a Verifiable Credential schema with a signed JSON example,
-you must first run `npm run build` to create a new local JSON-LD context file which is located at
-`docs/context/traceability-v1.jsonld` relative to the root of this repository.
-
-From there you should take the example Credential JSON without the proof,
-and replace the `credential.json` file in this directory with the Credential you intend to sign.
-
-From there run the following command in this directory.
 
 ```
 npm run create:future:vc:example ./data/credential.json
 ```
 
-The signed Credential will be written to this directory as `credential.verifiable.json`.
-In addition, the content of the Verifiable Credential will also be displayed in the
-console, along with a message to indicate if the Verifiable Credential passed local verification.
+This will result in a new file `./data/credential.verifiable.json`
+
+This file will contain a linked data proof which was generated over the LOCAL JSON-LD Context.
+
+This credential will not verify remotely until the remote context is published:
 
 ```
-✅  the Verifiable Credential was verified successfully.
+./docs/contexts/traceability-v1.jsonld -> after publish -> https://w3id.org/traceability/v1
 ```
-
-Open the file and copy the content JSON into the `example:` section of your YML schema
-definition. Run `npm run test` from the root of this repository to make sure that the
-Verifiable Credential passes verification before commiting and opening a Pull Request.
 
 These files can be added to Schemas as examples because the CI system uses the local context to verify them.
-
-## Adding Schemas
-
-A linked data term will need to be added to the top of each OpenAPI schema definition, or the CI will fail.
-Provided below is an example of the minimum required placeholder for a new schema to be added to the repository.
-
-```
-$linkedData:
-  term: PurchaseOrder
-  '@id': https://w3id.org/traceability#PurchaseOrder
-title: PurchaseOrder
-type: object
-description: A statement issued by a buyer for the sale of products or services to be delivered at a later date
-additionalProperties: true
-example: |-
-  {
-    "type": "PurchaseOrder"
-  }
-```

--- a/packages/traceability-schemas/data/README.md
+++ b/packages/traceability-schemas/data/README.md
@@ -3,6 +3,7 @@ This directory is reserved for testing credentials that will only work with:
 ##### LOCAL JSON-LD `@context` changes.
 
 Without this directory and the associated tooling scripts, authors would need to publish examples in a 2 step process, as seen [here](https://github.com/w3c-ccg/traceability-vocab/pull/262).
+Linking to this issue does not describe how to add context.
 
 ## Usage
 

--- a/packages/traceability-schemas/data/README.md
+++ b/packages/traceability-schemas/data/README.md
@@ -21,6 +21,13 @@ npm run create:future:vc:example ./data/credential.json
 ```
 
 The signed Credential will be written to this directory as `credential.verifiable.json`.
+In addition, the content of the Verifiable Credential will also be displayed in the
+console, along with a message to indicate if the Verifiable Credential passed local verification.
+
+```
+✅  the Verifiable Credential was verified successfully.
+```
+
 Open the file and copy the content JSON into the `example:` section of your YML schema
 definition. Run `npm run test` from the root of this repository to make sure that the
 Verifiable Credential passes verification before commiting and opening a Pull Request.

--- a/packages/traceability-schemas/data/README.md
+++ b/packages/traceability-schemas/data/README.md
@@ -22,3 +22,22 @@ This credential will not verify remotely until the remote context is published:
 ```
 
 These files can be added to Schemas as examples because the CI system uses the local context to verify them.
+
+## Adding Schemas
+
+A linked data term will need to be added to the top of each OpenAPI schema definition, or the CI will fail.
+Provided below is an example of the minimum required placeholder for a new schema to be added to the repository.
+
+```
+$linkedData:
+  term: PurchaseOrder
+  '@id': https://w3id.org/traceability#PurchaseOrder
+title: PurchaseOrder
+type: object
+description: A statement issued by a buyer for the sale of products or services to be delivered at a later date
+additionalProperties: true
+example: |-
+  {
+    "type": "PurchaseOrder"
+  }
+```


### PR DESCRIPTION
This pull request adds a `PurchaseOrderCertificate`, which is a verifiable credential wrapper for a `PurchaseOrder`.
Currently the `PurchaseOrder` is loosely typed allowing for credentials to be issued. 
Definitions for the `PurchaseOrder` schema will be added in subsequent pull requests. 