### PR TITLE
Add Software Bill of Materials Credential

### DIFF
--- a/docs/openapi/components/schemas/common/SoftwareBillOfMaterials.yml
+++ b/docs/openapi/components/schemas/common/SoftwareBillOfMaterials.yml
@@ -38,7 +38,7 @@ example: |-
     },
     "tool": [
       "github.com/spdx/tools-golang/builder",
-      "github.com/spdx/tools,-golang/idsearcher"
+      "github.com/spdx/tools-golang/idsearcher"
     ],
     "packageRelationship" : [
       "DESCRIBES SPDXRef-Package-hello"

--- a/docs/openapi/components/schemas/common/SoftwareBillOfMaterials.yml
+++ b/docs/openapi/components/schemas/common/SoftwareBillOfMaterials.yml
@@ -1,0 +1,111 @@
+$linkedData:
+  term: SoftwareBillOfMaterials
+  '@id': https://w3id.org/traceability#SoftwareBillOfMaterials
+title: SPDX Software Bill Of Materials
+description: |-
+  The structure for this Certificate is adapted from
+  the Software Package Data Exchange® (SPDX®) specification is a standard format for communicating the components, 
+  licenses and copyrights associated with software packages. https://github.com/spdx/spdx-spec
+  The specific example used as the basis for this file can be found here: 
+  https://github.com/spdx/spdx-examples/blob/master/example1/spdx/example1.spdx
+type: object
+required:
+  - type
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - SoftwareBillOfMaterials
+      - type: string
+        const:
+          - SoftwareBillOfMaterials
+additionalProperties: true
+example: |-
+  {
+    "type" : "SoftwareBillOfMaterials",
+    "SPDXVersion": "SPDX-2.2",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "documentName": "hello",
+    "documentNamespace": "https://swinslow.net/spdx-examples/example1/hello-v3",
+    "creator": {
+      "type": "Person",
+      "name": "Steve Winslow",
+      "email" : "steve@swinslow.net"
+    },
+    "tool": [
+      "github.com/spdx/tools-golang/builder",
+      "github.com/spdx/tools,-golang/idsearcher"
+    ],
+    "packageRelationship" : [
+      "DESCRIBES SPDXRef-Package-hello"
+    ],
+    "packages": [
+      {
+        "type": "SoftwarePackage",
+        "packageName": "hello",
+        "SPDXID": "SPDXRef-Package-hello",
+        "packageDownloadLocation": "git+https://github.com/swinslow/spdx-examples.git#example1/content",
+        "filesAnalyzed": true,
+        "packageVerificationCode": "9d20237bb72087e87069f96afb41c6ca2fa2a342",
+        "packageLicenseConcluded": "GPL-3.0-or-later",
+        "packageLicenseInfoFromFiles": "GPL-3.0-or-later",
+        "packageLicenseDeclared": "GPL-3.0-or-later",
+        "packageCopyrightText": "NOASSERTION",
+        "files" : [
+          {
+            "type" : "SoftwarePackageFile",
+            "fileName": "/build/hello",
+            "SPDXID": "SPDXRef-hello-binary",
+            "fileType": "BINARY",
+            "fileChecksum" : {
+              "SHA1": "20291a81ef065ff891b537b64d4fdccaf6f5ac02",
+              "SHA256": "83a33ff09648bb5fc5272baca88cf2b59fd81ac4cc6817b86998136af368708e",
+              "MD5": "08a12c966d776864cc1eb41fd03c3c3d"
+            },
+            "licenseConcluded": "GPL-3.0-or-later",
+            "licenseInfoInFile": "NOASSERTION",
+            "fileCopyrightText": "NOASSERTION",
+            "fileRelation" : [
+              "GENERATED_FROM SPDXRef-hello-src",
+              "GENERATED_FROM SPDXRef-Makefile"
+            ]
+          },
+          {
+            "type" : "SoftwarePackageFile",
+            "fileName": "/src/Makefile",
+            "SPDXID": "SPDXRef-Makefile",
+            "fileType": "SOURCE",
+            "fileChecksum": { 
+              "SHA1": "69a2e85696fff1865c3f0686d6c3824b59915c80",
+              "SHA256": "5da19033ba058e322e21c90e6d6d859c90b1b544e7840859c12cae5da005e79c",
+              "MD5": "559424589a4f3f75fd542810473d8bc1"
+            },
+            "licenseConcluded": "GPL-3.0-or-later",
+            "licenseInfoInFile": "GPL-3.0-or-later",
+            "fileCopyrightText": "NOASSERTION",
+            "fileRelation" : [
+              "BUILD_TOOL_OF SPDXRef-Package-hello"
+            ]
+          },
+          {
+            "type" : "SoftwarePackageFile",
+            "fileName": "/src/hello.c",
+            "SPDXID": "SPDXRef-hello-src",
+            "fileType": "SOURCE",
+            "fileChecksum": {
+              "SHA1": "20862a6d08391d07d09344029533ec644fac6b21",
+              "SHA256": "b4e5ca56d1f9110ca94ed0bf4e6d9ac11c2186eb7cd95159c6fdb50e8db5a823",
+              "MD5": "935054fe899ca782e11003bbae5e166c"
+            },
+            "licenseConcluded": "GPL-3.0-or-later",
+            "licenseInfoInFile": "GPL-3.0-or-later",
+            "fileCopyrightText": "Copyright Contributors to the spdx-examples project."
+          }
+        ]
+      }
+    ]
+  }

--- a/docs/openapi/components/schemas/common/SoftwareBillOfMaterialsCertificate.yml
+++ b/docs/openapi/components/schemas/common/SoftwareBillOfMaterialsCertificate.yml
@@ -1,0 +1,173 @@
+$linkedData:
+  term: SoftwareBillofMaterialsCertificate
+  '@id': https://w3id.org/traceability#SoftwareBillOfMaterialsCredential
+title: Software Bill of Materials Certificate
+description: |-
+  A Software Bill of Materials (SBOM) is a formal, machine-readable inventory of software components and dependencies,
+  information about those components, and their hierarchical relationships. These inventories should be
+  comprehensive – or should explicitly state where they could not be. SBOMs may include open source or
+  proprietary software and can be widely available or access-restricted.
+  https://ntia.gov/files/ntia/publications/sbom_at_a_glance_apr2021.pdf
+type: object
+properties:
+  '@context':
+    type: array
+    const:
+      - 'https://www.w3.org/2018/credentials/v1'
+      - 'https://w3id.org/traceability/v1'
+  type:
+    type: array
+    const:
+      - VerifiableCredential
+      - SoftwareBillofMaterialsCertificate
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  issuer:
+    type: object
+  credentialSubject:
+    description: | 
+      Software Bill of Materials to be signed over. 
+      Example taken from https://github.com/spdx/spdx-examples/blob/master/example1/spdx/example1.spdx
+    type: object
+  proof:
+    type: object
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ./LinkRole.yml
+additionalProperties: false
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "https://github.com/spdx/spdx-examples/blob/master/example1/spdx/example1.spdx",
+    "type": [
+      "VerifiableCredential",
+      "SoftwareBillofMaterialsCertificate"
+    ],
+    "name": "SPDX Software Bill of Materials Certificate",
+    "description": "Certificate Issued by Software Vendor for information on packages and binaries",
+    "relatedLink": [],
+    "issuanceDate": "2021-08-26T01:46:00Z",
+    "issuer": {
+      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "type": "Organization",
+      "name": "Software Vendor Company",
+      "description": "A company that provides software or libraries as a service",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "10612 Westheimer Rd",
+        "addressLocality": "Houston",
+        "addressRegion": "Texas",
+        "postalCode": "77042",
+        "addressCountry": "USA"
+      },
+      "email": "Jerrell.Brakus73@soft-vendor.example.gov",
+      "phoneNumber": "555-322-9464",
+      "faxNumber": "555-766-1744"
+    },
+    "credentialSubject": {
+      "type": "SoftwareBillOfMaterials",
+      "SPDXVersion": "SPDX-2.2",
+      "dataLicense": "CC0-1.0",
+      "SPDXID": "SPDXRef-DOCUMENT",
+      "documentName": "hello",
+      "documentNamespace": "https://swinslow.net/spdx-examples/example1/hello-v3",
+      "creator": {
+        "type": "Person",
+        "name": "Steve Winslow",
+        "email": "steve@swinslow.net"
+      },
+      "tool": [
+        "github.com/spdx/tools-golang/builder",
+        "github.com/spdx/tools,-golang/idsearcher"
+      ],
+      "packageRelationship": [
+        "DESCRIBES SPDXRef-Package-hello"
+      ],
+      "packages": [
+        {
+          "type": "SoftwarePackage",
+          "packageName": "hello",
+          "SPDXID": "SPDXRef-Package-hello",
+          "packageDownloadLocation": "git+https://github.com/swinslow/spdx-examples.git#example1/content",
+          "filesAnalyzed": true,
+          "packageVerificationCode": "9d20237bb72087e87069f96afb41c6ca2fa2a342",
+          "packageLicenseConcluded": "GPL-3.0-or-later",
+          "packageLicenseInfoFromFiles": "GPL-3.0-or-later",
+          "packageLicenseDeclared": "GPL-3.0-or-later",
+          "packageCopyrightText": "NOASSERTION",
+          "files": [
+            {
+              "type": "SoftwarePackageFile",
+              "fileName": "/build/hello",
+              "SPDXID": "SPDXRef-hello-binary",
+              "fileType": "BINARY",
+              "fileChecksum": {
+                "SHA1": "20291a81ef065ff891b537b64d4fdccaf6f5ac02",
+                "SHA256": "83a33ff09648bb5fc5272baca88cf2b59fd81ac4cc6817b86998136af368708e",
+                "MD5": "08a12c966d776864cc1eb41fd03c3c3d"
+              },
+              "licenseConcluded": "GPL-3.0-or-later",
+              "licenseInfoInFile": "NOASSERTION",
+              "fileCopyrightText": "NOASSERTION",
+              "fileRelation": [
+                "GENERATED_FROM SPDXRef-hello-src",
+                "GENERATED_FROM SPDXRef-Makefile"
+              ]
+            },
+            {
+              "type": "SoftwarePackageFile",
+              "fileName": "/src/Makefile",
+              "SPDXID": "SPDXRef-Makefile",
+              "fileType": "SOURCE",
+              "fileChecksum": {
+                "SHA1": "69a2e85696fff1865c3f0686d6c3824b59915c80",
+                "SHA256": "5da19033ba058e322e21c90e6d6d859c90b1b544e7840859c12cae5da005e79c",
+                "MD5": "559424589a4f3f75fd542810473d8bc1"
+              },
+              "licenseConcluded": "GPL-3.0-or-later",
+              "licenseInfoInFile": "GPL-3.0-or-later",
+              "fileCopyrightText": "NOASSERTION",
+              "fileRelation": [
+                "BUILD_TOOL_OF SPDXRef-Package-hello"
+              ]
+            },
+            {
+              "type": "SoftwarePackageFile",
+              "fileName": "/src/hello.c",
+              "SPDXID": "SPDXRef-hello-src",
+              "fileType": "SOURCE",
+              "fileChecksum": {
+                "SHA1": "20862a6d08391d07d09344029533ec644fac6b21",
+                "SHA256": "b4e5ca56d1f9110ca94ed0bf4e6d9ac11c2186eb7cd95159c6fdb50e8db5a823",
+                "MD5": "935054fe899ca782e11003bbae5e166c"
+              },
+              "licenseConcluded": "GPL-3.0-or-later",
+              "licenseInfoInFile": "GPL-3.0-or-later",
+              "fileCopyrightText": "Copyright Contributors to the spdx-examples project."
+            }
+          ]
+        }
+      ]
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2022-04-12T15:49:14Z",
+      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3eP5e3fm_Sj7x2sE9smg-OMdRdKDJcZVQDig_xE-XViDBrQpLcDnNGAnCo3RcLnrnQFvVHB9Ko6c_i7glC2CQ"
+    }
+  }
+
+

--- a/docs/openapi/components/schemas/common/SoftwareBillOfMaterialsCertificate.yml
+++ b/docs/openapi/components/schemas/common/SoftwareBillOfMaterialsCertificate.yml
@@ -31,10 +31,7 @@ properties:
   issuer:
     type: object
   credentialSubject:
-    description: | 
-      Software Bill of Materials to be signed over. 
-      Example taken from https://github.com/spdx/spdx-examples/blob/master/example1/spdx/example1.spdx
-    type: object
+    $ref: ./SoftwareBillOfMaterials.yml
   proof:
     type: object
   relatedLink:


### PR DESCRIPTION
This Pull Requests adds a Software Bill of Materials Credential adapted from the SPDX format which can be found at https://github.com/spdx/spdx-spec, and the specific example can be found here: https://github.com/spdx/spdx-examples/blob/master/example1/spdx/example1.spdx.

Both of these links are included directly in the documents. 