### PR TITLE
Adding openapi to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ docs/traceability-openapi-v1.json
 docs/intermediate.json
 docs/sections/vocab.html
 docs/testsuite/index.html
+docs/openapi/openapi.yml
 
 packages/traceability-schemas/data/*.json


### PR DESCRIPTION
Fix #337

- [x] Added `openapi.yml` to  [.gitignore](https://github.com/w3c-ccg/traceability-vocab/blob/main/.gitignore)
- [x] `credentials.json` and `credential.verifiable.json` already present in [.gitignore](https://github.com/w3c-ccg/traceability-vocab/blob/main/.gitignore)
https://github.com/w3c-ccg/traceability-vocab/blob/90a22652230248f30cab6a2f6d9487c4cedd66d4/.gitignore#L13