### PR TITLE
fix: `Import` to `Importer` typo on Importer Security Filing

### DIFF
--- a/docs/openapi/components/schemas/common/ImporterSecurityFiling.yml
+++ b/docs/openapi/components/schemas/common/ImporterSecurityFiling.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: ImportSecurityFiling
-  '@id': https://w3id.org/traceability#ImportSecurityFiling
-title: Import Security Filing
+  term: ImporterSecurityFiling
+  '@id': https://w3id.org/traceability#ImporterSecurityFiling
+title: Importer Security Filing
 description: An Importer Security Filing, commonly known as “10+2”, is a filing process that is required by the United States Customs and Border Protection (CPB) which requires import containerized cargo information. The information must be transmitted to the agency at least 24 hours before goods are loaded onboard a vessel to the USA. https://www.cbp.gov/border-security/ports-entry/cargo-security/importer-security-filing-102
 type: object
 properties:
@@ -10,7 +10,7 @@ properties:
       - type: array
       - type: string
         enum:
-          - ImportSecurityFiling
+          - ImporterSecurityFiling
   seller: 
     title: Seller
     description: An entity which offers (sells / leases / lends / loans) the services / goods. A seller may also be a provider.

--- a/docs/openapi/components/schemas/common/ImporterSecurityFilingCertificate.yml
+++ b/docs/openapi/components/schemas/common/ImporterSecurityFilingCertificate.yml
@@ -26,7 +26,7 @@ properties:
   issuer:
     type: object
   credentialSubject:
-    type: object
+    $ref: ./ImporterSecurityFiling.yml
   proof:
     type: object
 additionalProperties: false
@@ -167,9 +167,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-02-24T11:37:33Z",
+      "created": "2022-03-07T09:58:07Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..GSPUv9WD_DL3Cdq5An5UxkSTHAiuEo9EhHj5Yna24Tv6nzWEfSRssTLDXgbjccAdWFPqlTWarM6qKTMb0u_5AA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..3icbXUpiA6RiosqxNrIeJRqG7QahRa7gDd5N0onSwV0Rj3BsR2h-UByZcsj0yae0HBOgHo0-LQj_r_YYNO3zAQ"
     }
   }


### PR DESCRIPTION
The type name was wrong - it's _Importer Security Filing_ (which is part of the larger _Import Security Filing_ program that also includes Carriers' data submission). 