### PR TITLE
Add Schema to Purchase Order

### DIFF
--- a/docs/openapi/components/schemas/common/Purchase.yml
+++ b/docs/openapi/components/schemas/common/Purchase.yml
@@ -25,8 +25,8 @@ properties:
     $linkedData:
       term: invoice
       '@id': https://w3id.org/traceability#Invoice
-  purchaseOrder:
-    title: Purchase Order
+  purchaseOrderNo:
+    title: Purchase Order Number
     description: The purchase order associated with a purchase
     type: string
     $linkedData:
@@ -38,6 +38,7 @@ example: |-
     "type": [
       "Purchase"
     ],
+    "purchaseOrderNo" : "fe71665a-e7b3-49ba-ac89-82fc2bf1e877",
     "customer": {
       "type": "Person",
       "firstName": "Audreanne",

--- a/docs/openapi/components/schemas/common/Purchase.yml
+++ b/docs/openapi/components/schemas/common/Purchase.yml
@@ -27,10 +27,10 @@ properties:
       '@id': https://w3id.org/traceability#Invoice
   purchaseOrderNo:
     title: Purchase Order Number
-    description: The purchase order associated with a purchase
+    description: The purchase order associated with a purchase referenced by the document identifier
     type: string
     $linkedData:
-      term: purchaseOrder
+      term: purchaseOrderNo
       '@id': https://schema.org/identifier
 additionalProperties: false
 example: |-

--- a/docs/openapi/components/schemas/common/PurchaseOrder.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrder.yml
@@ -12,7 +12,7 @@ properties:
         enum:
           - PurchaseOrder
   purchaseOrderNo:
-    title: Puchase Order Number
+    title: Purchase Order Number
     description: Number for Purchase order
     type: string
   orderDate:
@@ -206,6 +206,7 @@ example: |-
     "type": [
       "PurchaseOrder"
     ],
+    "purchaseOrderNo" : "fe71665a-e7b3-49ba-ac89-82fc2bf1e877",
     "portOfEntry": {
       "type": "Place",
       "unLocode": "USLGB"

--- a/docs/openapi/components/schemas/common/PurchaseOrder.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrder.yml
@@ -1,11 +1,343 @@
 $linkedData:
   term: PurchaseOrder
-  '@id': https://w3id.org/traceability#PurchaseOrder
-title: PurchaseOrder
+  '@id': https://schema.org/Invoice
+title: Commercial Invoice
+description: A statement of the money due for goods or services; a bill. Aligned with data fields listed in https://unece.org/fileadmin/DAM/cefact/recommendations/rec06/rec06_ecetrd148.pdf
 type: object
-description: A statement issued by a buyer for the sale of products or services to be delivered at a later date
-additionalProperties: true
+properties:
+  type:
+    oneOf:
+      - type: array
+      - type: string
+        enum:
+          - PurchaseOrder
+  purchaseOrderNo:
+    title: Puchase Order Number
+    description: Number for Purchase order
+    type: string
+  orderDate:
+    title: Order Date
+    description: The date that payment is made.
+    type: string
+  portOfEntry:
+    title: Port Of Entry
+    description: Port where the purchased goods will enter first.
+    $ref: ./Place.yml
+    $linkedData:
+      term: portOfEntry
+      '@id': https://schema.org/Place
+  originCountry:
+    title: Origin Country
+    description: A country of origin for the consignment, consignment item, or product.
+    type: string
+    $linkedData:
+      term: originCountry
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#originCountry
+  destinationCountry:
+    title: Destination Country
+    description: Country to which the ordered product will be delivered
+    type: string
+    $linkedData:
+      term: destinationCountry
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#destinationCountry
+  seller:
+    title: Seller
+    description: An entity which offers (sells, leases, lends, or loans) the services or goods. A seller may also be a provider.
+    $ref: ./Organization.yml
+    $linkedData:
+      term: seller
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#sellerParty
+  buyer:
+    title: Buyer
+    description: Importer of record. Party placing the order or paying the invoice.
+    $ref: ./Organization.yml
+    $linkedData:
+      term: buyer
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#buyerParty
+  exporter:
+    title: Exporter
+    description: The party who makes, or on whose behalf the export declaration is made, and who is the owner of the goods or has similar rights of disposal over them at the time when the declaration is accepted.
+    $ref: ./Organization.yml
+    $linkedData:
+      term: exporter
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exporterParty
+  importer:
+    title: Importer
+    description: The party who makes, or on whose behalf a customs clearing agent or other authorized person makes, an import declaration. This may include a person who has possession of the goods or to whom the goods are consigned. Also refered to as Importer of Record.
+    $ref: ./Organization.yml
+    $linkedData:
+      term: importer
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#importerParty
+  shipFromParty:
+    title: Ship From Party
+    description: The party from whom goods will be or have been originally shipped. Also refered to as Original Despatch Party
+    $ref: ./Organization.yml
+    $linkedData:
+      term: shipFromParty
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipFromParty
+  shipToParty:
+    title: Ship To Party
+    description: The party to whom goods will be or have been ultimately shipped. Also refered to as Final Delivery Party or Ultimate Delivery Party
+    $ref: ./Organization.yml
+    $linkedData:
+      term: shipToParty
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#shipToParty
+  provider:
+    title: Provider
+    description: >-
+      The service provider, service operator, or service performer; the goods
+      producer. Another party (a seller) may offer those services or goods on
+      behalf of the provider. A provider may also serve as the seller.
+    $ref: ./Organization.yml
+    $linkedData:
+      term: provider
+      '@id': https://schema.org/provider
+  itemsShipped:
+    title: Items Shipped
+    description: Itemized list of shipped goods.
+    type: array
+    items:
+      $ref: ./TradeLineItem.yml
+    $linkedData:
+      term: itemsShipped
+      '@id': https://schema.org/itemShipped
+  comments:
+    title: Comments
+    description: Free text comments.
+    type: array
+    items:
+      type: string
+    $linkedData:
+      term: comments
+      '@id': https://schema.org/Comment
+  packageQuantity:
+    title: Package Quantity
+    description: Total number of packages.
+    type: number
+    $linkedData:
+      term: packageQuantity
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageQuantity
+  totalWeight:
+    title: Total Weight
+    description: Total weight of the products.
+    $ref: ./QuantitativeValue.yml
+    $linkedData:
+      term: weight
+      '@id': https://schema.org/weight
+  termsOfDelivery:
+    title: Terms of Delivery
+    description: The conditions agreed upon between the parties with regard to the delivery of goods and or services.
+    type: string
+    $linkedData:
+      term: termsOfDelivery
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedDeliveryTerms
+  termsOfPayment:
+    title: Terms of Payment
+    description: Terms, conditions, and currency of settlement, as agreed upon by the vendor and purchaser per the pro forma invoice, customer purchase order, and/or the letter of credit.
+    type: string
+    $linkedData:
+      term: termsOfPayment
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedPaymentTerms
+  currencyOfSettlement:
+    title: Terms of Settlement
+    description: Currency agreed upon between seller and buyer as payment.
+    type: string
+    $linkedData:
+      term: termsOfSettlement
+      '@id': https://schema.org/currency
+  purchaseOrderSubtotal:
+    title: Pucharse Order Subtotal
+    description: The subtotal of line items.
+    $ref: ./PriceSpecification.yml
+    $linkedData:
+      term: totalPaymentDue
+      '@id': https://schema.org/totalPaymentDue
+  discounts:
+    title: Discounts
+    description: Applicable discounts.
+    type: array
+    items:
+      $ref: ./PriceSpecification.yml
+    $linkedData:
+      term: discounts
+      '@id': https://schema.org/discount
+  additions:
+    title: Additions
+    description: Applicable additions.
+    $ref: ./PriceSpecification.yml
+  deductions:
+    title: Additions
+    description: Applicable additions.
+    type: array
+    items:
+      $ref: ./PriceSpecification.yml
+    $linkedData:
+      term: discounts
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#deductionAmount
+  assist:
+    title: Assist
+    description: Applicable assist.
+    $ref: ./PriceSpecification.yml
+  tax:
+    title: Tax
+    description: Applicable tax.
+    $ref: ./PriceSpecification.yml
+    $linkedData:
+      term: tax
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#taxTotalAmount
+  freightCost:
+    title: Freight Cost
+    description: Included cost of freight.
+    $ref: ./PriceSpecification.yml
+  insuranceCost:
+    title: Freight Cost
+    description: Included cost of insurance.
+    $ref: ./PriceSpecification.yml
+  totalOrderAmount:
+    title: Total Order Amount
+    description: The total amount due.
+    $ref: ./PriceSpecification.yml
+required:
+  - seller
+  - buyer
+additionalProperties: false
 example: |-
   {
-    "type": "PurchaseOrder"
+    "type": [
+      "PurchaseOrder"
+    ],
+    "portOfEntry": {
+      "type": "Place",
+      "unLocode": "USLGB"
+    },
+    "destinationCountry": "MEX",
+    "orderDate": "2021-02-21",
+    "seller": {
+      "type": [
+        "Organization"
+      ],
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+        "streetAddress": "1651, Shimonakano, Yoshida",
+        "addressLocality": "Tsubame-shi",
+        "addressRegion": "Niigata-ken",
+        "postalCode": "959-0215",
+        "addressCountry": "Japan"
+      }
+    },
+    "buyer": {
+      "type": [
+        "Organization"
+      ],
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "Generic Motors of America",
+        "streetAddress": "12 Generic Motors Dr",
+        "addressLocality": "Detroit",
+        "addressRegion": "Michigain",
+        "postalCode": "48232-5170",
+        "addressCountry": "USA"
+      }
+    },
+    "consignee": {
+      "type": [
+        "Organization"
+      ],
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "Generic Motors of America",
+        "streetAddress": "12 Generic Motors Dr",
+        "addressLocality": "Detroit",
+        "addressRegion": "Michigain",
+        "postalCode": "48232-5170",
+        "addressCountry": "USA"
+      }
+    },
+    "itemsShipped": [
+      {
+        "type": "TradeLineItem",
+        "product": {
+          "manufacturer": {
+            "type": "Organization",
+            "address": {
+              "type": "PostalAddress",
+              "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+              "streetAddress": "1651, Shimonakano, Yoshida",
+              "addressLocality": "Tsubame-shi",
+              "addressRegion": "Niigata-ken",
+              "postalCode": "959-0215",
+              "addressCountry": "Japan"
+            }
+          },
+          "description": "UNS S30400 chromium-nickel stainless steel rolls.",
+          "weight": {
+            "type": "QuantitativeValue",
+            "unitCode": "lbs",
+            "value": "16500"
+          }
+        },
+        "itemCount": 5,
+        "tradeLineItemWeight": {
+          "type": "QuantitativeValue",
+          "value": "82500",
+          "unitCode": "lbs"
+        },
+        "priceSpecification": {
+          "type": "PriceSpecification",
+          "price": 5200,
+          "priceCurrency": "USD"
+        }
+      },
+      {
+        "type": "TradeLineItem",
+        "product": {
+          "manufacturer": {
+            "type": "Organization",
+            "address": {
+              "type": "PostalAddress",
+              "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+              "streetAddress": "1651, Shimonakano, Yoshida",
+              "addressLocality": "Tsubame-shi",
+              "addressRegion": "Niigata-ken",
+              "postalCode": "959-0215",
+              "addressCountry": "Japan"
+            }
+          },
+          "description": "Galvalannealed ASTM A-653 zinc-iron alloy-coated steel sheets.",
+          "weight": {
+            "type": "QuantitativeValue",
+            "value": "12680",
+            "unitCode": "lbs"
+          }
+        },
+        "itemCount": 20,
+        "tradeLineItemWeight": {
+          "type": "QuantitativeValue",
+          "value": "253600",
+          "unitCode": "lbs"
+        },
+        "priceSpecification": {
+          "type": "PriceSpecification",
+          "price": 4400,
+          "priceCurrency": "USD"
+        }
+      }
+    ],
+    "totalWeight": {
+      "type": "QuantitativeValue",
+      "value": "336100",
+      "unitCode": "lbs"
+    },
+    "totalOrderAmount": {
+      "type": "PriceSpecification",
+      "price": 9600,
+      "priceCurrency": "USD"
+    }
   }

