### PR TITLE
feat: example data for HBL, MBL and SI

### DIFF
--- a/docs/openapi/components/schemas/common/HouseBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/HouseBillOfLading.yml
@@ -1,0 +1,174 @@
+$linkedData:
+  term: HouseBillOfLading
+  '@id': https://w3id.org/traceability#HouseBillOfLading
+title: HouseBillOfLading
+description: A separately identifiable collection of goods items to be transported or available to be transported from one consignor to one consignee via one or more modes of transport where each consignment is the subject of one single transport contract.
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+      - type: string
+        enum:
+          - HouseBillOfLading
+  billOfLadingNumber:
+    title: Bill Of Lading Number
+    description: >-
+      A unique number allocated by the shipping line to the transport document
+      and the main number used for the tracking of the status of the shipment.
+    type: string
+    $linkedData:
+      term: billOfLadingNumber
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number
+  bookingNumber:
+    title: Booking Number
+    description:  A unique identifier assigned by the carrier to the consignment, such as a booking reference number when cargo space is reserved prior to loading.
+    type: array
+    items: 
+      type: string
+    $linkedData:
+      term: bookingNumber
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierAssignedId
+  shipper: 
+    title: Shipper
+    description: A consignor party for the consignment.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: shipper
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consignorParty
+  consignee:
+    title: Consignee
+    description: A consignee party for the consignment.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: consignee
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty
+  forwardingAgent: 
+    title: Forwarding Agent
+    description: The freight forwarder party for this supply chain consignment.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: notifyParty
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#freightForwarderParty
+  notifyParty:
+    title: Notify Party
+    description: The freight forwarder party for this supply chain consignment.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: notifyParty
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#notifyParty
+  carrier:
+    title: Carrier
+    description: A carrier party.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: carrier
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierParty
+  manufacturingCountry: 
+    title: Manufacturing Country
+    description: Manufacturing country.
+    type: string
+    $linkedData:
+      term: countryOfOrigin
+      '@id': https://w3id.org/traceability#countryOfOrigin
+  totalNumberOfPackages: 
+    title: Total Number of Packages
+    description: A number of packages.
+    type: number
+    $linkedData:
+      term: totalNumberOfPackages
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity
+  dateOfExport:
+    title: Date of Export
+    description: The date, time, date time, or other date time value when this supply chain consignment will exit, or has exited from, the last port, airport, or border post of the country of export.
+    type: string
+    $linkedData:
+      term: dateOfExport
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exportExitDateTime
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
+  includedConsignmentItem:
+    title: Included Consignment Item
+    description: A consignment item included in the consignment.
+    $ref: ./ConsignmentItem.yml
+    $linkedData:
+      term: includedConsignmentItem
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem
+required:
+  - billOfLadingNumber
+example: |-
+  {
+    "type": "HouseBillOfLading",
+    "bookingNumber": [
+      "EX600812234"
+    ],
+    "billOfLadingNumber": "EX600812234A",
+    "shipper": {
+      "type": "Organization",
+      "name": "Espresso Italiano Co.",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "Via Vico Ferrovia 5",
+        "addressLocality": "Goro",
+        "addressRegion": "Ferrara",
+        "postalCode": "44020",
+        "addressCountry": "IT"
+      },
+      "email": "sales@espresso-italiano.example.com",
+      "phoneNumber": "+39 0351 9067195"
+    },
+    "consignee": {
+      "type": "Organization",
+      "name": "Prosumer Coffee Supplies, Ltd.",
+      "description": "Coffee Machine Imports",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "3934 Spinnaker Lane",
+        "addressLocality": "Joliet",
+        "addressRegion": "Illinois",
+        "postalCode": "60432",
+        "addressCountry": "US"
+      }
+    },
+    "carrier": {
+      "type": "Organization",
+      "name": "World Forward, Inc.",
+      "address": {
+        "type": "PostalAddress",
+        "organizationName": "MCL Multi Container Line LTD.",
+        "streetAddress": "Well Fung Ind Centre",
+        "addressLocality": "Kwai Chung",
+        "addressRegion": "Hong Kong",
+        "addressCountry": "Hong Kong"
+      }
+    },
+    "manufacturingCountry": "IT",
+    "totalNumberOfPackages": 880,
+    "dateOfExport": "2022-02-02T09:30:00Z",
+    "consignmentItems": [
+      {
+        "marksAndNumbers": "Espresso Italiano",
+        "commodity": {
+          "type": "Commodity",
+          "commodityCode": "851671",
+          "commodityCodeType": "HS"
+        },
+        "quantity": 880,
+        "netWeight": {
+          "type": "QuantitativeValue",
+          "unitCode": "kg",
+          "value": "14600"
+        },
+        "netWeight": {
+          "type": "QuantitativeValue",
+          "unitCode": "kg",
+          "value": "15960"
+        }
+      }
+    ]
+  }

