### PR TITLE
PackingList Definition Clarification

### DIFF
--- a/docs/openapi/components/schemas/common/PackingList.yml
+++ b/docs/openapi/components/schemas/common/PackingList.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: PackingListCertificate
-  '@id': https://w3id.org/traceability#PackingListCertificate
-title: Packing List Certificate
+  term: PackingList
+  '@id': https://w3id.org/traceability#PackingList
+title: Packing List
 description: Evidence data for a registered eCommerce Packing List
 type: object
 required:
@@ -15,7 +15,7 @@ properties:
       - type: array
       - type: string
         enum:
-          - PackingListCertificate
+          - PackingList
   deliveryStatus:
     title: DeliveryStatus
     type: string
@@ -109,7 +109,7 @@ properties:
         https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity
 example: |-
   {
-    "type": "PackingListCertificate",
+    "type": "PackingList",
     "deliveryAddress": {
       "type": "PostalAddress",
       "streetAddress": "IC. Modewegs Vej 1",

--- a/docs/openapi/components/schemas/common/PackingListCertificate.yml
+++ b/docs/openapi/components/schemas/common/PackingListCertificate.yml
@@ -1,0 +1,185 @@
+$linkedData:
+  term: PackingListCertificate
+  '@id': https://w3id.org/traceability#PackingListCertificate
+title: Commercial Invoice Certificate
+description: Certifications made about a purchase order
+type: object
+properties:
+  '@context':
+    type: array
+    const:
+      - 'https://www.w3.org/2018/credentials/v1'
+      - 'https://w3id.org/traceability/v1'
+  type:
+    type: array
+    const:
+      - VerifiableCredential
+      - PackingListCertificate
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  issuer:
+    type: object
+  credentialSubject:
+    $ref: ./PackingList.yml
+  proof:
+    type: object
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ./LinkRole.yml
+additionalProperties: false
+required: []
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "https://example.com/credential/123",
+    "type": [
+      "VerifiableCredential",
+      "PackingListCertificate"
+    ],
+    "name": "Packing List Certificate",
+    "description": "Evidence data for a registered eCommerce Packing List",
+    "relatedLink": [],
+    "issuanceDate": "2019-12-11T03:50:55Z",
+    "issuer": {
+      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "type": "Organization",
+      "name": "Waters Inc",
+      "description": "Stand-alone executive benchmark",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "027 Brakus Knoll",
+        "addressLocality": "East Johnniemouth",
+        "addressRegion": "Arizona",
+        "postalCode": "25780-5840",
+        "addressCountry": "Grenada"
+      },
+      "email": "Kendrick.Spinka57@example.org",
+      "phoneNumber": "555-322-9464",
+      "faxNumber": "555-766-1744"
+    },
+    "credentialSubject": {
+      "type": "PackingList",
+      "deliveryAddress": {
+        "type": "PostalAddress",
+        "streetAddress": "IC. Modewegs Vej 1",
+        "addressLocality": "Kgs. Lyngby",
+        "postalCode": "2800",
+        "addressCountry": "DK"
+      },
+      "provider": {
+        "type": "Organization",
+        "name": "Xxinau Manufacturing Co. Ltd.",
+        "description": "Advanced Production - Delivered",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "Xin Fei Da Dao 139",
+          "addressLocality": "Xindao",
+          "addressRegion": "Fujian Province",
+          "postalCode": "361100",
+          "addressCountry": "CN"
+        },
+        "email": "xxinau-sales@example.org",
+        "phoneNumber": "+86-555-865-8495"
+      },
+      "originAddress": {
+        "type": "PostalAddress",
+        "streetAddress": "Xin Fei Da Dao 139",
+        "addressLocality": "Xindao",
+        "addressRegion": "Fujian Province",
+        "postalCode": "361100",
+        "addressCountry": "CN"
+      },
+      "partOfOrder": [
+        {
+          "orderNumber": "PO00000329",
+          "manufacturer": {
+            "type": "Organization",
+            "name": "Xxinau Manufacturing Co. Ltd.",
+            "description": "Advanced Production - Delivered",
+            "address": {
+              "type": "PostalAddress",
+              "streetAddress": "Xin Fei Da Dao 139",
+              "addressLocality": "Xindao",
+              "addressRegion": "Fujian Province",
+              "postalCode": "361100",
+              "addressCountry": "CN"
+            },
+            "email": "xxinau-sales@example.org",
+            "phoneNumber": "+86-555-865-8495"
+          },
+          "transportPackages": [
+            {
+              "type": "Package",
+              "physicalShippingMarks": "by ACRE AGE IS THE NEW BLACK",
+              "itemQuantity": 540,
+              "perPackageUnitQuantity": 1,
+              "shippedItems": {
+                "description": "Rollators",
+                "itemCount": 540
+              },
+              "netWeight": 4302,
+              "grossWeight": 3834,
+              "weightUnit": "kg",
+              "grossVolume": 66.96,
+              "volumeUnit": "cbm"
+            },
+            {
+              "type": "Package",
+              "physicalShippingMarks": "by ACRE AGE IS THE NEW BLACK",
+              "itemQuantity": 2,
+              "perPackageUnitQuantity": 100,
+              "shippedItems": {
+                "description": "Rollator backrest",
+                "itemCount": 200
+              },
+              "netWeight": 42,
+              "grossWeight": 44,
+              "weightUnit": "kg",
+              "grossVolume": 0.28,
+              "volumeUnit": "cbm"
+            },
+            {
+              "type": "Package",
+              "physicalShippingMarks": "by ACRE AGE IS THE NEW BLACK",
+              "itemQuantity": 80,
+              "perPackageUnitQuantity": 1,
+              "shippedItems": {
+                "description": "Carton box",
+                "itemCount": 80
+              },
+              "netWeight": 50,
+              "grossWeight": 160,
+              "weightUnit": "kg",
+              "grossVolume": 0.5,
+              "volumeUnit": "cbm"
+            }
+          ],
+          "grossWeight": 4038,
+          "weightUnit": "kg",
+          "grossVolume": 67.74,
+          "volumeUnit": "cbm",
+          "packageQuantity": 622,
+          "itemQuantity": 820
+        }
+      ]
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2022-03-03T15:51:24Z",
+      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..RKuV_ZeOMCelvVYSLjtlmU7_MfXzEZrkT8O06Fg1rTDeWZK0wxdgk64w_AYq6sF4fQU2oqzUz9MqjvGxJEoOBw"
+    }
+  }

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -872,7 +872,7 @@ paths:
                 $ref: './components/schemas/common/Package.yml'
     
 
-  /schemas/common/PackingListCertificate.yml:
+  /schemas/common/PackingList.yml:
     get:
       tags:
       - Common
@@ -881,7 +881,7 @@ paths:
           content:
             application/yml:
               schema:
-                $ref: './components/schemas/common/PackingListCertificate.yml'
+                $ref: './components/schemas/common/PackingList.yml'
     
 
   /schemas/common/ParcelDelivery.yml:

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -884,6 +884,18 @@ paths:
                 $ref: './components/schemas/common/PackingList.yml'
     
 
+  /schemas/common/PackingListCertificate.yml:
+    get:
+      tags:
+      - Common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/PackingListCertificate.yml'
+    
+
   /schemas/common/ParcelDelivery.yml:
     get:
       tags:


### PR DESCRIPTION
The `PackingListCertificate` in the current definition uses the term "Certificate" but does not define a Verifiable Credential. This pull request renames `PackingListCertificate` to `PackingList`. And then defines `PackingListCertificate` as a Verifiable Credential with a `PackingList` as the `credentialSubject`. 