### PR TITLE
Move Credentials into their own Section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docs/schemas
 docs/traceability-openapi-v1.json
 docs/intermediate.json
 docs/sections/vocab.html
+docs/sections/credentials.html
 docs/testsuite/index.html
 docs/openapi/openapi.yml
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -457,7 +457,7 @@
 				<p>
 					This vocabulary uses 
 					<code> '@vocab': 'https://w3id.org/traceability/#undefinedTerm' </code>
-    			to disable JSON-LD related errors associated with Verifiable Credentials, 
+    					to disable JSON-LD related errors associated with Verifiable Credentials, 
 					issued about terms that have not yet been added here.
 				</p>
 			</section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -442,7 +442,27 @@
           defined in a industry-specific vocabulary. This is to ensure the
           broadest possible interoperability, within and beyond supply chain.
         </p>
-      </section>  
+      </section> 
+
+      <section class="informative">
+        <h4>Open API</h4>
+  			<p>
+    			This vocabulary can also be viewed as an
+    			<a href="https://w3id.org/traceability/openapi/">Open API Specification</a>.
+  			</p>
+      </section>   
+
+			<section>
+				<h4>Undefined Terms</h4>
+				<p>
+					This vocabulary uses 
+					<code> '@vocab': 'https://w3id.org/traceability/#undefinedTerm' </code>
+    			to disable JSON-LD related errors associated with Verifiable Credentials, 
+					issued about terms that have not yet been added here.
+				</p>
+			</section>
+
+
     </section>
 
       <section class="informative">

--- a/docs/index.html
+++ b/docs/index.html
@@ -806,7 +806,11 @@ back to the Express Carrier (14) well in advance of the goods arrival.
         </section>
       </section>
 
-    
+ 
+    <section
+    data-include="sections/credentials.html"
+    data-include-replace="true"
+    ></section>   
 
     <section
     data-include="sections/vocab.html"

--- a/docs/index.html
+++ b/docs/index.html
@@ -677,7 +677,7 @@ back to the Express Carrier (14) well in advance of the goods arrival.
         </p>
       </section>
       <section>
-          <h5>Featured Credentials</h5>
+          <h5>Supporting Documents</h5>
           <dl>
             <dt>Mill Test Report Certificate</dt>
             <dd>

--- a/docs/index.html
+++ b/docs/index.html
@@ -532,64 +532,6 @@ steel, containing the two CTPAT certifications, USMCA Certificate of
 Origin, Steel Import License, Mill Test Report, and Commercial Invoice.
 Data is verified by CBP’s automated processes.
             </p>
-
-            <h5>Featured Steel Credentials</h5>
-          <dl>
-            <dt>Mill Test Report Certificate</dt>
-            <dd>
-              <p>The <a href="#MillTestReportCertificate">Mill Test Report</a> 
-                certifies steel type and quality, listing chemical and mechanical 
-                properties.</p>
-            </dd>
-            <dt>Commercial Invoice Certificate</dt>
-            <dd>
-              <figure>
-                <img src="samples/commercial-invoice-ex.png" alt="Commercial Invoice example" style="width:40%">
-                <figcaption>Sample Commercial Invoice</figcaption>
-              </figure>
-              <p>
-                <a href="#CommercialInvoiceCertificate">Commercial Invoice</a> 
-                indicates to authorities the value of goods subject to tariffs 
-                and duties.
-              </p> 
-            </dd>
-            <dt>Bill of Lading Certificate</dt>
-            <dd>
-              <figure>
-                <img src="samples/bill-of-lading-ex-2.png" alt="Bill of Lading example" style="width:40%">
-                <figcaption>Sample Bill of Lading</figcaption>
-              </figure>
-              <p>
-                <a href="#BillOfLadingCertificate">Bill of Lading</a> certificates 
-                are issued by the carrier, indicating a) receipt of goods, b) evidence 
-                of consignment contract, and c) title of goods. 
-              </p> 
-            </dd>
-            <dt>Verifiable Business Card</dt>
-            <dd>
-              <p>
-                <a href="#VerifiableBusinessCard">Verifiable Business Cards</a> hold 
-                verifiable presentation endpoint addresses.  
-              </p>
-            </dd>
-            
-            <dt>USMCA Certificate Of Origin</dt>
-            <dd>
-              <figure>
-                <img src="samples/usmca-form.png" alt="USMCA Certificate Of Origin" style="width:40%">
-                <figcaption>USMCA Certificate Of Origin</figcaption>
-              </figure>
-              <p>
-               The <a href="#USMCACertificateOfOrigin">USMCA Certificate Of Origin</a> 
-              schema is adapted from 
-              <a href="https://www.fedex.com/content/dam/fedex/us-united-states/International/upload/FedEx_USMCA_T-MEC_CUSMA_Fillable_Form.pdf">
-                FedEx's</a> and <a href="https://www.ups.com/assets/resources/media/ups-usmca-fillable-form-us.pdf">UPS's</a> 
-                USMCA Forms, implementing the 
-                <a href="https://trade.cbp.gov/USMCA/s/">United States - Mexico - Canada 
-                Agreement (USMCA)</a>. 
-              </p> 
-            </dd>
-          </dl>
         </section>
 
         <section>
