### PR TITLE
Fix Syntax Errors in Schemas

### DIFF
--- a/docs/openapi/components/schemas/common/AgActivity.yml
+++ b/docs/openapi/components/schemas/common/AgActivity.yml
@@ -10,9 +10,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - AgActivity
       - type: string
-        enum:
-          - AgActivity
+        const:
+          - AgActivity 
   farm:
     title: Farm
     description: The Farm or business entity performing the activity.

--- a/docs/openapi/components/schemas/common/AgActivity.yml
+++ b/docs/openapi/components/schemas/common/AgActivity.yml
@@ -10,13 +10,9 @@ properties:
   type:
     oneOf:
       - type: array
-        items:
-          type: string
-          enum:
-            - AgActivity
       - type: string
-        const:
-          - AgActivity 
+        enum:
+          - AgActivity
   farm:
     title: Farm
     description: The Farm or business entity performing the activity.

--- a/docs/openapi/components/schemas/common/AgActivity.yml
+++ b/docs/openapi/components/schemas/common/AgActivity.yml
@@ -10,12 +10,8 @@ properties:
   type:
     oneOf:
       - type: array
-        items:
-          type: string
-          enum:
-            - AgActivity
       - type: string
-        const:
+        enum:
           - AgActivity
   farm:
     title: Farm

--- a/docs/openapi/components/schemas/common/AgActivity.yml
+++ b/docs/openapi/components/schemas/common/AgActivity.yml
@@ -10,8 +10,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - AgActivity
       - type: string
-        enum:
+        const:
           - AgActivity
   farm:
     title: Farm

--- a/docs/openapi/components/schemas/common/AgInspectionReport.yml
+++ b/docs/openapi/components/schemas/common/AgInspectionReport.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - AgInspectionReport
       - type: string
-        enum:
-          - AgInspectionReport
+        const:
+          - AgInspectionReport 
   facility:
     title: Facility
     description: Information on the inspection facility.

--- a/docs/openapi/components/schemas/common/AgPackage.yml
+++ b/docs/openapi/components/schemas/common/AgPackage.yml
@@ -11,9 +11,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - AgPackage
       - type: string
-        enum:
-          - AgPackage
+        const:
+          - AgPackage 
   packageName:
     title: Package Name
     description: Name of the items within the package.

--- a/docs/openapi/components/schemas/common/AgParcelDelivery.yml
+++ b/docs/openapi/components/schemas/common/AgParcelDelivery.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - AgParcelDelivery
       - type: string
-        enum:
-          - AgParcelDelivery
+        const:
+          - AgParcelDelivery 
   deliveryAddress:
     title: Delivery Address
     description: Final destination address to which the shipment is being sent.

--- a/docs/openapi/components/schemas/common/AgProduct.yml
+++ b/docs/openapi/components/schemas/common/AgProduct.yml
@@ -12,9 +12,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - AgProduct
       - type: string
-        enum:
-          - AgProduct
+        const:
+          - AgProduct 
   upc:
     title: UPC Number
     description: >-

--- a/docs/openapi/components/schemas/common/BillOfLading.yml
+++ b/docs/openapi/components/schemas/common/BillOfLading.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - BillOfLading
       - type: string
-        enum:
-          - BillOfLading
+        const:
+          - BillOfLading 
   billOfLadingNumber:
     title: Bill Of Lading Number
     description: This identifier might not be globally unique.

--- a/docs/openapi/components/schemas/common/CargoItem.yml
+++ b/docs/openapi/components/schemas/common/CargoItem.yml
@@ -11,9 +11,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - CargoItem
       - type: string
-        enum:
-          - CargoItem
+        const:
+          - CargoItem 
   cargoLineItems:
     title: Cargo Line Item
     description: Identifies the specific details of packages within a cargo item.

--- a/docs/openapi/components/schemas/common/CargoLineItem.yml
+++ b/docs/openapi/components/schemas/common/CargoLineItem.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - CargoLineItem
       - type: string