--- a/docs/openapi/components/schemas/common/HouseBillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/common/HouseBillOfLadingCertificate.yml
@@ -4,7 +4,7 @@ $linkedData:
 title: House Bill of Lading Certificate
 description: >- 
   A bill of lading issued by a freight forwarder. Often covers a consignment of parcels from various shippers that has been grouped or consolidated by the forwarder. The forwarder may, for example, receive a single groupage bill of lading from the carrier, then issue a series of House B/Ls to the respective shipper.
-  (source: Olegario Llamazares: DICTIONARY OF INTERNATIONAL TRADE, Key definitions of 2000 trade terms and acronyms).
+  (source: Olegario Llamazares: Dictionary Of International Trade, Key definitions of 2000 trade terms and acronyms).
 type: object
 properties:
   '@context':
@@ -26,9 +26,9 @@ properties:
   issuanceDate:
     type: string
   issuer:
-    type: object
+    $ref: ./Entity.yml
   credentialSubject:
-    type: object
+    $ref: ./HouseBillOfLading.yml
   proof:
     type: object
   relatedLink:
@@ -38,43 +38,102 @@ properties:
     items:
       $ref: ./LinkRole.yml
 additionalProperties: false
-required: []
 example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/traceability/v1"
     ],
-    "id": "https://example.com/credential/123",
+    "id": "did:key:z6MkmbqKc6KncFZUbVJwUppttTkiMAtnVJ5wzC5oVBWci3pc",
     "type": [
       "VerifiableCredential",
-      "HouseBillOfLadingCertificate"
+      "MasterBillOfLadingCertificate"
     ],
-    "name": "House Bill Of Lading",
+    "name": "Master Bill Of Lading",
     "issuanceDate": "2022-03-04T13:40:00Z",
     "issuer": {
       "type": "Organization",
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "MULTI CONTAINER LINE",
+      "name": "World Forward, Inc.",
       "address": {
         "type": "PostalAddress",
         "organizationName": "MCL Multi Container Line LTD.",
-        "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-        "addressLocality": "Kowloon Bay",
+        "streetAddress": "Well Fung Ind Centre",
+        "addressLocality": "Kwai Chung",
         "addressRegion": "Hong Kong",
-        "addressCountry": "Hong Kong SAR"
+        "addressCountry": "Hong Kong"
       }
     },
     "credentialSubject": {
-      "type": [
-        "Consignment"
+      "type": "HouseBillOfLading",
+      "bookingNumber": [
+        "EX600812234"
+      ],
+      "billOfLadingNumber": "EX600812234A",
+      "shipper": {
+        "type": "Organization",
+        "name": "Espresso Italiano Co.",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "Via Vico Ferrovia 5",
+          "addressLocality": "Goro",
+          "addressRegion": "Ferrara",
+          "postalCode": "44020",
+          "addressCountry": "IT"
+        },
+        "email": "sales@espresso-italiano.example.com",
+        "phoneNumber": "+39 0351 9067195"
+      },
+      "consignee": {
+        "type": "Organization",
+        "name": "Prosumer Coffee Supplies, Ltd.",
+        "description": "Coffee Machine Imports",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "3934 Spinnaker Lane",
+          "addressLocality": "Joliet",
+          "addressRegion": "Illinois",
+          "postalCode": "60432",
+          "addressCountry": "US"
+        }
+      },
+      "carrier": {
+        "type": "Organization",
+        "name": "World Forward, Inc.",
+        "address": {
+          "type": "PostalAddress",
+          "organizationName": "MCL Multi Container Line LTD.",
+          "streetAddress": "Well Fung Ind Centre",
+          "addressLocality": "Kwai Chung",
+          "addressRegion": "Hong Kong",
+          "addressCountry": "Hong Kong"
+        }
+      },
+      "manufacturingCountry": "IT",
+      "totalNumberOfPackages": 880,
+      "dateOfExport": "2022-02-02T09:30:00Z",
+      "consignmentItems": [
+        {
+          "marksAndNumbers": "Espresso Italiano",
+          "commodity": {
+            "type": "Commodity",
+            "commodityCode": "851671",
+            "commodityCodeType": "HS"
+          },
+          "quantity": 880,
+          "netWeight": {
+            "type": "QuantitativeValue",
+            "unitCode": "kg",
+            "value": "15960"
+          }
+        }
       ]
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-04T13:10:21Z",
+      "created": "2022-03-08T15:58:38Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..rsmy5fkli1fk7bh_huMS9gUtRpwUcuvqjKfEsRF8DTMv8cfRJigIcXQA1y2f6LQGKQok82s84RLo6ioeOoJVCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..nHvnFsLZTSJ8IxoWy8nvRNKJf-np5w5vntMi0lVwxrB7NLAw6PumVRnJt_jsCdoIW8puBbb-OmlxTwYzNax0DQ"
     }
   }