--- a/docs/openapi/components/schemas/common/PurchaseOrder.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrder.yml
@@ -2,7 +2,7 @@ $linkedData:
   term: PurchaseOrder
   '@id': https://schema.org/Invoice
 title: Commercial Invoice
-description: A statement of the money due for goods or services; a bill. Aligned with data fields listed in https://unece.org/fileadmin/DAM/cefact/recommendations/rec06/rec06_ecetrd148.pdf
+description: A statement issued by a buyer for the sale of products or services to be delivered at a later date
 type: object
 properties:
   type:

--- a/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
@@ -77,6 +77,7 @@ example: |-
         "type": "Place",
         "unLocode": "USLGB"
       },
+      "purchaseOrderNo": "fe71665a-e7b3-49ba-ac89-82fc2bf1e877",
       "destinationCountry": "MEX",
       "orderDate": "2021-02-21",
       "seller": {
@@ -210,9 +211,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-14T18:38:39Z",
+      "created": "2022-03-14T18:56:45Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..AkW0-ynf2SvJ2Bs_TvLq1Wc6ZvyeOLVd-LUazCwsBGn42Czr7gXRFDRZGcMyiS1T31FR9H44GtaVNwrPa4tZCA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..v0cnMAflvMI2aBBB3B8HSu80KR4hY9gSV8qu6k4uDoqcU4SjNdgCwOaSwmFMnwQ2A9FsCp1cXnM0FjkDe7UeCQ"
     }
   }