-        enum:
-          - CargoLineItem
+        const:
+          - CargoLineItem 
   cargoLineItemID:
     title: cargoLineItemID
     description: >-

--- a/docs/openapi/components/schemas/common/ChargeDeclaration.yml
+++ b/docs/openapi/components/schemas/common/ChargeDeclaration.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ChargeDeclaration
       - type: string
-        enum:
-          - ChargeDeclaration
+        const:
+          - ChargeDeclaration 
   weightCharge:
     title: Weight Charge
     description: The weight/volume charge for air carriage. Box 24A and 24B.

--- a/docs/openapi/components/schemas/common/ChemicalProperty.yml
+++ b/docs/openapi/components/schemas/common/ChemicalProperty.yml
@@ -10,9 +10,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ChemicalProperty
       - type: string
-        enum:
-          - ChemicalProperty
+        const:
+          - ChemicalProperty 
   identifier:
     title: Property Identifier
     description: Identifiers for a property.

--- a/docs/openapi/components/schemas/common/CommercialInvoice.yml
+++ b/docs/openapi/components/schemas/common/CommercialInvoice.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - CommercialInvoice
       - type: string
-        enum:
-          - CommercialInvoice
+        const:
+          - CommercialInvoice 
   identifier:
     title: Property Identifier
     description: Identifiers for a property.

--- a/docs/openapi/components/schemas/common/Commodity.yml
+++ b/docs/openapi/components/schemas/common/Commodity.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Commodity
       - type: string
-        enum:
-          - Commodity
+        const:
+          - Commodity 
   commodityCode:
     title: Commodity Code
     description: >-

--- a/docs/openapi/components/schemas/common/ConsignmentItem.yml
+++ b/docs/openapi/components/schemas/common/ConsignmentItem.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ConsignmentItem
       - type: string
-        enum:
-          - ConsignmentItem
+        const:
+          - ConsignmentItem 
   marksAndNumbers: 
     title: Marks and Numbers
     description: Physical markings or labels on individual packages or transport units for shipping purposes.

--- a/docs/openapi/components/schemas/common/ConsignmentRatingDetail.yml
+++ b/docs/openapi/components/schemas/common/ConsignmentRatingDetail.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ConsignmentRatingDetail
       - type: string
-        enum:
-          - ConsignmentRatingDetail
+        const:
+          - ConsignmentRatingDetail 
   numberOfPieces:
     title: Number of Pieces and RCP
     description: The number of pieces for the applicable rating entry. Box 22A.

--- a/docs/openapi/components/schemas/common/ContactPoint.yml
+++ b/docs/openapi/components/schemas/common/ContactPoint.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ContactPoint
       - type: string
-        enum:
-          - ContactPoint
+        const:
+          - ContactPoint 
   name:
     title: Name
     description: Name of the entity.

--- a/docs/openapi/components/schemas/common/Customer.yml
+++ b/docs/openapi/components/schemas/common/Customer.yml
@@ -14,9 +14,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Customer
       - type: string
-        enum:
-          - Customer
+        const:
+          - Customer 
   name:
     title: Name of the Customer
     type: string

--- a/docs/openapi/components/schemas/common/DCSAShippingInstruction.yml
+++ b/docs/openapi/components/schemas/common/DCSAShippingInstruction.yml
@@ -14,9 +14,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - DCSAShippingInstruction
       - type: string
-        enum:
-          - DCSAShippingInstruction
+        const:
+          - DCSAShippingInstruction 
   shippingInstructionID:
     title: Shipping Instruction ID
     description: >-

--- a/docs/openapi/components/schemas/common/DocumentVerificationEvidence.yml
+++ b/docs/openapi/components/schemas/common/DocumentVerificationEvidence.yml
@@ -16,9 +16,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - DocumentVerificationEvidence
       - type: string