--- a/docs/openapi/components/schemas/common/MasterBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MasterBillOfLading.yml
@@ -1,0 +1,175 @@
+$linkedData:
+  term: MasterBillOfLading
+  '@id': https://w3id.org/traceability#MasterBillOfLading
+title: MasterBillOfLading
+description: A separately identifiable collection of goods items to be transported or available to be transported from one consignor to one consignee via one or more modes of transport where each consignment is the subject of one single transport contract.
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+      - type: string
+        enum:
+          - MasterBillOfLading
+  billOfLadingNumber:
+    title: Bill Of Lading Number
+    description: >-
+      A unique number allocated by the shipping line to the transport document
+      and the main number used for the tracking of the status of the shipment.
+    type: string
+    $linkedData:
+      term: billOfLadingNumber
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Bill_of_lading_number
+  bookingNumber:
+    title: Booking Number
+    description:  A unique identifier assigned by the carrier to the consignment, such as a booking reference number when cargo space is reserved prior to loading.
+    type: array
+    items: 
+      type: string
+    $linkedData:
+      term: bookingNumber
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierAssignedId
+  shipper: 
+    title: Shipper
+    description: A consignor party for the consignment.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: shipper
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consignorParty
+  consignee:
+    title: Consignee
+    description: A consignee party for the consignment.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: consignee
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#consigneeParty
+  forwardingAgent: 
+    title: Forwarding Agent
+    description: The freight forwarder party for this supply chain consignment.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: notifyParty
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#freightForwarderParty
+  notifyParty:
+    title: Notify Party
+    description: The freight forwarder party for this supply chain consignment.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: notifyParty
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#notifyParty
+  carrier:
+    title: Carrier
+    description: A carrier party.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: carrier
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierParty
+  manufacturingCountry: 
+    title: Manufacturing Country
+    description: Manufacturing country.
+    type: string
+    $linkedData:
+      term: countryOfOrigin
+      '@id': https://w3id.org/traceability#countryOfOrigin
+  totalNumberOfPackages: 
+    title: Total Number of Packages
+    description: A number of packages.
+    type: number
+    $linkedData:
+      term: totalNumberOfPackages
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity
+  dateOfExport:
+    title: Date of Export
+    description: The date, time, date time, or other date time value when this supply chain consignment will exit, or has exited from, the last port, airport, or border post of the country of export.
+    type: string
+    $linkedData:
+      term: dateOfExport
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exportExitDateTime
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
+  includedConsignmentItem:
+    title: Included Consignment Item
+    description: A consignment item included in the consignment.
+    $ref: ./ConsignmentItem.yml
+    $linkedData:
+      term: includedConsignmentItem
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem
+required:
+  - billOfLadingNumber
+example: |-
+  {
+    "type": "Consignment",
+    "bookingNumber": [
+      "EX600822199"
+    ],
+    "billOfLadingNumber": "EX600822199A",
+    "shipper": {
+      "type": "Organization",
+      "name": "Espresso Italiano Co.",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "Via Vico Ferrovia 5",
+        "addressLocality": "Goro",
+        "addressRegion": "Ferrara",
+        "postalCode": "44020",
+        "addressCountry": "IT"
+      },
+      "email": "sales@espresso-italiano.example.com",
+      "phoneNumber": "+39 0351 9067195"
+    },
+    "consignee": {
+      "type": "Organization",
+      "name": "Prosumer Coffee Supplies, Ltd.",
+      "description": "Coffee Machine Imports",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "3934 Spinnaker Lane",
+        "addressLocality": "Joliet",
+        "addressRegion": "Illinois",
+        "postalCode": "60432",
+        "addressCountry": "US"
+      }
+    },
+    "carrier": {
+      "type": "Organization",
+      "id": "did:key:z6Mku6sNEit2qhNyaKDoj6ozURx5ApD85Za5g6dmnpYi6Auv",
+      "name": "MULTI CONTAINER LINE",
+      "address": {
+        "type": "PostalAddress",
+        "organizationName": "MCL Multi Container Line LTD.",
+        "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
+        "addressLocality": "Kowloon Bay",
+        "addressRegion": "Hong Kong",
+        "addressCountry": "Hong Kong SAR"
+      }
+    },
+    "manufacturingCountry": "IT",
+    "totalNumberOfPackages": 880,
+    "dateOfExport": "2022-02-02T09:30:00Z",
+    "consignmentItems": [
+      {
+        "marksAndNumbers": "Espresso Italiano",
+        "commodity": {
+          "type": "Commodity",
+          "commodityCode": "851671",
+          "commodityCodeType": "HS"
+        },
+        "quantity": 880,
+        "netWeight": {
+          "type": "QuantitativeValue",
+          "unitCode": "kg",
+          "value": "14600"
+        },
+        "netWeight": {
+          "type": "QuantitativeValue",
+          "unitCode": "kg",
+          "value": "15960"
+        }
+      }
+    ]
+  }