--- a/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
@@ -2,7 +2,18 @@ $linkedData:
   term: PurchaseOrderCertificate
   '@id': https://w3id.org/traceability#PurchaseOrderCertificate
 title: Commercial Invoice Certificate
-description: Certifications made about a purchase order
+description: >-
+  A purchaser's written offer to a supplier formally stating all terms and
+  conditions of a proposed transaction. Sometimes, in a certain number of international
+  trade operations, international sale contracts are not made. In these cases, it is usual to
+  confirm the operation with an international purchase order. This practise is usual for
+  sales of a small amount of money and for repetitive sales to the same client concerning
+  products which are not very complex or for products that do not have a high added
+  value. Usually it is the exporter who issues this document. Nevertheless, sometimes,
+  companies with international purchase experience (such trading companies) have
+  their own international purchase order template where they establish the purchase
+  conditions to their suppliers.
+  (source: Olegario Llamazares: Dictionary Of International Trade, Key definitions of 2000 trade terms and acronyms).
 type: object
 properties:
   '@context':

--- a/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
@@ -70,13 +70,149 @@ example: |-
       "faxNumber": "555-766-1744"
     },
     "credentialSubject": {
-      "type": "PurchaseOrder"
+      "type": [
+        "PurchaseOrder"
+      ],
+      "portOfEntry": {
+        "type": "Place",
+        "unLocode": "USLGB"
+      },
+      "destinationCountry": "MEX",
+      "orderDate": "2021-02-21",
+      "seller": {
+        "type": [
+          "Organization"
+        ],
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+          "streetAddress": "1651, Shimonakano, Yoshida",
+          "addressLocality": "Tsubame-shi",
+          "addressRegion": "Niigata-ken",
+          "postalCode": "959-0215",
+          "addressCountry": "Japan"
+        }
+      },
+      "buyer": {
+        "type": [
+          "Organization"
+        ],
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Generic Motors of America",
+          "streetAddress": "12 Generic Motors Dr",
+          "addressLocality": "Detroit",
+          "addressRegion": "Michigain",
+          "postalCode": "48232-5170",
+          "addressCountry": "USA"
+        }
+      },
+      "consignee": {
+        "type": [
+          "Organization"
+        ],
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Generic Motors of America",
+          "streetAddress": "12 Generic Motors Dr",
+          "addressLocality": "Detroit",
+          "addressRegion": "Michigain",
+          "postalCode": "48232-5170",
+          "addressCountry": "USA"
+        }
+      },
+      "itemsShipped": [
+        {
+          "type": "TradeLineItem",
+          "product": {
+            "manufacturer": {
+              "type": "Organization",
+              "address": {
+                "type": "PostalAddress",
+                "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+                "streetAddress": "1651, Shimonakano, Yoshida",
+                "addressLocality": "Tsubame-shi",
+                "addressRegion": "Niigata-ken",
+                "postalCode": "959-0215",
+                "addressCountry": "Japan"
+              }
+            },
+            "description": "UNS S30400 chromium-nickel stainless steel rolls.",
+            "weight": {
+              "type": "QuantitativeValue",
+              "unitCode": "lbs",
+              "value": "16500"
+            }
+          },
+          "itemCount": 5,
+          "tradeLineItemWeight": {
+            "type": "QuantitativeValue",
+            "value": "82500",
+            "unitCode": "lbs"
+          },
+          "priceSpecification": {
+            "type": "PriceSpecification",
+            "price": 5200,
+            "priceCurrency": "USD"
+          }
+        },
+        {
+          "type": "TradeLineItem",
+          "product": {
+            "manufacturer": {
+              "type": "Organization",
+              "address": {
+                "type": "PostalAddress",
+                "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+                "streetAddress": "1651, Shimonakano, Yoshida",
+                "addressLocality": "Tsubame-shi",
+                "addressRegion": "Niigata-ken",
+                "postalCode": "959-0215",
+                "addressCountry": "Japan"
+              }
+            },
+            "description": "Galvalannealed ASTM A-653 zinc-iron alloy-coated steel sheets.",
+            "weight": {
+              "type": "QuantitativeValue",
+              "value": "12680",
+              "unitCode": "lbs"
+            }
+          },
+          "itemCount": 20,
+          "tradeLineItemWeight": {
+            "type": "QuantitativeValue",
+            "value": "253600",
+            "unitCode": "lbs"
+          },
+          "priceSpecification": {
+            "type": "PriceSpecification",
+            "price": 4400,
+            "priceCurrency": "USD"
+          }
+        }
+      ],
+      "totalWeight": {
+        "type": "QuantitativeValue",
+        "value": "336100",
+        "unitCode": "lbs"
+      },
+      "totalOrderAmount": {
+        "type": "PriceSpecification",
+        "price": 9600,
+        "priceCurrency": "USD"
+      }
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-01T17:54:40Z",
+      "created": "2022-03-14T18:38:39Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ySb9Cw-uQVuh40QKMWRrJ8OKJC1uyg3VmyKuNiR5WnLhILVI2Wy07IcBkQe0w926A8NdmcQKwGTZIN4TKyzWCQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..AkW0-ynf2SvJ2Bs_TvLq1Wc6ZvyeOLVd-LUazCwsBGn42Czr7gXRFDRZGcMyiS1T31FR9H44GtaVNwrPa4tZCA"
     }
   }


### PR DESCRIPTION
- Adds a schema and example JSON to Purchase Order.
- Makes clarification for optional Purchase Order Identifier https://github.com/w3c-ccg/traceability-vocab/issues/336