-        enum:
-          - DocumentVerificationEvidence
+        const:
+          - DocumentVerificationEvidence 
   verifier:
     title: verifier
     type: array

--- a/docs/openapi/components/schemas/common/Entity.yml
+++ b/docs/openapi/components/schemas/common/Entity.yml
@@ -3,7 +3,7 @@ $linkedData:
   '@id': https://w3id.org/traceability#Entity
 title: Entity
 description: A person or organization.
-anyOf:
+oneOf:
   - $ref: ./Person.yml
   - $ref: ./Organization.yml
 example: |-

--- a/docs/openapi/components/schemas/common/EntrySummary.yml
+++ b/docs/openapi/components/schemas/common/EntrySummary.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - EntrySummary
       - type: string
-        enum:
-          - EntrySummary
+        const:
+          - EntrySummary 
   entryNumber:
     title: Entry Number
     description: The 11 digit alphanumeric code. The entry number is comprised of the three-digit filer code, followed by the seven-digit entry number, and completed with the one-digit check digit. The Entry Filer Code represents the three-character alphanumeric filer code assigned to the filer or importer by CBP. The Entry Number represents the seven-digit number assigned by the filer. The number may be assigned in any manner convenient, provided that the same number is not assigned to more than one CBP Form 3461. Leading zeros must be shown. The check digit is computed on the previous 10 characters. The formula for calculating the check digit can be found in Appendix 1.

--- a/docs/openapi/components/schemas/common/EntrySummaryLineItem.yml
+++ b/docs/openapi/components/schemas/common/EntrySummaryLineItem.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - EntrySummaryLineItem
       - type: string
-        enum:
-          - EntrySummaryLineItem
+        const:
+          - EntrySummaryLineItem 
   commodity:
     title: Commodity
     description: Product commodity code, codification system and description

--- a/docs/openapi/components/schemas/common/Event.yml
+++ b/docs/openapi/components/schemas/common/Event.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Event
       - type: string
-        enum:
-          - Event
+        const:
+          - Event 
   eventType:
     title: Event Type
     description: The Type of the Event.

--- a/docs/openapi/components/schemas/common/ForeignChargeDeclaration.yml
+++ b/docs/openapi/components/schemas/common/ForeignChargeDeclaration.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ForeignChargeDeclaration
       - type: string
-        enum:
-          - ForeignChargeDeclaration
+        const:
+          - ForeignChargeDeclaration 
   foreignCurrencyConvertionRate:
     title: Currency Conversion Rate
     description: >-

--- a/docs/openapi/components/schemas/common/FreightManifest.yml
+++ b/docs/openapi/components/schemas/common/FreightManifest.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - FreightManifest
       - type: string
-        enum:
-          - FreightManifest
+        const:
+          - FreightManifest 
   carrier:
     title: Carrier
     description: >-

--- a/docs/openapi/components/schemas/common/GeoCoordinates.yml
+++ b/docs/openapi/components/schemas/common/GeoCoordinates.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - GeoCoordinates
       - type: string
-        enum:
-          - GeoCoordinates
+        const:
+          - GeoCoordinates 
   latitude:
     title: Latitude
     description: >-

--- a/docs/openapi/components/schemas/common/HouseBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/HouseBillOfLading.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - HouseBillOfLading
       - type: string
-        enum:
-          - HouseBillOfLading
+        const:
+          - HouseBillOfLading 
   billOfLadingNumber:
     title: Bill Of Lading Number
     description: >-

--- a/docs/openapi/components/schemas/common/IATAAirWaybill.yml
+++ b/docs/openapi/components/schemas/common/IATAAirWaybill.yml
@@ -14,9 +14,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - IATAAirWaybill
       - type: string
-        enum:
-          - IATAAirWaybill
+        const:
+          - IATAAirWaybill 
   airWaybillNumber:
     title: Air Waybill Number
     type: string