--- a/docs/openapi/components/schemas/common/MasterBillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/common/MasterBillOfLadingCertificate.yml
@@ -4,6 +4,7 @@ $linkedData:
 title: Master Bill of Lading Certificate
 description: >- 
   A receipt for the cargo and a contract for transportation between a shipper and the ocean carrier. It may also be used as instrument of ownership (negotiable bill of lading) which can be bought, sold or traded while the goods are in transit. To be used in this manner, it must be a negotiable "order bill of lading". 
+  (source: Olegario Llamazares: Dictionary Of International Trade, Key definitions of 2000 trade terms and acronyms).
   Model based on https://service.unece.org/trade/uncefact/publication/Transport%20and%20Logistics/MaritimeBill/HTML/001.htm
 type: object
 properties:
@@ -26,26 +27,19 @@ properties:
   issuanceDate:
     type: string
   issuer:
-    type: object
+    $ref: ./Entity.yml
   credentialSubject:
-    type: object
+    $ref: ./MasterBillOfLading.yml
   proof:
     type: object
-  relatedLink:
-    title: Related Link
-    description: Links related to this verifiable credential
-    type: array
-    items:
-      $ref: ./LinkRole.yml
 additionalProperties: false
-required: []
 example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/traceability/v1"
     ],
-    "id": "https://example.com/credential/123",
+    "id": "did:key:z6MkmbqKc6KncFZUbVJwUppttTkiMAtnVJ5wzC5oVBWci3pc",
     "type": [
       "VerifiableCredential",
       "MasterBillOfLadingCertificate"
@@ -66,15 +60,76 @@ example: |-
       }
     },
     "credentialSubject": {
-      "type": [
-        "Consignment"
+      "type": "Consignment",
+      "bookingNumber": [
+        "EX600822199"
+      ],
+      "billOfLadingNumber": "EX600822199A",
+      "shipper": {
+        "type": "Organization",
+        "name": "Espresso Italiano Co.",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "Via Vico Ferrovia 5",
+          "addressLocality": "Goro",
+          "addressRegion": "Ferrara",
+          "postalCode": "44020",
+          "addressCountry": "IT"
+        },
+        "email": "sales@espresso-italiano.example.com",
+        "phoneNumber": "+39 0351 9067195"
+      },
+      "consignee": {
+        "type": "Organization",
+        "name": "Prosumer Coffee Supplies, Ltd.",
+        "description": "Coffee Machine Imports",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "3934 Spinnaker Lane",
+          "addressLocality": "Joliet",
+          "addressRegion": "Illinois",
+          "postalCode": "60432",
+          "addressCountry": "US"
+        }
+      },
+      "carrier": {
+        "type": "Organization",
+        "id": "did:key:z6Mku6sNEit2qhNyaKDoj6ozURx5ApD85Za5g6dmnpYi6Auv",
+        "name": "MULTI CONTAINER LINE",
+        "address": {
+          "type": "PostalAddress",
+          "organizationName": "MCL Multi Container Line LTD.",
+          "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
+          "addressLocality": "Kowloon Bay",
+          "addressRegion": "Hong Kong",
+          "addressCountry": "Hong Kong SAR"
+        }
+      },
+      "manufacturingCountry": "IT",
+      "totalNumberOfPackages": 880,
+      "dateOfExport": "2022-02-02T09:30:00Z",
+      "consignmentItems": [
+        {
+          "marksAndNumbers": "Espresso Italiano",
+          "commodity": {
+            "type": "Commodity",
+            "commodityCode": "851671",
+            "commodityCodeType": "HS"
+          },
+          "quantity": 880,
+          "netWeight": {
+            "type": "QuantitativeValue",
+            "unitCode": "kg",
+            "value": "15960"
+          }
+        }
       ]
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-04T13:08:19Z",
+      "created": "2022-03-08T15:57:04Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..l8rzZ6KZgPooiJgbJlFVKss8J8bnmBgEazVlL62cWi7eABz59M_6RARv203rQsB8_qMB9SwlIl0spLAifebRCQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..LlB68rBrtV8jNqgZ9DdJDAuKSpz7bNoAjp7jFXD7gTXTBkAZ9izWliqKiXxKVXEf9JJRx1ECvrlECm4RqpaiAQ"
     }
   }