@@ -732,8 +674,66 @@ CBP receives the pouch of verifiable documentation (12). The parties and data
 are cross referenced; commercial and physical provenance is verified; and CBP’s
 automated processes can issue Import Approval (13) documentation for presentation
 back to the Express Carrier (14) well in advance of the goods arrival.
-        </p>        
-          <h5>Featured E-Commerce Credentials</h5>
+        </p>
+      </section>
+      <section>
+          <h5>Featured Credentials</h5>
+          <dl>
+            <dt>Mill Test Report Certificate</dt>
+            <dd>
+              <p>The <a href="#MillTestReportCertificate">Mill Test Report</a> 
+                certifies steel type and quality, listing chemical and mechanical 
+                properties.</p>
+            </dd>
+            <dt>Commercial Invoice Certificate</dt>
+            <dd>
+              <figure>
+                <img src="samples/commercial-invoice-ex.png" alt="Commercial Invoice example" style="width:40%">
+                <figcaption>Sample Commercial Invoice</figcaption>
+              </figure>
+              <p>
+                <a href="#CommercialInvoiceCertificate">Commercial Invoice</a> 
+                indicates to authorities the value of goods subject to tariffs 
+                and duties.
+              </p> 
+            </dd>
+            <dt>Bill of Lading Certificate</dt>
+            <dd>
+              <figure>
+                <img src="samples/bill-of-lading-ex-2.png" alt="Bill of Lading example" style="width:40%">
+                <figcaption>Sample Bill of Lading</figcaption>
+              </figure>
+              <p>
+                <a href="#BillOfLadingCertificate">Bill of Lading</a> certificates 
+                are issued by the carrier, indicating a) receipt of goods, b) evidence 
+                of consignment contract, and c) title of goods. 
+              </p> 
+            </dd>
+            <dt>Verifiable Business Card</dt>
+            <dd>
+              <p>
+                <a href="#VerifiableBusinessCard">Verifiable Business Cards</a> hold 
+                verifiable presentation endpoint addresses.  
+              </p>
+            </dd>
+            
+            <dt>USMCA Certificate Of Origin</dt>
+            <dd>
+              <figure>
+                <img src="samples/usmca-form.png" alt="USMCA Certificate Of Origin" style="width:40%">
+                <figcaption>USMCA Certificate Of Origin</figcaption>
+              </figure>
+              <p>
+               The <a href="#USMCACertificateOfOrigin">USMCA Certificate Of Origin</a> 
+              schema is adapted from 
+              <a href="https://www.fedex.com/content/dam/fedex/us-united-states/International/upload/FedEx_USMCA_T-MEC_CUSMA_Fillable_Form.pdf">
+                FedEx's</a> and <a href="https://www.ups.com/assets/resources/media/ups-usmca-fillable-form-us.pdf">UPS's</a> 
+                USMCA Forms, implementing the 
+                <a href="https://trade.cbp.gov/USMCA/s/">United States - Mexico - Canada 
+                Agreement (USMCA)</a>. 
+              </p> 
+            </dd>
+          </dl>
           <dl>
             <dt>Purchase Order</dt>
             <dd>