--- a/docs/openapi/components/schemas/common/ImmediateDelivery.yml
+++ b/docs/openapi/components/schemas/common/ImmediateDelivery.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ImmediateDelivery
       - type: string
-        enum:
-          - ImmediateDelivery
+        const:
+          - ImmediateDelivery 
   portOfEntry:
     title: Port Of Entry
     $ref: ./Place.yml

--- a/docs/openapi/components/schemas/common/ImmediateDeliveryEntity.yml
+++ b/docs/openapi/components/schemas/common/ImmediateDeliveryEntity.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ImmediateDeliveryEntity
       - type: string
-        enum:
-          - ImmediateDeliveryEntity
+        const:
+          - ImmediateDeliveryEntity 
   manufacturer:
     title: Manufacturer
     description: A manufacturer party.

--- a/docs/openapi/components/schemas/common/ImporterSecurityFiling.yml
+++ b/docs/openapi/components/schemas/common/ImporterSecurityFiling.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ImporterSecurityFiling
       - type: string
-        enum:
-          - ImporterSecurityFiling
+        const:
+          - ImporterSecurityFiling 
   seller: 
     title: Seller
     description: An entity which offers (sells / leases / lends / loans) the services / goods. A seller may also be a provider.

--- a/docs/openapi/components/schemas/common/Inbond.yml
+++ b/docs/openapi/components/schemas/common/Inbond.yml
@@ -18,9 +18,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Inbond
       - type: string
-        enum:
-          - Inbond
+        const:
+          - Inbond 
   product:
     title: Product
     description: Product details as outlined in the Product schema

--- a/docs/openapi/components/schemas/common/InspectionReport.yml
+++ b/docs/openapi/components/schemas/common/InspectionReport.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - InspectionReport
       - type: string
-        enum:
-          - InspectionReport
+        const:
+          - InspectionReport 
   comment:
     title: Comment
     description: Comments, typically from users.

--- a/docs/openapi/components/schemas/common/Inspector.yml
+++ b/docs/openapi/components/schemas/common/Inspector.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Inspector
       - type: string
-        enum:
-          - Inspector
+        const:
+          - Inspector 
   person:
     title: Person
     description: Person doing the inspection.

--- a/docs/openapi/components/schemas/common/Inspector.yml
+++ b/docs/openapi/components/schemas/common/Inspector.yml
@@ -26,6 +26,8 @@ properties:
     title: Qualification List
     description: List of qualifications relevant to the inspection.
     type: array
+    items:
+      $ref: ./Qualification.yml
     $linkedData:
       term: qualification
       '@id': https://w3id.org/traceability#qualification

--- a/docs/openapi/components/schemas/common/Instructions.yml
+++ b/docs/openapi/components/schemas/common/Instructions.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Instructions
       - type: string
-        enum:
-          - Instructions
+        const:
+          - Instructions 
   description:
     title: First Name
     description: A textual description.

--- a/docs/openapi/components/schemas/common/IntentToSell.yml
+++ b/docs/openapi/components/schemas/common/IntentToSell.yml
@@ -15,9 +15,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - IntentToSell
       - type: string
-        enum:
-          - IntentToSell
+        const:
+          - IntentToSell 
   seller:
     title: Seller
     description: >-

--- a/docs/openapi/components/schemas/common/Invoice.yml
+++ b/docs/openapi/components/schemas/common/Invoice.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Invoice
       - type: string
-        enum:
-          - Invoice
+        const:
+          - Invoice 
   identifier:
     title: Property Identifier
     description: Identifiers for a property.

--- a/docs/openapi/components/schemas/common/IssuerAgent.yml
+++ b/docs/openapi/components/schemas/common/IssuerAgent.yml
@@ -22,9 +22,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - IssuerAgent
       - type: string
-        enum:
-          - IssuerAgent
+        const:
+          - IssuerAgent 
   issuerAgentOrg:
     title: IssuerAgentOrg
     $ref: ./Organization.yml