--- a/docs/openapi/components/schemas/common/ShippingInstructions.yml
+++ b/docs/openapi/components/schemas/common/ShippingInstructions.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: Consignment
-  '@id': https://w3id.org/traceability#Consignment
-title: Consignment
+  term: ShippingInstructions
+  '@id': https://w3id.org/traceability#ShippingInstructions
+title: ShippingInstructions
 description: A separately identifiable collection of goods items to be transported or available to be transported from one consignor to one consignee via one or more modes of transport where each consignment is the subject of one single transport contract.
 type: object
 properties:
@@ -10,7 +10,17 @@ properties:
       - type: array
       - type: string
         enum:
-          - Consignment
+          - ShippingInstructions
+  bookingNumber:
+    title: Booking Number
+    description:  A unique identifier assigned by the carrier to the consignment, such as a booking reference number when cargo space is reserved prior to loading.
+    type: array
+    items: 
+      type: string
+    $linkedData:
+      term: bookingNumber
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncefact/#carrierAssignedId
   shipper: 
     title: Shipper
     description: A consignor party for the consignment.
@@ -79,9 +89,14 @@ properties:
     $linkedData:
       term: includedConsignmentItem
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#includedConsignmentItem
+required:
+  - bookingNumber
 example: |-
   {
-    "type": "Consignment",
+    "type": "ShippingInstructions",
+    "bookingNumber": [
+      "EX600822199"
+    ],
     "shipper": {
       "type": "Organization",
       "name": "Espresso Italiano Co.",
@@ -111,7 +126,6 @@ example: |-
     },
     "carrier": {
       "type": "Organization",
-      "id": "did:key:z6Mku6sNEit2qhNyaKDoj6ozURx5ApD85Za5g6dmnpYi6Auv",
       "name": "MULTI CONTAINER LINE",
       "address": {
         "type": "PostalAddress",
@@ -120,36 +134,30 @@ example: |-
         "addressLocality": "Kowloon Bay",
         "addressRegion": "Hong Kong",
         "addressCountry": "Hong Kong SAR"
-      },
-      "manufacturingCountry": "IT",
-      "totalNumberOfPackages": 880,
-      "dateOfExport": "2022-02-02T09:30:00Z",
-      "consignmentItems": [
-        {
-          "marksAndNumbers": "Espresso Italiano",
-          "commodity": {
-            "type": "Commodity",
-            "commodityCode": "851671",
-            "commodityCodeType": "HS"
-          },
-          "quantity": 880,
-          "netWeight": {
-            "type": "QuantitativeValue",
-            "unitCode": "kg",
-            "value": "14600"
-          },
-          "netWeight": {
-            "type": "QuantitativeValue",
-            "unitCode": "kg",
-            "value": "15960"
-          }
+      }
+    },
+    "manufacturingCountry": "IT",
+    "totalNumberOfPackages": 880,
+    "dateOfExport": "2022-02-02T09:30:00Z",
+    "consignmentItems": [
+      {
+        "marksAndNumbers": "Espresso Italiano",
+        "commodity": {
+          "type": "Commodity",
+          "commodityCode": "851671",
+          "commodityCodeType": "HS"
+        },
+        "quantity": 880,
+        "netWeight": {
+          "type": "QuantitativeValue",
+          "unitCode": "kg",
+          "value": "14600"
+        },
+        "netWeight": {
+          "type": "QuantitativeValue",
+          "unitCode": "kg",
+          "value": "15960"
         }
-      ]
-    }
+      }
+    ]
   }