--- a/packages/traceability-schemas/scripts/schemas-to-vocab.js
+++ b/packages/traceability-schemas/scripts/schemas-to-vocab.js
@@ -21,15 +21,14 @@ const buildLinkedDataTable = (schema) => {
     <td><a href="${$linkedData['@id']}">${$linkedData['@id']}</a></td>
   </tr>
   
-  ${
-    $id
+  ${$id
       ? `
 <tr>
   <td><a href="https://swagger.io/specification/#schema-object">schema</a></td>
   <td><a href="${baseUrl + $id}">${baseUrl + $id}</a></td>
 </tr>`
       : ''
-  }
+    }
 
   </tbody>
   </table>
@@ -119,7 +118,7 @@ const separateSchemas = (schemaList) => {
 
 (() => {
   console.log('🧪 build vocab from schemas');
-	const { credentials, vocab } = separateSchemas(schemas);
+  const { credentials, vocab } = separateSchemas(schemas);
 
   const credentialSection = `
     <section>

--- a/packages/traceability-schemas/scripts/schemas-to-vocab.js
+++ b/packages/traceability-schemas/scripts/schemas-to-vocab.js
@@ -91,34 +91,14 @@ const buildVocabSection = (schema) => {
   return buildProperty(schema);
 };
 
-(async () => {
+(() => {
   console.log('🧪 build vocab from schemas');
   const sections = schemas.map(buildVocabSection).join('\n');
   const section = `
-<section id="vocabulary" class="normative">
-<h2>Vocabulary </h2>
-
-<section id="Open API" class="informative">
-  <h2>Open API</h2>
-  <p>
-    This vocabulary can also be viewed as an
-    <a href="https://w3id.org/traceability/openapi/">Open API Specification</a>.
-  </p>
-</section>
-
-<section>
-<h3 id="undefinedTerm">Undefined Terms</h3>
-<p>This vocabulary uses <code> '@vocab': 'https://w3id.org/traceability/#undefinedTerm' </code>
-    to disable JSON-LD related errors associated with Verifiable Credentials, issued about
-    terms that have not yet been added here.
-</p>
-</section>
-
-<section>
-<h2>Defined Terms</h2>
-${sections}
-</section>
-</section>
+    <section>
+      <h2>Vocabulary</h2>
+      ${sections}
+    </section>
   `;
   fs.writeFileSync(vocabPath, section);
 })();

--- a/packages/traceability-schemas/scripts/schemas-to-vocab.js
+++ b/packages/traceability-schemas/scripts/schemas-to-vocab.js
@@ -6,6 +6,7 @@ const path = require('path');
 const { schemas } = require('../services/schemas');
 
 const vocabPath = path.resolve(__dirname, '../../../docs/sections/vocab.html');
+const credentialPath = path.resolve(__dirname, '../../../docs/sections/credentials.html');
 
 const baseUrl = 'https://w3id.org/traceability';
 
@@ -91,14 +92,49 @@ const buildVocabSection = (schema) => {
   return buildProperty(schema);
 };
 
+const separateSchemas = (schemaList) => {
+  // Define Arrays to sort the schemas into
+  const credentialSchemas = [];
+  const vocabSchemas = [];
+
+  // Separates Schemas into Credentials and Vocabulary
+  schemaList.forEach((schema) => {
+    const { example } = schema;
+    const obj = JSON.parse(example);
+    const type = Array.isArray(obj.type) ? obj.type : [obj.type];
+    if (type.indexOf('VerifiableCredential') === -1) {
+      vocabSchemas.push(schema);
+    } else {
+      credentialSchemas.push(schema);
+    }
+  });
+
+  // Generate the text for each respective section
+  const credentials = credentialSchemas.map(buildVocabSection).join('\n');
+  const vocab = vocabSchemas.map(buildVocabSection).join('\n');
+
+  // Return the html text for each section
+  return { credentials, vocab };
+};
+
 (() => {
   console.log('🧪 build vocab from schemas');
-  const sections = schemas.map(buildVocabSection).join('\n');
-  const section = `
+	const { credentials, vocab } = separateSchemas(schemas);
+
+  const credentialSection = `
     <section>
-      <h2>Vocabulary</h2>
-      ${sections}
+      <h2>Credentials</h2>
+      ${credentials}
     </section>
   `;
-  fs.writeFileSync(vocabPath, section);
+
+  const vocabSection = `
+    <section>
+      <h2>Vocabulary</h2>
+      ${vocab}
+    </section>
+  `;
+
+  fs.writeFileSync(credentialPath, credentialSection);
+  fs.writeFileSync(vocabPath, vocabSection);
 })();


### PR DESCRIPTION
This PR has the following edits to the respec document

1. Moves the 'Supporting documents' from workflows into their own subsection
2. Moved vocabulary description for OpenAPI and Terms from script to top of document
3. Moved Credentials into their own section to appear in the table of contents
4. Updated the Vocab section so that Vocabulary Term appears in the table of contents

The most sensible location for `Supporting Documents` is with the Credential.
How to approach this is the topic of this issue: https://github.com/w3c-ccg/traceability-vocab/issues/357

Will be fixed in a future PR once the approach has been agreed upon. 