--- a/docs/openapi/components/schemas/common/LEIaddress.yml
+++ b/docs/openapi/components/schemas/common/LEIaddress.yml
@@ -14,9 +14,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - LEIaddress
       - type: string
-        enum:
-          - LEIaddress
+        const:
+          - LEIaddress 
   language:
     title: Language
     type: string

--- a/docs/openapi/components/schemas/common/LEIauthority.yml
+++ b/docs/openapi/components/schemas/common/LEIauthority.yml
@@ -12,9 +12,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - LEIauthority
       - type: string
-        enum:
-          - LEIauthority
+        const:
+          - LEIauthority 
   validationAuthorityID:
     title: validationAuthorityID
     type: string

--- a/docs/openapi/components/schemas/common/LEIentity.yml
+++ b/docs/openapi/components/schemas/common/LEIentity.yml
@@ -24,9 +24,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - LEIentity
       - type: string
-        enum:
-          - LEIentity
+        const:
+          - LEIentity 
   legalName:
     title: Legalname
     type: string

--- a/docs/openapi/components/schemas/common/LEIevidenceDocument.yml
+++ b/docs/openapi/components/schemas/common/LEIevidenceDocument.yml
@@ -13,9 +13,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - LEIevidenceDocument
       - type: string
-        enum:
-          - LEIevidenceDocument
+        const:
+          - LEIevidenceDocument 
   lei:
     title: Lei
     type: string

--- a/docs/openapi/components/schemas/common/LEIregistration.yml
+++ b/docs/openapi/components/schemas/common/LEIregistration.yml
@@ -16,9 +16,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - LEIregistration
       - type: string
-        enum:
-          - LEIregistration
+        const:
+          - LEIregistration 
   initialRegistrationDate:
     title: Initialregistrationdate
     type: string

--- a/docs/openapi/components/schemas/common/LegalEntityIdentifierCredential.yml
+++ b/docs/openapi/components/schemas/common/LegalEntityIdentifierCredential.yml
@@ -10,9 +10,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - LegalEntityIdentifierCredential
       - type: string
-        enum:
-          - LegalEntityIdentifierCredential
+        const:
+          - LegalEntityIdentifierCredential 
   leiCode:
     title: leiCode
     description: >-

--- a/docs/openapi/components/schemas/common/LinkRole.yml
+++ b/docs/openapi/components/schemas/common/LinkRole.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - LinkRole
       - type: string
-        enum:
-          - LinkRole
+        const:
+          - LinkRole 
   target:
     title: Target
     description: An entry point, within some Web-based protocol.

--- a/docs/openapi/components/schemas/common/MasterBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MasterBillOfLading.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - MasterBillOfLading
       - type: string
-        enum:
+        const:
           - MasterBillOfLading
   billOfLadingNumber:
     title: Bill Of Lading Number

--- a/docs/openapi/components/schemas/common/MeasuredProperty.yml
+++ b/docs/openapi/components/schemas/common/MeasuredProperty.yml
@@ -5,7 +5,7 @@ title: Measured Property
 description: >-
   A property, used to indicate attributes and relationships of some Thing;
   equivalent to rdf:Property.
-anyOf:
+oneOf:
   - $ref: ./ChemicalProperty.yml
   - $ref: ./MechanicalProperty.yml
 example: |-

--- a/docs/openapi/components/schemas/common/MeasuredValue.yml
+++ b/docs/openapi/components/schemas/common/MeasuredValue.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - MeasuredValue
       - type: string
-        enum:
+        const:
           - MeasuredValue
   value:
     title: Measurement Value

--- a/docs/openapi/components/schemas/common/MechanicalProperty.yml
+++ b/docs/openapi/components/schemas/common/MechanicalProperty.yml
@@ -10,8 +10,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - MechanicalProperty
       - type: string
-        enum:
+        const:
           - MechanicalProperty
   identifier:
     title: Property Identifier