-
-
-
-
-
-

--- a/docs/openapi/components/schemas/common/ShippingInstructionsCertificate.yml
+++ b/docs/openapi/components/schemas/common/ShippingInstructionsCertificate.yml
@@ -4,7 +4,7 @@ $linkedData:
 title: Shipping Instructions Certificate
 description: >- 
   Shipping Instructions or Shipper's Letter of Instruction is a form issued by a shipper to authorize a carrier to issue a bill of lading or an air waybill on the shipper's behalf. The form contains all details of shipment (e.g., shipper, consignee, bill-to-party, commodity, pieces, weight, cube, etc.) and authorizes the carrier to sign the bill of lading in the name of the shipper.
-  (source: Olegario Llamazares: DICTIONARY OF INTERNATIONAL TRADE, Key definitions of 2000 trade terms and acronyms).
+  (source: Olegario Llamazares: Dictionary Of International Trade, Key definitions of 2000 trade terms and acronyms).
   Model based on https://service.unece.org/trade/uncefact/publication/Transport%20and%20Logistics/itigg%20unttc/Shipping%20Instructions/Multimodal%20Shipping%20Instructions_D21B/HTML/001.htm.
 type: object
 properties:
@@ -27,9 +27,9 @@ properties:
   issuanceDate:
     type: string
   issuer:
-    type: object
+    $ref: ./Entity.yml
   credentialSubject:
-    type: object
+    $ref: ./ShippingInstructions.yml
   proof:
     type: object
   relatedLink:
@@ -39,14 +39,13 @@ properties:
     items:
       $ref: ./LinkRole.yml
 additionalProperties: false
-required: []
 example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/traceability/v1"
     ],