--- a/docs/openapi/components/schemas/common/MillTestReport.yml
+++ b/docs/openapi/components/schemas/common/MillTestReport.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - MillTestReport
       - type: string
-        enum:
+        const:
           - MillTestReport
   manufacturer:
     title: Manufacturer

--- a/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - MultiModalBillOfLading
       - type: string
-        enum:
+        const:
           - MultiModalBillOfLading
   billOfLadingNumber:
     title: Bill Of Lading Number

--- a/docs/openapi/components/schemas/common/OGBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/OGBillOfLading.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - OGBillOfLading
       - type: string
-        enum:
+        const:
           - OGBillOfLading
   billOfLading:
     title: Bill Of Lading

--- a/docs/openapi/components/schemas/common/Observation.yml
+++ b/docs/openapi/components/schemas/common/Observation.yml
@@ -10,8 +10,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Observation
       - type: string
-        enum:
+        const:
           - Observation
   property:
     title: Measured Property

--- a/docs/openapi/components/schemas/common/OrderedItem.yml
+++ b/docs/openapi/components/schemas/common/OrderedItem.yml
@@ -13,8 +13,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - OrderedItem
       - type: string
-        enum:
+        const:
           - OrderedItem
   name:
     title: Name

--- a/docs/openapi/components/schemas/common/Organization.yml
+++ b/docs/openapi/components/schemas/common/Organization.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Organization
       - type: string
-        enum:
-          - Organization
+        const:
+          - Organization 
   name:
     title: Name
     description: Name of the organization.

--- a/docs/openapi/components/schemas/common/PGAStatusMessage.yml
+++ b/docs/openapi/components/schemas/common/PGAStatusMessage.yml
@@ -24,8 +24,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - PGAStatusMessage
       - type: string
-        enum:
+        const:
           - PGAStatusMessage
   recordNo:
     type: string

--- a/docs/openapi/components/schemas/common/Package.yml
+++ b/docs/openapi/components/schemas/common/Package.yml
@@ -10,8 +10,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Package
       - type: string
-        enum:
+        const:
           - Package
   physicalShippingMarks:
     title: shippingMarks

--- a/docs/openapi/components/schemas/common/PackingList.yml
+++ b/docs/openapi/components/schemas/common/PackingList.yml
@@ -19,8 +19,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - PackingList
       - type: string
-        enum:
+        const:
           - PackingList
   seller: 
     title: Seller

--- a/docs/openapi/components/schemas/common/ParcelDelivery.yml
+++ b/docs/openapi/components/schemas/common/ParcelDelivery.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ParcelDelivery
       - type: string
-        enum:
+        const:
           - ParcelDelivery
   deliveryAddress:
     title: Delivery Address

--- a/docs/openapi/components/schemas/common/PartOfOrder.yml
+++ b/docs/openapi/components/schemas/common/PartOfOrder.yml
@@ -12,8 +12,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - PartOfOrder
       - type: string
-        enum:
+        const:
           - PartOfOrder
   manufacturer:
     title: Manufacturer

--- a/docs/openapi/components/schemas/common/Person.yml
+++ b/docs/openapi/components/schemas/common/Person.yml
@@ -8,9 +8,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Person
       - type: string
-        enum:
-          - Person
+        const:
+          - Person 
   firstName:
     title: First Name
     description: Person's first name.

--- a/docs/openapi/components/schemas/common/Phytosanitary.yml
+++ b/docs/openapi/components/schemas/common/Phytosanitary.yml
@@ -12,8 +12,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Phytosanitary
       - type: string
-        enum:
+        const:
           - Phytosanitary
   certificateNumber:
     title: Certificate Number

--- a/docs/openapi/components/schemas/common/Place.yml
+++ b/docs/openapi/components/schemas/common/Place.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Place
       - type: string
-        enum:
+        const:
           - Place
   globalLocationNumber:
     title: Global Location Number (GLN)

--- a/docs/openapi/components/schemas/common/PostalAddress.yml
+++ b/docs/openapi/components/schemas/common/PostalAddress.yml
@@ -10,9 +10,13 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - PostalAddress
       - type: string
-        enum:
-          - PostalAddress
+        const:
+          - PostalAddress   
   organizationName:
     title: Organization Name
     description: The name of the organization expressed in text.

--- a/docs/openapi/components/schemas/common/PriceSpecification.yml
+++ b/docs/openapi/components/schemas/common/PriceSpecification.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - PriceSpecification
       - type: string
-        enum:
+        const:
           - PriceSpecification
   price:
     title: Price

--- a/docs/openapi/components/schemas/common/Product.yml
+++ b/docs/openapi/components/schemas/common/Product.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Product
       - type: string
-        enum:
+        const:
           - Product
   productID:
     title: Product ID

--- a/docs/openapi/components/schemas/common/ProductRegistrationEvidenceDocument.yml
+++ b/docs/openapi/components/schemas/common/ProductRegistrationEvidenceDocument.yml
@@ -31,8 +31,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ProductRegistrationEvidenceDocument
       - type: string
-        enum:
+        const:
           - ProductRegistrationEvidenceDocument
   category:
     title: A category for the product item.

--- a/docs/openapi/components/schemas/common/Purchase.yml
+++ b/docs/openapi/components/schemas/common/Purchase.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Purchase
       - type: string
-        enum:
+        const:
           - Purchase
   customer:
     title: Customer

--- a/docs/openapi/components/schemas/common/PurchaseOrder.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrder.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - PurchaseOrder
       - type: string
-        enum:
+        const:
           - PurchaseOrder
   purchaseOrderNo:
     title: Purchase Order Number

--- a/docs/openapi/components/schemas/common/Qualification.yml
+++ b/docs/openapi/components/schemas/common/Qualification.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Qualification
       - type: string
-        enum:
+        const:
           - Qualification
   qualificationCategory:
     title: Qualification Category

--- a/docs/openapi/components/schemas/common/QuantitativeValue.yml
+++ b/docs/openapi/components/schemas/common/QuantitativeValue.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - QuantitativeValue
       - type: string
-        enum:
+        const:
           - QuantitativeValue
   unitCode:
     title: Unit Code

--- a/docs/openapi/components/schemas/common/SIMASteelImportLicense.yml
+++ b/docs/openapi/components/schemas/common/SIMASteelImportLicense.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - SIMASteelImportLicense
       - type: string
-        enum:
+        const:
           - SIMASteelImportLicense
   applicantCompany:
     title: Applicant Company

--- a/docs/openapi/components/schemas/common/SIMASteelImportProductSpecifier.yml
+++ b/docs/openapi/components/schemas/common/SIMASteelImportProductSpecifier.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - SIMASteelImportProductSpecifier
       - type: string
-        enum:
+        const:
           - SIMASteelImportProductSpecifier
   steelProduct:
     title: Steel Product

--- a/docs/openapi/components/schemas/common/Seal.yml
+++ b/docs/openapi/components/schemas/common/Seal.yml
@@ -11,8 +11,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - Seal
       - type: string
-        enum:
+        const:
           - Seal
   sealNumber:
     title: Seal Number

--- a/docs/openapi/components/schemas/common/ServiceCharge.yml
+++ b/docs/openapi/components/schemas/common/ServiceCharge.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ServiceCharge
       - type: string
-        enum:
+        const:
           - ServiceCharge
   chargeCode:
     description: The unique identifier for this logistics service charge.

--- a/docs/openapi/components/schemas/common/ShippingInstructions.yml
+++ b/docs/openapi/components/schemas/common/ShippingInstructions.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ShippingInstructions
       - type: string
-        enum:
+        const:
           - ShippingInstructions
   billOfLadingNumber:
     title: Bill Of Lading Number