-    "id": "https://example.com/credential/123",
+    "id": "did:key:z6MkmT8iNWLcXDiWjc9YKiYTVogvgzc9QqdeZF5cEZ9qJzt3",
     "type": [
       "VerifiableCredential",
       "ShippingInstructionsCertificate"
@@ -56,27 +55,85 @@ example: |-
     "issuer": {
       "type": "Organization",
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "Xxinau Manufacturing Co. Ltd.",
-      "description": "Advanced Production - Delivered",
+      "name": "Espresso Italiano Co.",
       "address": {
         "type": "PostalAddress",
-        "streetAddress": "Xin Fei Da Dao 139",
-        "addressLocality": "Xindao",
-        "addressRegion": "Fujian Province",
-        "postalCode": "361100",
-        "addressCountry": "CN"
+        "streetAddress": "Via Vico Ferrovia 5",
+        "addressLocality": "Goro",
+        "addressRegion": "Ferrara",
+        "postalCode": "44020",
+        "addressCountry": "IT"
       }
     },
     "credentialSubject": {
-      "type": [
-        "Consignment"
+      "type": "ShippingInstructions",
+      "bookingNumber": [
+        "EX600822199"
+      ],
+      "shipper": {
+        "type": "Organization",
+        "name": "Espresso Italiano Co.",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "Via Vico Ferrovia 5",
+          "addressLocality": "Goro",
+          "addressRegion": "Ferrara",
+          "postalCode": "44020",
+          "addressCountry": "IT"
+        },
+        "email": "sales@espresso-italiano.example.com",
+        "phoneNumber": "+39 0351 9067195"
+      },
+      "consignee": {
+        "type": "Organization",
+        "name": "Prosumer Coffee Supplies, Ltd.",
+        "description": "Coffee Machine Imports",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "3934 Spinnaker Lane",
+          "addressLocality": "Joliet",
+          "addressRegion": "Illinois",
+          "postalCode": "60432",
+          "addressCountry": "US"
+        }
+      },
+      "carrier": {
+        "type": "Organization",
+        "name": "MULTI CONTAINER LINE",
+        "address": {
+          "type": "PostalAddress",
+          "organizationName": "MCL Multi Container Line LTD.",
+          "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
+          "addressLocality": "Kowloon Bay",
+          "addressRegion": "Hong Kong",
+          "addressCountry": "Hong Kong SAR"
+        }
+      },
+      "manufacturingCountry": "IT",
+      "totalNumberOfPackages": 880,
+      "dateOfExport": "2022-02-02T09:30:00Z",
+      "consignmentItems": [
+        {
+          "marksAndNumbers": "Espresso Italiano",
+          "commodity": {
+            "type": "Commodity",
+            "commodityCode": "851671",
+            "commodityCodeType": "HS"
+          },
+          "quantity": 880,
+          "netWeight": {
+            "type": "QuantitativeValue",
+            "unitCode": "kg",
+            "value": "15960"
+          }
+        }
       ]
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-04T13:07:40Z",
+      "created": "2022-03-08T16:06:24Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xpoSNYbQ031OO08lJ2-1_-kmtW6aKZ2QXzlt2zIXMoSLzefGnfpR89Z-I1aNkxXrKUsR8LUrqfHbu1smt34aAg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..PrMfSDep-55NqKLUOW6Tk3zhtpR9GWHexBNymdesWJ3avGVhjCtxHsDmVTSjlrUcJsItQ6Dse1yYuMjv2-mNDw"
     }
   }

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -200,18 +200,6 @@ paths:
                 $ref: './components/schemas/common/Commodity.yml'
     
 
-  /schemas/common/Consignment.yml:
-    get:
-      tags:
-      - Common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/Consignment.yml'
-    
-
   /schemas/common/ConsignmentItem.yml:
     get:
       tags:
@@ -596,6 +584,18 @@ paths:
                 $ref: './components/schemas/common/GeoCoordinates.yml'
     
 
+  /schemas/common/HouseBillOfLading.yml:
+    get:
+      tags:
+      - Common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/HouseBillOfLading.yml'
+    
+
   /schemas/common/HouseBillOfLadingCertificate.yml:
     get:
       tags:
@@ -798,6 +798,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/LinkRole.yml'
+    
+
+  /schemas/common/MasterBillOfLading.yml:
+    get:
+      tags:
+      - Common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/MasterBillOfLading.yml'
     
 
   /schemas/common/MasterBillOfLadingCertificate.yml:
@@ -1170,6 +1182,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/Seal.yml'
+    
+
+  /schemas/common/ShippingInstructions.yml:
+    get:
+      tags:
+      - Common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/ShippingInstructions.yml'
     
 
   /schemas/common/ShippingInstructionsCertificate.yml:


### PR DESCRIPTION
Added examples which was left blank in the first iteration. 
Also changed from common `Consignment` subject to dedicated schemas, to define the different parts of consignment needed. 