--- a/docs/openapi/components/schemas/common/ShippingStop.yml
+++ b/docs/openapi/components/schemas/common/ShippingStop.yml
@@ -7,6 +7,16 @@ description: >-
   https://blanker.org/files/air-waybill-2.xls
 type: object
 properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - ShippingStop
+      - type: string
+        const:
+          - ShippingStop
   from:
     title: From
     $ref: ./Place.yml

--- a/docs/openapi/components/schemas/common/SteelProduct.yml
+++ b/docs/openapi/components/schemas/common/SteelProduct.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - SteelProduct
       - type: string
-        enum:
+        const:
           - SteelProduct
   heatNumber:
     title: Heat Number

--- a/docs/openapi/components/schemas/common/TradeLineItem.yml
+++ b/docs/openapi/components/schemas/common/TradeLineItem.yml
@@ -10,8 +10,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - TradeLineItem
       - type: string
-        enum:
+        const:
           - TradeLineItem
   purchaseOrderNumber: 
     title: Purchase Order Number

--- a/docs/openapi/components/schemas/common/Transport.yml
+++ b/docs/openapi/components/schemas/common/Transport.yml
@@ -5,6 +5,16 @@ title: Transport
 description: A transport which can be a leg of a journey.
 type: object
 properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - Transport
+      - type: string
+        const:
+          - Transport
   loadLocation:
     title: Load Location
     $ref: ./Place.yml

--- a/docs/openapi/components/schemas/common/TransportEquipment.yml
+++ b/docs/openapi/components/schemas/common/TransportEquipment.yml
@@ -11,8 +11,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - TransportEquipment
       - type: string
-        enum:
+        const:
           - TransportEquipment
   equipmentReference:
     title: Equipment Reference

--- a/docs/openapi/components/schemas/common/USMCACertifier.yml
+++ b/docs/openapi/components/schemas/common/USMCACertifier.yml
@@ -8,8 +8,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - USMCACertifier
       - type: string
-        enum:
+        const:
           - USMCACertifier
   role:
     title: Role

--- a/docs/openapi/components/schemas/common/UsdaSc6.yml
+++ b/docs/openapi/components/schemas/common/UsdaSc6.yml
@@ -10,8 +10,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - UsdaSc6
       - type: string
-        enum:
+        const:
           - UsdaSc6
   serialNumber:
     title: Serial Number

--- a/docs/openapi/components/schemas/common/Workflow.yml
+++ b/docs/openapi/components/schemas/common/Workflow.yml
@@ -5,6 +5,16 @@ title: Workflow
 description: A workflow instance and definition. 
 type: object
 properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - Workflow
+      - type: string
+        const:
+          - Workflow
   definition: 
     description: Identifier of a particular type of workflow. 
     type: array

--- a/docs/openapi/components/schemas/common/ppq203.yml
+++ b/docs/openapi/components/schemas/common/ppq203.yml
@@ -10,8 +10,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ppq203
       - type: string
-        enum:
+        const:
           - ppq203
   certificateNumber:
     title: Certificate Number

--- a/docs/openapi/components/schemas/common/ppq587.yml
+++ b/docs/openapi/components/schemas/common/ppq587.yml
@@ -10,8 +10,12 @@ properties:
   type:
     oneOf:
       - type: array
+        items:
+          type: string
+          enum:
+            - ppq587
       - type: string
-        enum:
+        const:
           - ppq587
   signatureDate:
     title: signatureDate


### PR DESCRIPTION
Work in progress, a lot of the schemas do not display correctly in https://w3c-ccg.github.io/traceability-vocab/openapi/ due to syntax errors. This address syntax errors in the yaml files. 

![Screenshot 2022-03-22 at 17-57-33 Screenshot](https://user-images.githubusercontent.com/86194145/159444093-fae7b682-8468-4b32-a98a-366302f9416d.png)

