### PR TITLE
Update Organization & related examples

### DIFF
--- a/docs/openapi/components/schemas/common/AgActivity.yml
+++ b/docs/openapi/components/schemas/common/AgActivity.yml
@@ -99,15 +99,30 @@ example: |-
           ],
           "name": "Jimbo's Awesome Farm",
           "description": "Devolved transitional functionalities",
-          "address": {
+          "place": {
             "type": [
-              "PostalAddress"
+                "Place"
             ],
-            "streetAddress": "9540 Marilou Throughway",
-            "addressLocality": "South Aniyahtown",
-            "addressRegion": "West Virginia",
-            "postalCode": "95833-0026",
-            "addressCountry": "Dominica"
+            "globalLocationNumber": "9339929638102",
+            "geo": {
+                "type": [
+                "GeoCoordinates"
+                ],
+                "latitude": "40.9090",
+                "longitude": "151.8748"
+            },
+            "address": {
+                "type": [
+                "PostalAddress"
+                ],
+                "organizationName": "Bogisich LLC",
+                "streetAddress": "50938 Donavon Junctions",
+                "addressLocality": "Rhodastad",
+                "addressRegion": "Louisiana",
+                "postalCode": "26521-2810",
+                "addressCountry": "American Samoa"
+            },
+            "unLocode": "DKCPH"
           },
           "email": "Chloe.Ondricka42@example.org",
           "phoneNumber": "555-496-7149",

--- a/docs/openapi/components/schemas/common/AgInspectionReport.yml
+++ b/docs/openapi/components/schemas/common/AgInspectionReport.yml
@@ -253,29 +253,6 @@ example: |-
         ],
         "name": "Leannon and Sons",
         "description": "Fundamental multi-tasking service-desk",
-          "place": {
-            "type":[
-              "Place"
-            ],
-            "geo":{
-              "type":[
-                "GeoCoordinates"
-              ],
-              "latitude":"43.2557",
-              "longitude":"-79.8711"
-            },
-            "address":{
-              "type":[
-                "PostalAddress"
-              ],
-              "postalCode":"",
-              "addressRegion":"Ontario",
-              "streetAddress":"",
-              "addressCountry":"CANADA",
-              "addressLocality":"Hamilton"
-            },
-            "globalLocationNumber":"SC720"
-          },
         "email": "Hipolito58@example.org",
         "phoneNumber": "555-895-1661",
         "faxNumber": "555-497-2527"

--- a/docs/openapi/components/schemas/common/AgInspectionReport.yml
+++ b/docs/openapi/components/schemas/common/AgInspectionReport.yml
@@ -118,15 +118,30 @@ example: |-
           ],
           "name": "Runolfsson Inc",
           "description": "Stand-alone multimedia portal",
-          "address": {
+          "place": {
             "type": [
-              "PostalAddress"
+              "Place"
             ],
-            "streetAddress": "573 Aron Isle",
-            "addressLocality": "Lake Gayle",
-            "addressRegion": "Nevada",
-            "postalCode": "42931-4420",
-            "addressCountry": "India"
+            "globalLocationNumber": "5449782976823",
+            "geo": {
+              "type": [
+                "GeoCoordinates"
+              ],
+              "latitude": "-79.6395",
+              "longitude": "178.5353"
+            },
+            "address": {
+              "type": [
+                "PostalAddress"
+              ],
+              "organizationName": "Bednar - Kiehn",
+              "streetAddress": "853 Wisozk River",
+              "addressLocality": "New Noemyfort",
+              "addressRegion": "New Mexico",
+              "postalCode": "18047-2038",
+              "addressCountry": "Togo"
+            },
+            "unLocode": "DKCPH"
           },
           "email": "Marina96@example.net",
           "phoneNumber": "555-521-6143",
@@ -236,21 +251,34 @@ example: |-
         "type": [
           "Organization"
         ],
-        "name": "Schulist, Lesch and Zulauf",
-        "description": "Reduced zero tolerance support",
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "streetAddress": "7849 Hodkiewicz Way",
-          "addressLocality": "Nelliebury",
-          "addressRegion": "Maryland",
-          "postalCode": "88580-4041",
-          "addressCountry": "Ethiopia"
-        },
-        "email": "Kurtis_Runte75@example.com",
-        "phoneNumber": "555-112-1507",
-        "faxNumber": "555-167-8782"
+        "name": "Leannon and Sons",
+        "description": "Fundamental multi-tasking service-desk",
+          "place": {
+            "type":[
+              "Place"
+            ],
+            "geo":{
+              "type":[
+                "GeoCoordinates"
+              ],
+              "latitude":"43.2557",
+              "longitude":"-79.8711"
+            },
+            "address":{
+              "type":[
+                "PostalAddress"
+              ],
+              "postalCode":"",
+              "addressRegion":"Ontario",
+              "streetAddress":"",
+              "addressCountry":"CANADA",
+              "addressLocality":"Hamilton"
+            },
+            "globalLocationNumber":"SC720"
+          },
+        "email": "Hipolito58@example.org",
+        "phoneNumber": "555-895-1661",
+        "faxNumber": "555-497-2527"
       },
       "AgPackage": [
         {

--- a/docs/openapi/components/schemas/common/AgParcelDelivery.yml
+++ b/docs/openapi/components/schemas/common/AgParcelDelivery.yml
@@ -175,16 +175,6 @@ example: |-
       ],
       "name": "Leannon and Sons",
       "description": "Fundamental multi-tasking service-desk",
-      "address": {
-        "type": [
-          "PostalAddress"
-        ],
-        "streetAddress": "3393 Madison Forks",
-        "addressLocality": "West Ladariusmouth",
-        "addressRegion": "New Jersey",
-        "postalCode": "39242",
-        "addressCountry": "Djibouti"
-      },
       "email": "Hipolito58@example.org",
       "phoneNumber": "555-895-1661",
       "faxNumber": "555-497-2527"

--- a/docs/openapi/components/schemas/common/BillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/common/BillOfLadingCertificate.yml
@@ -68,18 +68,10 @@ example: |-
     ],
     "issuanceDate": "2019-12-11T03:50:55Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": "Organization",
       "name": "Hauck Group",
       "description": "Focused secondary synergy",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "3198 O'Kon Wall",
-        "addressLocality": "North Adolphchester",
-        "addressRegion": "Nevada",
-        "postalCode": "50788",
-        "addressCountry": "Cote d'Ivoire"
-      },
       "email": "Bernita.Quitzon98@example.com",
       "phoneNumber": "555-171-4411",
       "faxNumber": "555-758-9761"
@@ -171,9 +163,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2019-12-11T03:50:55Z",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..g9J070BT6vKDscw8nlQ9bSXc9ONbd9gIdtnqZ8d8HWQNYVyK-y6PygSoFOuUP9wdXd8QCQNcZpXI7Rgz_NtuCQ",
+      "created": "2022-04-14T17:32:37Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..t13UHWj248_D8xlVKhPlbSsZ7gmrehFeVkgdiNC0YAFReihG1IbwhFOwUkNpQfBz1Qg2ZVBKYrPhbm7bCpWKBA"
     }
   }

--- a/docs/openapi/components/schemas/common/BindingDataRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/common/BindingDataRegistrationCredential.yml
@@ -86,13 +86,30 @@ example: |-
         "type": "Organization",
         "name": "Hane LLC",
         "description": "Expanded solution-oriented collaboration",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "571 McDermott Overpass",
-          "addressLocality": "Bretbury",
-          "addressRegion": "Minnesota",
-          "postalCode": "46974-2565",
-          "addressCountry": "Eritrea"
+        "place": {
+          "type": [
+              "Place"
+          ],
+          "globalLocationNumber": "9339929638102",
+          "geo": {
+              "type": [
+              "GeoCoordinates"
+              ],
+              "latitude": "40.9090",
+              "longitude": "151.8748"
+          },
+          "address": {
+              "type": [
+              "PostalAddress"
+              ],
+              "organizationName": "Bogisich LLC",
+              "streetAddress": "50938 Donavon Junctions",
+              "addressLocality": "Rhodastad",
+              "addressRegion": "Louisiana",
+              "postalCode": "26521-2810",
+              "addressCountry": "American Samoa"
+          },
+          "unLocode": "DKCPH"
         },
         "email": "Maud65@example.com",
         "phoneNumber": "555-673-9451",

--- a/docs/openapi/components/schemas/common/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/common/CTPATCertificate.yml
@@ -114,21 +114,13 @@ example: |-
       "description": "Your Supply Chain's Strongest Link",
       "email": "ctpathelpdesk@cbp.dhs.gov",
       "phoneNumber": "1-800-927-8729",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U"
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn"
     },
     "issuanceDate": "2022-01-13T09:16:46Z",
     "credentialSubject": {
       "id": "did:key:z6MkhfZ7sNYEJ8vFSpwJaeyN7zNUaTxS4TBxW3y6R9ZKRaQ4",
       "type": "Organization",
-      "name": "Trans-Atlantic Shipping Co. Ltd.",
-      "address": {
-        "type": "PostalAddress",
-        "organizationName": "Trans-Atlantic Shipping Co. Ltd.",
-        "streetAddress": "82 Whitchurch Road",
-        "addressLocality": "Elsworth",
-        "postalCode": "CB3 8NW",
-        "addressCountry": "UK"
-      }
+      "name": "Trans-Atlantic Shipping Co. Ltd."
     },
     "sviNumber": "57118961",
     "ctpatAccountNumber": "12008",
@@ -137,9 +129,9 @@ example: |-
     "issuingCountry": "US",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-02-28T13:30:06Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T17:51:18Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..UP5ZVVOAHWC7Oqu8p9EpldNcOLNvc_35K2cAkSKVv6vjBeWQ62mBW8QdTYLseqIzz-yC4HeYborMdXm778G7CA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..KjM1d7gGHeFT2bORfWDF6D1Y79ng4PR6TB5KznEy7jrxjQ9P181B6T0Z8XsA-j7I2TNOXqWuU4dDXiVPR4oiBQ"
     }
   }

--- a/docs/openapi/components/schemas/common/CommercialInvoiceCertificate.yml
+++ b/docs/openapi/components/schemas/common/CommercialInvoiceCertificate.yml
@@ -54,21 +54,14 @@ example: |-
     "name": "Commercial Invoice Certificate",
     "issuanceDate": "2022-02-23T11:55:00Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": [
         "Organization"
       ],
-      "address": {
-        "type": [
-          "PostalAddress"
-        ],
-        "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-        "streetAddress": "1651, Shimonakano, Yoshida",
-        "addressLocality": "Tsubame-shi",
-        "addressRegion": "Niigata-ken",
-        "postalCode": "959-0215",
-        "addressCountry": "Japan"
-      }
+      "name": "Better Life Tech",
+      "description": "Better Lives Products",
+      "email": "procurement@lifetech-example.org",
+      "phoneNumber": "+32-5555-8495"
     },
     "credentialSubject": {
       "type": [
@@ -84,65 +77,31 @@ example: |-
         "type": [
           "Organization"
         ],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-          "streetAddress": "1651, Shimonakano, Yoshida",
-          "addressLocality": "Tsubame-shi",
-          "addressRegion": "Niigata-ken",
-          "postalCode": "959-0215",
-          "addressCountry": "Japan"
-        }
+        "email": "Gustave.Dicki37@example.net",
+        "phoneNumber": "555-238-5681"
       },
       "buyer": {
         "type": [
           "Organization"
         ],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "organizationName": "Generic Motors of America",
-          "streetAddress": "12 Generic Motors Dr",
-          "addressLocality": "Detroit",
-          "addressRegion": "Michigain",
-          "postalCode": "48232-5170",
-          "addressCountry": "USA"
-        }
+        "name": "Better Life Tech",
+        "description": "Better Lives Products",
+        "email": "procurement@lifetech-example.org",
+        "phoneNumber": "+32-5555-8495"
       },
       "shipToParty": {
         "type": [
           "Organization"
         ],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "organizationName": "Generic Motors of America",
-          "streetAddress": "12 Generic Motors Dr",
-          "addressLocality": "Detroit",
-          "addressRegion": "Michigain",
-          "postalCode": "48232-5170",
-          "addressCountry": "USA"
-        }
+        "email": "Gustave.Dicki37@example.net",
+        "phoneNumber": "555-238-5681"
       },
       "itemsShipped": [
         {
           "type": "TradeLineItem",
           "product": {
             "manufacturer": {
-              "type": "Organization",
-              "address": {
-                "type": "PostalAddress",
-                "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-                "streetAddress": "1651, Shimonakano, Yoshida",
-                "addressLocality": "Tsubame-shi",
-                "addressRegion": "Niigata-ken",
-                "postalCode": "959-0215",
-                "addressCountry": "Japan"
-              }
+              "type": "Organization"
             },
             "description": "UNS S30400 chromium-nickel stainless steel rolls.",
             "weight": {
@@ -167,16 +126,7 @@ example: |-
           "type": "TradeLineItem",
           "product": {
             "manufacturer": {
-              "type": "Organization",
-              "address": {
-                "type": "PostalAddress",
-                "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-                "streetAddress": "1651, Shimonakano, Yoshida",
-                "addressLocality": "Tsubame-shi",
-                "addressRegion": "Niigata-ken",
-                "postalCode": "959-0215",
-                "addressCountry": "Japan"
-              }
+              "type": "Organization"
             },
             "description": "Galvalannealed ASTM A-653 zinc-iron alloy-coated steel sheets.",
             "weight": {
@@ -211,9 +161,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-15T12:04:22Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:51:30Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..qzIwzu-MTo8Tn1FTUoAkSsJkNB__vJUtQGgHAIx8vrka5HY5OWM5t8qI20FjwJcx8fOT9vfz4HHaX8vsUfEwBA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Du7C1F-CsprxsXEPF7bFIEDbTPEBtsJBm5rvAYBWRBh3_8laAoaz828qfHXJ8pyOZya8IUSdxfOkbZ4vctvRBA"
     }
   }

--- a/docs/openapi/components/schemas/common/DCSAShippingInstruction.yml
+++ b/docs/openapi/components/schemas/common/DCSAShippingInstruction.yml
@@ -189,13 +189,30 @@ example: |-
       "type": "Organization",
       "name": "Xxinau Manufacturing Co. Ltd.",
       "description": "Advanced Production - Delivered",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Xin Fei Da Dao 139",
-        "addressLocality": "Xindao",
-        "addressRegion": "Fujian Province",
-        "postalCode": "361100",
-        "addressCountry": "CN"
+      "place": {
+        "type": [
+          "Place"
+        ],
+        "globalLocationNumber": "5449782976823",
+        "geo": {
+          "type": [
+            "GeoCoordinates"
+          ],
+          "latitude": "-79.6395",
+          "longitude": "178.5353"
+        },
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Bednar - Kiehn",
+          "streetAddress": "853 Wisozk River",
+          "addressLocality": "New Noemyfort",
+          "addressRegion": "New Mexico",
+          "postalCode": "18047-2038",
+          "addressCountry": "Togo"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "xxinau-sales@example.org",
       "phoneNumber": "+86-555-865-8495"
@@ -204,13 +221,28 @@ example: |-
       "type": "Organization",
       "name": "Better Life Tech",
       "description": "Better Lives Products",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Rue de la Poste 272",
-        "addressLocality": "Ramegnies-Chin",
-        "addressRegion": "Hainaut",
-        "postalCode": "7520",
-        "addressCountry": "BE"
+      "place": {
+        "type":[
+          "Place"
+        ],
+        "geo":{
+          "type":[
+            "GeoCoordinates"
+          ],
+          "latitude":"43.2557",
+          "longitude":"-79.8711"
+        },
+        "address":{
+          "type":[
+            "PostalAddress"
+          ],
+          "postalCode":"",
+          "addressRegion":"Ontario",
+          "streetAddress":"",
+          "addressCountry":"CANADA",
+          "addressLocality":"Hamilton"
+        },
+        "globalLocationNumber":"SC720"
       },
       "email": "procurement@lifetech-example.org",
       "phoneNumber": "+32-5555-8495"
@@ -219,13 +251,30 @@ example: |-
       "type": "Organization",
       "name": "Better Life Tech",
       "description": "Better Lives Products",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Rue de la Poste 272",
-        "addressLocality": "Ramegnies-Chin",
-        "addressRegion": "Hainaut",
-        "postalCode": "7520",
-        "addressCountry": "BE"
+      "place": {
+        "type": [
+            "Place"
+        ],
+        "globalLocationNumber": "9339929638102",
+        "geo": {
+            "type": [
+            "GeoCoordinates"
+            ],
+            "latitude": "40.9090",
+            "longitude": "151.8748"
+        },
+        "address": {
+            "type": [
+            "PostalAddress"
+            ],
+            "organizationName": "Bogisich LLC",
+            "streetAddress": "50938 Donavon Junctions",
+            "addressLocality": "Rhodastad",
+            "addressRegion": "Louisiana",
+            "postalCode": "26521-2810",
+            "addressCountry": "American Samoa"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "procurement@lifetech-example.org",
       "phoneNumber": "+32-5555-8495"

--- a/docs/openapi/components/schemas/common/DCSAShippingInstructionCertificate.yml
+++ b/docs/openapi/components/schemas/common/DCSAShippingInstructionCertificate.yml
@@ -45,17 +45,9 @@ example: |-
     "issuanceDate": "2022-01-24T05:22:00Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "name": "Xxinau Manufacturing Co. Ltd.",
-      "description": "Advanced Production - Delivered",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Xin Fei Da Dao 139",
-        "addressLocality": "Xindao",
-        "addressRegion": "Fujian Province",
-        "postalCode": "361100",
-        "addressCountry": "CN"
-      }
+      "description": "Advanced Production - Delivered"
     },
     "credentialSubject": {
       "type": "DCSAShippingInstruction",
@@ -65,14 +57,6 @@ example: |-
         "type": "Organization",
         "name": "Xxinau Manufacturing Co. Ltd.",
         "description": "Advanced Production - Delivered",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Xin Fei Da Dao 139",
-          "addressLocality": "Xindao",
-          "addressRegion": "Fujian Province",
-          "postalCode": "361100",
-          "addressCountry": "CN"
-        },
         "email": "xxinau-sales@example.org",
         "phoneNumber": "+86-555-865-8495"
       },
@@ -80,14 +64,6 @@ example: |-
         "type": "Organization",
         "name": "Better Life Tech",
         "description": "Better Lives Products",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Rue de la Poste 272",
-          "addressLocality": "Ramegnies-Chin",
-          "addressRegion": "Hainaut",
-          "postalCode": "7520",
-          "addressCountry": "BE"
-        },
         "email": "procurement@lifetech-example.org",
         "phoneNumber": "+32-5555-8495"
       },
@@ -95,27 +71,12 @@ example: |-
         "type": "Organization",
         "name": "Better Life Tech",
         "description": "Better Lives Products",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Rue de la Poste 272",
-          "addressLocality": "Ramegnies-Chin",
-          "addressRegion": "Hainaut",
-          "postalCode": "7520",
-          "addressCountry": "BE"
-        },
         "email": "procurement@lifetech-example.org",
         "phoneNumber": "+32-5555-8495"
       },
       "consigneesFreightForwarder": {
         "type": "Organization",
         "name": "Intertrans NV [378]",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Belcrownlaan 25 - 3rd floor",
-          "addressLocality": "Antwerpen",
-          "postalCode": "BE-2100AN",
-          "addressCountry": "BE"
-        },
         "phoneNumber": "+32-3-201.98.10"
       },
       "cargoItems": [
@@ -170,9 +131,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-10T16:02:53Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T17:27:22Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..VH1zJjCViYZXcV4wV-0aCGdNqRRgDYtSGsA552s4S_u5417DAAVWpx1LBXUAzFtEoEJ54zk5c-QNIukoyQKXCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HkkPZmn7oxvvrLUpesLVleI1Zt85UwCWRY-dyuCXIWDHmJOZg1A10J7gW79dHeq7r4qLLDyOt8b93DxIOTSWAw"
     }
   }

--- a/docs/openapi/components/schemas/common/DCSATransportDocument.yml
+++ b/docs/openapi/components/schemas/common/DCSATransportDocument.yml
@@ -196,13 +196,30 @@ example: |-
         "type": "Organization",
         "name": "Xxinau Manufacturing Co. Ltd.",
         "description": "Advanced Production - Delivered",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Xin Fei Da Dao 139",
-          "addressLocality": "Xindao",
-          "addressRegion": "Fujian Province",
-          "postalCode": "361100",
-          "addressCountry": "CN"
+        "place": {
+          "type": [
+              "Place"
+          ],
+          "globalLocationNumber": "9339929638102",
+          "geo": {
+              "type": [
+              "GeoCoordinates"
+              ],
+              "latitude": "40.9090",
+              "longitude": "151.8748"
+          },
+          "address": {
+              "type": [
+              "PostalAddress"
+              ],
+              "organizationName": "Bogisich LLC",
+              "streetAddress": "50938 Donavon Junctions",
+              "addressLocality": "Rhodastad",
+              "addressRegion": "Louisiana",
+              "postalCode": "26521-2810",
+              "addressCountry": "American Samoa"
+          },
+          "unLocode": "DKCPH"
         },
         "email": "xxinau-sales@example.org",
         "phoneNumber": "+86-555-865-8495"
@@ -211,13 +228,28 @@ example: |-
         "type": "Organization",
         "name": "Better Life Tech",
         "description": "Better Lives Products",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Rue de la Poste 272",
-          "addressLocality": "Ramegnies-Chin",
-          "addressRegion": "Hainaut",
-          "postalCode": "7520",
-          "addressCountry": "BE"
+        "place": {
+          "type":[
+            "Place"
+          ],
+          "geo":{
+            "type":[
+              "GeoCoordinates"
+            ],
+            "latitude":"43.2557",
+            "longitude":"-79.8711"
+          },
+          "address":{
+            "type":[
+              "PostalAddress"
+            ],
+            "postalCode":"",
+            "addressRegion":"Ontario",
+            "streetAddress":"",
+            "addressCountry":"CANADA",
+            "addressLocality":"Hamilton"
+          },
+          "globalLocationNumber":"SC720"
         },
         "email": "procurement@lifetech-example.org",
         "phoneNumber": "+32-5555-8495"
@@ -226,13 +258,30 @@ example: |-
         "type": "Organization",
         "name": "Better Life Tech",
         "description": "Better Lives Products",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Rue de la Poste 272",
-          "addressLocality": "Ramegnies-Chin",
-          "addressRegion": "Hainaut",
-          "postalCode": "7520",
-          "addressCountry": "BE"
+        "place": {
+          "type": [
+            "Place"
+          ],
+          "globalLocationNumber": "5449782976823",
+          "geo": {
+            "type": [
+              "GeoCoordinates"
+            ],
+            "latitude": "-79.6395",
+            "longitude": "178.5353"
+          },
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "Bednar - Kiehn",
+            "streetAddress": "853 Wisozk River",
+            "addressLocality": "New Noemyfort",
+            "addressRegion": "New Mexico",
+            "postalCode": "18047-2038",
+            "addressCountry": "Togo"
+          },
+          "unLocode": "DKCPH"
         },
         "email": "procurement@lifetech-example.org",
         "phoneNumber": "+32-5555-8495"

--- a/docs/openapi/components/schemas/common/DCSATransportDocumentCertificate.yml
+++ b/docs/openapi/components/schemas/common/DCSATransportDocumentCertificate.yml
@@ -60,16 +60,8 @@ example: |-
     "issuanceDate": "2022-01-24T09:50:30Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "MULTI CONTAINER LINE",
-      "address": {
-        "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
-        "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-        "addressLocality": "Kowloon Bay",
-        "addressRegion": "Hong Kong",
-        "addressCountry": "Hong Kong SAR"
-      }
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+      "name": "MULTI CONTAINER LINE"
     },
     "credentialSubject": {
       "type": "DCSATransportDocument",
@@ -82,14 +74,6 @@ example: |-
           "type": "Organization",
           "name": "Xxinau Manufacturing Co. Ltd.",
           "description": "Advanced Production - Delivered",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "Xin Fei Da Dao 139",
-            "addressLocality": "Xindao",
-            "addressRegion": "Fujian Province",
-            "postalCode": "361100",
-            "addressCountry": "CN"
-          },
           "email": "xxinau-sales@example.org",
           "phoneNumber": "+86-555-865-8495"
         },
@@ -97,14 +81,6 @@ example: |-
           "type": "Organization",
           "name": "Better Life Tech",
           "description": "Better Lives Products",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "Rue de la Poste 272",
-            "addressLocality": "Ramegnies-Chin",
-            "addressRegion": "Hainaut",
-            "postalCode": "7520",
-            "addressCountry": "BE"
-          },
           "email": "procurement@lifetech-example.org",
           "phoneNumber": "+32-5555-8495"
         },
@@ -112,27 +88,12 @@ example: |-
           "type": "Organization",
           "name": "Better Life Tech",
           "description": "Better Lives Products",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "Rue de la Poste 272",
-            "addressLocality": "Ramegnies-Chin",
-            "addressRegion": "Hainaut",
-            "postalCode": "7520",
-            "addressCountry": "BE"
-          },
           "email": "procurement@lifetech-example.org",
           "phoneNumber": "+32-5555-8495"
         },
         "consigneesFreightForwarder": {
           "type": "Organization",
           "name": "Intertrans NV [378]",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "Belcrownlaan 25 - 3rd floor",
-            "addressLocality": "Antwerpen",
-            "postalCode": "BE-2100AN",
-            "addressCountry": "BE"
-          },
           "phoneNumber": "+32-3-201.98.10"
         },
         "cargoItems": [
@@ -206,15 +167,7 @@ example: |-
         "modeOfTransport": "Vessel",
         "carrier": {
           "type": "Organization",
-          "name": "MULTI CONTAINER LINE",
-          "address": {
-            "type": "PostalAddress",
-            "organizationName": "MCL Multi Container Line LTD.",
-            "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-            "addressLocality": "Kowloon Bay",
-            "addressRegion": "Hong Kong",
-            "addressCountry": "Hong Kong SAR"
-          }
+          "name": "MULTI CONTAINER LINE"
         },
         "vesselNumber": "HMM Algeciras",
         "voyageNumber": "V.0004W"
@@ -222,9 +175,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-10T16:03:29Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T17:56:07Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..jNU65NBRqquFNb-GixHe0W3RnKxncvHuI2ruVAAp00OoL7mLpNqs6jxybeHcB-RrAbxpvipD7OLTalQ7HEdlDg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..s_IAJeQDc1mtIoxejoJT-BblZYUgZ-mZkaSlDGCX2Rkdr2J67OiClnDu-Vh2ZuHhnlqn5PGQQG8KvB5Vr3WUBg"
     }
   }

--- a/docs/openapi/components/schemas/common/Entity.yml
+++ b/docs/openapi/components/schemas/common/Entity.yml
@@ -17,13 +17,30 @@ example: |-
       "type": "Organization",
       "name": "Hyatt - Spencer",
       "description": "Cross-platform 24/7 interface",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "705 Hyman Streets",
-        "addressLocality": "Evelinemouth",
-        "addressRegion": "Nevada",
-        "postalCode": "06775-7181",
-        "addressCountry": "Colombia"
+      "place": {
+        "type": [
+          "Place"
+        ],
+        "globalLocationNumber": "5449782976823",
+        "geo": {
+          "type": [
+            "GeoCoordinates"
+          ],
+          "latitude": "-79.6395",
+          "longitude": "178.5353"
+        },
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Bednar - Kiehn",
+          "streetAddress": "853 Wisozk River",
+          "addressLocality": "New Noemyfort",
+          "addressRegion": "New Mexico",
+          "postalCode": "18047-2038",
+          "addressCountry": "Togo"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "Bernhard81@example.org",
       "phoneNumber": "555-265-4610",

--- a/docs/openapi/components/schemas/common/EntrySummaryCertificate.yml
+++ b/docs/openapi/components/schemas/common/EntrySummaryCertificate.yml
@@ -50,15 +50,8 @@ example: |-
     ],
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "Future Mobility, Inc.",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "2016 W Farmington Rd",
-        "addressLocality": "West Peoria",
-        "postalCode": "61604",
-        "addressCountry": "US"
-      }
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+      "name": "Future Mobility, Inc."
     },
     "issuanceDate": "2022-03-03T15:20:00Z",
     "credentialSubject": {
@@ -98,25 +91,14 @@ example: |-
       "referenceNumber": "ref199812841",
       "ultimateConsignee": {
         "type": "Organization",
-        "name": "Future Mobility, Inc.",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "2016 W Farmington Rd",
-          "addressLocality": "West Peoria",
-          "postalCode": "61604",
-          "addressCountry": "US"
-        }
+        "name": "Better Life Tech",
+        "description": "Better Lives Products",
+        "email": "procurement@lifetech-example.org",
+        "phoneNumber": "+32-5555-8495"
       },
       "importerOfRecord": {
         "type": "Organization",
-        "name": "Future Mobility, Inc.",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "2016 W Farmington Rd",
-          "addressLocality": "West Peoria",
-          "postalCode": "61604",
-          "addressCountry": "US"
-        }
+        "name": "Future Mobility, Inc."
       },
       "descriptionOfMerchandise": [
         {
@@ -185,9 +167,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-03T14:21:32Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:04:23Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..cyUIAkW9wD2AEEAdBU162c6-qNO9OnPHkRALouRYQXkYDV0EVa6Oo0wkFN2ovDlMtPGKlT_di4dBIKvgUX56AA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..RUmT1Mwn7odi7DM0pf9QcUUQ-W9rYpmr8uL8IK4uvoSh0kmeQ-5x4pLLJZ0qGNfy7iyDSsbBL3NXEoJqw7dFDA"
     }
   }

--- a/docs/openapi/components/schemas/common/Event.yml
+++ b/docs/openapi/components/schemas/common/Event.yml
@@ -73,13 +73,30 @@ example: |-
         "type": "Organization",
         "name": "Gleason Inc",
         "description": "Assimilated client-driven hub",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "46718 Catalina Corner",
-          "addressLocality": "Port Dasiafort",
-          "addressRegion": "Florida",
-          "postalCode": "16352",
-          "addressCountry": "Palau"
+        "place": {
+          "type": [
+              "Place"
+          ],
+          "globalLocationNumber": "9339929638102",
+          "geo": {
+              "type": [
+              "GeoCoordinates"
+              ],
+              "latitude": "40.9090",
+              "longitude": "151.8748"
+          },
+          "address": {
+              "type": [
+              "PostalAddress"
+              ],
+              "organizationName": "Bogisich LLC",
+              "streetAddress": "50938 Donavon Junctions",
+              "addressLocality": "Rhodastad",
+              "addressRegion": "Louisiana",
+              "postalCode": "26521-2810",
+              "addressCountry": "American Samoa"
+          },
+          "unLocode": "DKCPH"
         },
         "email": "Sigurd.Langosh@example.com",
         "phoneNumber": "555-296-7144",
@@ -89,13 +106,30 @@ example: |-
         "type": "Organization",
         "name": "Hagenes LLC",
         "description": "Right-sized asynchronous task-force",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "16064 Winona Wall",
-          "addressLocality": "New Brendonberg",
-          "addressRegion": "Vermont",
-          "postalCode": "21278-9834",
-          "addressCountry": "Netherlands"
+        "place": {
+          "type": [
+            "Place"
+          ],
+          "globalLocationNumber": "5449782976823",
+          "geo": {
+            "type": [
+              "GeoCoordinates"
+            ],
+            "latitude": "-79.6395",
+            "longitude": "178.5353"
+          },
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "Bednar - Kiehn",
+            "streetAddress": "853 Wisozk River",
+            "addressLocality": "New Noemyfort",
+            "addressRegion": "New Mexico",
+            "postalCode": "18047-2038",
+            "addressCountry": "Togo"
+          },
+          "unLocode": "DKCPH"
         },
         "email": "Tristin95@example.com",
         "phoneNumber": "555-540-4871",

--- a/docs/openapi/components/schemas/common/FreightManifestCertificate.yml
+++ b/docs/openapi/components/schemas/common/FreightManifestCertificate.yml
@@ -44,30 +44,14 @@ example: |-
     "issuanceDate": "2022-01-25T11:10:00Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "MULTI CONTAINER LINE",
-      "address": {
-        "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
-        "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-        "addressLocality": "Kowloon Bay",
-        "addressRegion": "Hong Kong",
-        "addressCountry": "Hong Kong SAR"
-      }
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+      "name": "MULTI CONTAINER LINE"
     },
     "credentialSubject": {
       "type": "FreightManifest",
       "carrier": {
         "type": "Organization",
-        "name": "MULTI CONTAINER LINE",
-        "address": {
-          "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
-          "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-          "addressLocality": "Kowloon Bay",
-          "addressRegion": "Hong Kong",
-          "addressCountry": "Hong Kong SAR"
-        }
+        "name": "MULTI CONTAINER LINE"
       },
       "carrierCode": "MCML",
       "transportMeans": "HMM Algeciras",
@@ -82,14 +66,6 @@ example: |-
             "type": "Organization",
             "name": "Xxinau Manufacturing Co. Ltd.",
             "description": "Advanced Production - Delivered",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "Xin Fei Da Dao 139",
-              "addressLocality": "Xindao",
-              "addressRegion": "Fujian Province",
-              "postalCode": "361100",
-              "addressCountry": "CN"
-            },
             "email": "xxinau-sales@example.org",
             "phoneNumber": "+86-555-865-8495"
           },
@@ -97,14 +73,6 @@ example: |-
             "type": "Organization",
             "name": "Better Life Tech",
             "description": "Better Lives Products",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "Rue de la Poste 272",
-              "addressLocality": "Ramegnies-Chin",
-              "addressRegion": "Hainaut",
-              "postalCode": "7520",
-              "addressCountry": "BE"
-            },
             "email": "procurement@lifetech-example.org",
             "phoneNumber": "+32-5555-8495"
           },
@@ -112,14 +80,6 @@ example: |-
             "type": "Organization",
             "name": "Better Life Tech",
             "description": "Better Lives Products",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "Rue de la Poste 272",
-              "addressLocality": "Ramegnies-Chin",
-              "addressRegion": "Hainaut",
-              "postalCode": "7520",
-              "addressCountry": "BE"
-            },
             "email": "procurement@lifetech-example.org",
             "phoneNumber": "+32-5555-8495"
           },
@@ -153,26 +113,14 @@ example: |-
           "bookingNumber": "XMANHR6182210",
           "consignor": {
             "type": "Organization",
-            "name": "Chuang's Enterprises",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "Lido Gdns Sham Tseng",
-              "addressLocality": "Tsuen Wan District",
-              "addressRegion": "Hong Kong",
-              "addressCountry": "HK"
-            }
+            "name": "Chuang's Enterprises"
           },
           "consignee": {
             "type": "Organization",
             "name": "Intl. Construction Materials GMBH.",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "Alsembergsesteenweg 326",
-              "addressLocality": "Nieuwmunster",
-              "addressRegion": "West Flanders",
-              "postalCode": "8377",
-              "addressCountry": "BE"
-            }
+            "description": "Advanced Production - Delivered",
+            "email": "xxinau-sales@example.org",
+            "phoneNumber": "+86-555-865-8495"
           },
           "freight": {
             "type": [
@@ -202,9 +150,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-02-26T11:56:02Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:01:32Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..uWNWuhUoN3JMs8te7zXOVXxp_XeK1FDRvOWK-XY1pLnsRBRXJMo4r6t5Qlop3UZ3v5wzmADCUcwNtZFkxFXaBw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..3ZvulnE1wHJ0LVVqzTJskEKJKVAoYETQ0aX36QtD2aRdGMD9l8UgnEWDcQLCATft-MCAq4uAUH13140R_1UyBQ"
     }
   }

--- a/docs/openapi/components/schemas/common/HouseBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/HouseBillOfLading.yml
@@ -208,13 +208,28 @@ example: |-
     "shipper": {
       "type": "Organization",
       "name": "Espresso Italiano Co.",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Via Vico Ferrovia 5",
-        "addressLocality": "Goro",
-        "addressRegion": "Ferrara",
-        "postalCode": "44020",
-        "addressCountry": "IT"
+      "place": {
+        "type":[
+          "Place"
+        ],
+        "geo":{
+          "type":[
+            "GeoCoordinates"
+          ],
+          "latitude":"43.2557",
+          "longitude":"-79.8711"
+        },
+        "address":{
+          "type":[
+            "PostalAddress"
+          ],
+          "postalCode":"",
+          "addressRegion":"Ontario",
+          "streetAddress":"",
+          "addressCountry":"CANADA",
+          "addressLocality":"Hamilton"
+        },
+        "globalLocationNumber":"SC720"
       },
       "email": "sales@espresso-italiano.example.com",
       "phoneNumber": "+39 0351 9067195"
@@ -237,13 +252,28 @@ example: |-
         "type": "Organization",
         "name": "Prosumer Coffee Supplies, Ltd.",
         "description": "Coffee Machine Imports",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "3934 Spinnaker Lane",
-          "addressLocality": "Joliet",
-          "addressRegion": "Illinois",
-          "postalCode": "60432",
-          "addressCountry": "US"
+        "place": {
+          "type":[
+            "Place"
+          ],
+          "geo":{
+            "type":[
+              "GeoCoordinates"
+            ],
+            "latitude":"43.2557",
+            "longitude":"-79.8711"
+          },
+          "address":{
+            "type":[
+              "PostalAddress"
+            ],
+            "postalCode":"",
+            "addressRegion":"Ontario",
+            "streetAddress":"",
+            "addressCountry":"CANADA",
+            "addressLocality":"Hamilton"
+          },
+          "globalLocationNumber":"SC720"
         }
       }
     ],

--- a/docs/openapi/components/schemas/common/HouseBillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/common/HouseBillOfLadingCertificate.yml
@@ -53,16 +53,8 @@ example: |-
     "issuanceDate": "2022-03-04T13:40:00Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "World Forward, Inc.",
-      "address": {
-        "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
-        "streetAddress": "Well Fung Ind Centre",
-        "addressLocality": "Kwai Chung",
-        "addressRegion": "Hong Kong",
-        "addressCountry": "Hong Kong"
-      }
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+      "name": "World Forward, Inc."
     },
     "credentialSubject": {
       "type": "HouseBillOfLading",
@@ -73,57 +65,25 @@ example: |-
       "shipper": {
         "type": "Organization",
         "name": "Espresso Italiano Co.",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Via Vico Ferrovia 5",
-          "addressLocality": "Goro",
-          "addressRegion": "Ferrara",
-          "postalCode": "44020",
-          "addressCountry": "IT"
-        },
         "email": "sales@espresso-italiano.example.com",
         "phoneNumber": "+39 0351 9067195"
       },
       "consignee": {
         "type": "Organization",
         "name": "Prosumer Coffee Supplies, Ltd.",
-        "description": "Coffee Machine Imports",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "3934 Spinnaker Lane",
-          "addressLocality": "Joliet",
-          "addressRegion": "Illinois",
-          "postalCode": "60432",
-          "addressCountry": "US"
-        }
+        "description": "Coffee Machine Imports"
       },
       "notifyParty": [
         {
           "type": "Organization",
           "name": "Prosumer Coffee Supplies, Ltd.",
-          "description": "Coffee Machine Imports",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "3934 Spinnaker Lane",
-            "addressLocality": "Joliet",
-            "addressRegion": "Illinois",
-            "postalCode": "60432",
-            "addressCountry": "US"
-          }
+          "description": "Coffee Machine Imports"
         }
       ],
       "carrier": {
         "type": "Organization",
         "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-        "name": "World Forward, Inc.",
-        "address": {
-          "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
-          "streetAddress": "Well Fung Ind Centre",
-          "addressLocality": "Kwai Chung",
-          "addressRegion": "Hong Kong",
-          "addressCountry": "Hong Kong"
-        }
+        "name": "World Forward, Inc."
       },
       "mainCarriageTransportMovement": {
         "type": "Transport",
@@ -192,9 +152,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-11T13:44:09Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:36:35Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..gT0NIJkFI8XCWewO-mhBjtvM0n7vySAv1qi1MnTwrDIniDkavknKXBAfC8dh8YOc3AxlpTenytVihU7or0RwAQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..LbEdQPEoZmVmRncSoeXXJSmG8a2k4NXmHOWhOt71D_Dp8uOdIHVJBNz5YqtcM9mo0tb_6IH3n9QJJ2iiwJLYCQ"
     }
   }

--- a/docs/openapi/components/schemas/common/IATAAirWaybill.yml
+++ b/docs/openapi/components/schemas/common/IATAAirWaybill.yml
@@ -499,13 +499,28 @@ example: |-
         "type": "Organization",
         "name": "Xxinau Manufacturing Co. Ltd.",
         "description": "Advanced Production - Delivered",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Xin Fei Da Dao 139",
-          "addressLocality": "Xindao",
-          "addressRegion": "Fujian Province",
-          "postalCode": "361100",
-          "addressCountry": "CN"
+        "place": {
+          "type":[
+            "Place"
+          ],
+          "geo":{
+            "type":[
+              "GeoCoordinates"
+            ],
+            "latitude":"43.2557",
+            "longitude":"-79.8711"
+          },
+          "address":{
+            "type":[
+              "PostalAddress"
+            ],
+            "postalCode":"",
+            "addressRegion":"Ontario",
+            "streetAddress":"",
+            "addressCountry":"CANADA",
+            "addressLocality":"Hamilton"
+          },
+          "globalLocationNumber":"SC720"
         }
       },
       "shippersAccountNumber": "Trade",

--- a/docs/openapi/components/schemas/common/IATAAirWaybillCertificate.yml
+++ b/docs/openapi/components/schemas/common/IATAAirWaybillCertificate.yml
@@ -48,15 +48,8 @@ example: |-
     "issuanceDate": "2028-02-28T16:04:20Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "On Time Express Limited",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Suite 605, 6/F, Hai Tian Logistics Centre, #1 Hai Tian Road",
-        "addressLocality": "Hu-Li District",
-        "addressRegion": "Xiamen",
-        "addressCountry": "CN"
-      }
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+      "name": "On Time Express Limited"
     },
     "credentialSubject": {
       "type": "AirWaybillCertificate",
@@ -72,40 +65,18 @@ example: |-
         },
         "carrier": {
           "type": "Organization",
-          "name": "On Time Express Limited",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "Suite 605, 6/F, Hai Tian Logistics Centre, #1 Hai Tian Road",
-            "addressLocality": "Hu-Li District",
-            "addressRegion": "Xiamen",
-            "addressCountry": "CN"
-          }
+          "name": "On Time Express Limited"
         },
         "conditionsOfContract": "It is agreed that the goods described herein are accepted in apparent good order and condition (except as noted) for carriage SUBJECT TO THE CONDITIONS OF CONTRACT ON THE REVERSE HEREOF. ALL GOODS MAY BE CARRIED BY ANY OTHER MEANS INCLUDING ROAD OR ANY OTHER CARRIER UNLESS SPECIFIC CONTRARY INSTRUCTIONS ARE GIVEN HEREON BY THE SHIPPER, AND SHIPPER AGREES THAT THE SHIPMENT MAY BE CARRIED VIA INTERMEDIATE STOPPING PLACES WHICH THE CARRIER DEEMS APPROPRIATE. THE SHIPPER'S ATTENTION IS DRAWN TO THE NOTICE CONCERNING CARRIER'S LIMITATION OF LIABILITY. Shipper may increase such limitation of liability by declaring a higher value for carriage and paying a supplemental charge if required.",
         "shipper": {
           "type": "Organization",
           "name": "Xxinau Manufacturing Co. Ltd.",
-          "description": "Advanced Production - Delivered",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "Xin Fei Da Dao 139",
-            "addressLocality": "Xindao",
-            "addressRegion": "Fujian Province",
-            "postalCode": "361100",
-            "addressCountry": "CN"
-          }
+          "description": "Advanced Production - Delivered"
         },
         "shippersAccountNumber": "Trade",
         "consignee": {
           "type": "Organization",
-          "name": "By Acre",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "I.C.Modewegs Vej 1",
-            "addressLocality": "Kgs. Lyngby",
-            "postalCode": "2800",
-            "addressCountry": "DK"
-          }
+          "name": "By Acre"
         },
         "requestedRouting": [
           {
@@ -186,9 +157,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-07T10:34:10Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:29:39Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..JF_5ovAtWlpv_KOYAJ--XDJ_jbKej6mENPwq3HhoZS7DJSjvzA1e1FFkdnK4CjWlqIV4xcba2wuzTFjBGG4WCA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h4_4F3iGfbZh7oTUjvseZxf0d0VPMstHH8GHcXKtpb1NJLXED9Eh2ysgSAHUCPgNVMprYYNgMMsxXSO4WnZ-DQ"
     }
   }

--- a/docs/openapi/components/schemas/common/ImmediateDeliveryCertificate.yml
+++ b/docs/openapi/components/schemas/common/ImmediateDeliveryCertificate.yml
@@ -50,16 +50,9 @@ example: |-
     ],
     "issuanceDate": "2022-02-25T14:34:00Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": "Organization",
-      "name": "Onwards A/S",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Sludevej 63",
-        "addressLocality": "Kgs. Lyngby",
-        "postalCode": "2800",
-        "addressCountry": "DK"
-      }
+      "name": "Onwards A/S"
     },
     "credentialSubject": {
       "type": "ImmediateDelivery",
@@ -70,14 +63,7 @@ example: |-
       "bondType": "Single Transaction Bond",
       "importer": {
         "type": "Organization",
-        "name": "Onwards A/S",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Sludevej 63",
-          "addressLocality": "Kgs. Lyngby",
-          "postalCode": "2800",
-          "addressCountry": "DK"
-        }
+        "name": "Onwards A/S"
       },
       "assignedIdentifier": "12345678",
       "assignedIdentifierType": "CBP",
@@ -114,14 +100,7 @@ example: |-
           "itemParty": {
             "consignee": {
               "type": "Organization",
-              "name": "Future Mobility, Inc.",
-              "address": {
-                "type": "PostalAddress",
-                "streetAddress": "2016 W Farmington Rd",
-                "addressLocality": "West Peoria",
-                "postalCode": "61604",
-                "addressCountry": "US"
-              }
+              "name": "Future Mobility, Inc."
             },
             "assignedIdentifier": "12345678",
             "assignedIdentifierType": "CBP"
@@ -145,9 +124,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-10T20:29:23Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:28:03Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..l3FzYXLHB6DsC-wDTJj9mnRSohsWBrE-a9cp5eA1dQJKSVtvIP5b4R34hFeLmJtBaySt8VVV5Y3m_QR-FhgRCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..v-VYnUUr-AirH3wo4qr2h6ByHNVQXfJcUvg-KeleKCbpgWJTPJap4_fPw4Di2yCDvmQuU1ZnUPAY1umshOMPBw"
     }
   }

--- a/docs/openapi/components/schemas/common/ImporterSecurityFiling.yml
+++ b/docs/openapi/components/schemas/common/ImporterSecurityFiling.yml
@@ -177,13 +177,28 @@ example: |-
       {
         "type": "Organization",
         "name": "Xxinau Manufacturing Co. Ltd.",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Xin Fei Da Dao 139",
-          "addressLocality": "Xindao",
-          "addressRegion": "Fujian Province",
-          "postalCode": "361100",
-          "addressCountry": "CN"
+        "place": {
+          "type":[
+            "Place"
+          ],
+          "geo":{
+            "type":[
+              "GeoCoordinates"
+            ],
+            "latitude":"43.2557",
+            "longitude":"-79.8711"
+          },
+          "address":{
+            "type":[
+              "PostalAddress"
+            ],
+            "postalCode":"",
+            "addressRegion":"Ontario",
+            "streetAddress":"",
+            "addressCountry":"CANADA",
+            "addressLocality":"Hamilton"
+          },
+          "globalLocationNumber":"SC720"
         }
       }
     ]

--- a/docs/openapi/components/schemas/common/ImporterSecurityFilingCertificate.yml
+++ b/docs/openapi/components/schemas/common/ImporterSecurityFilingCertificate.yml
@@ -45,74 +45,31 @@ example: |-
     "name": "Importer Security Filing Certificate",
     "issuanceDate": "2022-02-24T12:10:00Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": "Organization",
-      "name": "Onwards A/S",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Sludevej 63",
-        "addressLocality": "Kgs. Lyngby",
-        "postalCode": "2800",
-        "addressCountry": "DK"
-      }
+      "name": "Onwards A/S"
     },
     "credentialSubject": {
       "type": "ImporterSecurityFiling",
       "seller": {
         "type": "Organization",
-        "name": "Onwards A/S",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Sludevej 63",
-          "addressLocality": "Kgs. Lyngby",
-          "postalCode": "2800",
-          "addressCountry": "DK"
-        }
+        "name": "Onwards A/S"
       },
       "buyer": {
         "type": "Organization",
-        "name": "Future Mobility, Inc.",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "2016 W Farmington Rd",
-          "addressLocality": "West Peoria",
-          "postalCode": "61604",
-          "addressCountry": "US"
-        }
+        "name": "Future Mobility, Inc."
       },
       "importer": {
         "type": "Organization",
-        "name": "Onwards A/S",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Sludevej 63",
-          "addressLocality": "Kgs. Lyngby",
-          "postalCode": "2800",
-          "addressCountry": "DK"
-        }
+        "name": "Onwards A/S"
       },
       "consignee": {
         "type": "Organization",
-        "name": "Future Mobility, Inc.",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "2016 W Farmington Rd",
-          "addressLocality": "West Peoria",
-          "postalCode": "61604",
-          "addressCountry": "US"
-        }
+        "name": "Future Mobility, Inc."
       },
       "shipToParty": {
         "type": "Organization",
-        "name": "Future Mobility - Georgia",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "3837 Martinez Blvd",
-          "addressLocality": "Augusta",
-          "addressRegion": "Georgia",
-          "postalCode": "30907",
-          "addressCountry": "US"
-        }
+        "name": "Future Mobility - Georgia"
       },
       "filingItems": [
         {
@@ -125,51 +82,27 @@ example: |-
           "countryOfOrigin": "CN",
           "manufacturer": {
             "type": "Organization",
-            "name": "Xxinau Manufacturing Co. Ltd.",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "Xin Fei Da Dao 139",
-              "addressLocality": "Xindao",
-              "addressRegion": "Fujian Province",
-              "postalCode": "361100",
-              "addressCountry": "CN"
-            }
+            "name": "Xxinau Manufacturing Co. Ltd."
           }
         }
       ],
       "containerStuffingLocation": [
         {
-          "type": "Place",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "Xin Fei Da Dao 139",
-            "addressLocality": "Xindao",
-            "addressRegion": "Fujian Province",
-            "postalCode": "361100",
-            "addressCountry": "CN"
-          }
+          "type": "Place"
         }
       ],
       "consolidator": [
         {
           "type": "Organization",
-          "name": "Xxinau Manufacturing Co. Ltd.",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "Xin Fei Da Dao 139",
-            "addressLocality": "Xindao",
-            "addressRegion": "Fujian Province",
-            "postalCode": "361100",
-            "addressCountry": "CN"
-          }
+          "name": "Xxinau Manufacturing Co. Ltd."
         }
       ]
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-07T09:58:07Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:25:53Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..3icbXUpiA6RiosqxNrIeJRqG7QahRa7gDd5N0onSwV0Rj3BsR2h-UByZcsj0yae0HBOgHo0-LQj_r_YYNO3zAQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..qnJkX-Q3NxjrHmxYSxeWphXb4l3O3tMI1Gu8vdufKR_oHkgMYSby2ebyB9vovOtqREWp0JK3HxYf2SzJIEyPDA"
     }
   }

--- a/docs/openapi/components/schemas/common/Inspector.yml
+++ b/docs/openapi/components/schemas/common/Inspector.yml
@@ -45,13 +45,28 @@ example: |-
         "type": "Organization",
         "name": "Johnson - Lebsack",
         "description": "Exclusive bottom-line firmware",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "76468 Kuphal Common",
-          "addressLocality": "East Stanley",
-          "addressRegion": "Oregon",
-          "postalCode": "16884-0184",
-          "addressCountry": "Germany"
+        "place": {
+          "type":[
+            "Place"
+          ],
+          "geo":{
+            "type":[
+              "GeoCoordinates"
+            ],
+            "latitude":"43.2557",
+            "longitude":"-79.8711"
+          },
+          "address":{
+            "type":[
+              "PostalAddress"
+            ],
+            "postalCode":"",
+            "addressRegion":"Ontario",
+            "streetAddress":"",
+            "addressCountry":"CANADA",
+            "addressLocality":"Hamilton"
+          },
+          "globalLocationNumber":"SC720"
         },
         "email": "Briana55@example.org",
         "phoneNumber": "555-467-2604",

--- a/docs/openapi/components/schemas/common/IntentToSell.yml
+++ b/docs/openapi/components/schemas/common/IntentToSell.yml
@@ -69,13 +69,30 @@ example: |-
       "type": "Organization",
       "name": "Berge and Sons",
       "description": "Persistent clear-thinking matrix",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "947 Lynch Glen",
-        "addressLocality": "Ellisstad",
-        "addressRegion": "California",
-        "postalCode": "09418",
-        "addressCountry": "China"
+      "place": {
+        "type": [
+            "Place"
+        ],
+        "globalLocationNumber": "9339929638102",
+        "geo": {
+            "type": [
+            "GeoCoordinates"
+            ],
+            "latitude": "40.9090",
+            "longitude": "151.8748"
+        },
+        "address": {
+            "type": [
+            "PostalAddress"
+            ],
+            "organizationName": "Bogisich LLC",
+            "streetAddress": "50938 Donavon Junctions",
+            "addressLocality": "Rhodastad",
+            "addressRegion": "Louisiana",
+            "postalCode": "26521-2810",
+            "addressCountry": "American Samoa"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "Anita_Graham54@example.org",
       "phoneNumber": "555-615-9236",
@@ -85,13 +102,30 @@ example: |-
       "type": "Organization",
       "name": "Lueilwitz - Kuvalis",
       "description": "Persistent dynamic definition",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "68232 Sarah Courts",
-        "addressLocality": "Nicolastown",
-        "addressRegion": "Florida",
-        "postalCode": "48217-0439",
-        "addressCountry": "Mongolia"
+      "place": {
+        "type": [
+          "Place"
+        ],
+        "globalLocationNumber": "5449782976823",
+        "geo": {
+          "type": [
+            "GeoCoordinates"
+          ],
+          "latitude": "-79.6395",
+          "longitude": "178.5353"
+        },
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Bednar - Kiehn",
+          "streetAddress": "853 Wisozk River",
+          "addressLocality": "New Noemyfort",
+          "addressRegion": "New Mexico",
+          "postalCode": "18047-2038",
+          "addressCountry": "Togo"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "Greg_Swift94@example.net",
       "phoneNumber": "555-149-2244",
@@ -103,13 +137,28 @@ example: |-
         "type": "Organization",
         "name": "Murazik Inc",
         "description": "Horizontal high-level internet solution",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "8331 Halvorson Keys",
-          "addressLocality": "Jamisonberg",
-          "addressRegion": "Iowa",
-          "postalCode": "99310",
-          "addressCountry": "Cameroon"
+        "place": {
+          "type":[
+            "Place"
+          ],
+          "geo":{
+            "type":[
+              "GeoCoordinates"
+            ],
+            "latitude":"43.2557",
+            "longitude":"-79.8711"
+          },
+          "address":{
+            "type":[
+              "PostalAddress"
+            ],
+            "postalCode":"",
+            "addressRegion":"Ontario",
+            "streetAddress":"",
+            "addressCountry":"CANADA",
+            "addressLocality":"Hamilton"
+          },
+          "globalLocationNumber":"SC720"
         },
         "email": "Pascale_Schmidt95@example.com",
         "phoneNumber": "555-574-1888",

--- a/docs/openapi/components/schemas/common/InvoiceRegistrationEvidenceDocument.yml
+++ b/docs/openapi/components/schemas/common/InvoiceRegistrationEvidenceDocument.yml
@@ -118,13 +118,28 @@ example: |-
     "customer": {
       "type": "Customer",
       "name": "Eva Oberbrunner",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "25849 Carolina Street",
-        "addressLocality": "Baileymouth",
-        "addressRegion": "Minnesota",
-        "postalCode": "23047",
-        "addressCountry": "Samoa"
+      "place": {
+        "type":[
+          "Place"
+        ],
+        "geo":{
+          "type":[
+            "GeoCoordinates"
+          ],
+          "latitude":"43.2557",
+          "longitude":"-79.8711"
+        },
+        "address":{
+          "type":[
+            "PostalAddress"
+          ],
+          "postalCode":"",
+          "addressRegion":"Ontario",
+          "streetAddress":"",
+          "addressCountry":"CANADA",
+          "addressLocality":"Hamilton"
+        },
+        "globalLocationNumber":"SC720"
       },
       "telephone": "555-284-1409",
       "email": "Daniella_Morar46@example.com"

--- a/docs/openapi/components/schemas/common/IssuerAgent.yml
+++ b/docs/openapi/components/schemas/common/IssuerAgent.yml
@@ -100,13 +100,28 @@ example: |-
       "type": "Organization",
       "name": "Lesch - Smith",
       "description": "Adaptive attitude-oriented customer loyalty",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "98546 Megane Locks",
-        "addressLocality": "Lake Lilliana",
-        "addressRegion": "Idaho",
-        "postalCode": "61383",
-        "addressCountry": "Saint Vincent and the Grenadines"
+      "place": {
+        "type":[
+          "Place"
+        ],
+        "geo":{
+          "type":[
+            "GeoCoordinates"
+          ],
+          "latitude":"43.2557",
+          "longitude":"-79.8711"
+        },
+        "address":{
+          "type":[
+            "PostalAddress"
+          ],
+          "postalCode":"",
+          "addressRegion":"Ontario",
+          "streetAddress":"",
+          "addressCountry":"CANADA",
+          "addressLocality":"Hamilton"
+        },
+        "globalLocationNumber":"SC720"
       },
       "email": "Cordia1@example.net",
       "phoneNumber": "555-721-4155",

--- a/docs/openapi/components/schemas/common/MasterBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MasterBillOfLading.yml
@@ -225,13 +225,30 @@ example: |-
     "shipper": {
       "type": "Organization",
       "name": "Espresso Italiano Co.",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Via Vico Ferrovia 5",
-        "addressLocality": "Goro",
-        "addressRegion": "Ferrara",
-        "postalCode": "44020",
-        "addressCountry": "IT"
+      "place": {
+        "type": [
+            "Place"
+        ],
+        "globalLocationNumber": "9339929638102",
+        "geo": {
+            "type": [
+            "GeoCoordinates"
+            ],
+            "latitude": "40.9090",
+            "longitude": "151.8748"
+        },
+        "address": {
+            "type": [
+            "PostalAddress"
+            ],
+            "organizationName": "Bogisich LLC",
+            "streetAddress": "50938 Donavon Junctions",
+            "addressLocality": "Rhodastad",
+            "addressRegion": "Louisiana",
+            "postalCode": "26521-2810",
+            "addressCountry": "American Samoa"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "sales@espresso-italiano.example.com",
       "phoneNumber": "+39 0351 9067195"
@@ -254,13 +271,28 @@ example: |-
         "type": "Organization",
         "name": "Prosumer Coffee Supplies, Ltd.",
         "description": "Coffee Machine Imports",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "3934 Spinnaker Lane",
-          "addressLocality": "Joliet",
-          "addressRegion": "Illinois",
-          "postalCode": "60432",
-          "addressCountry": "US"
+        "place": {
+          "type":[
+            "Place"
+          ],
+          "geo":{
+            "type":[
+              "GeoCoordinates"
+            ],
+            "latitude":"43.2557",
+            "longitude":"-79.8711"
+          },
+          "address":{
+            "type":[
+              "PostalAddress"
+            ],
+            "postalCode":"",
+            "addressRegion":"Ontario",
+            "streetAddress":"",
+            "addressCountry":"CANADA",
+            "addressLocality":"Hamilton"
+          },
+          "globalLocationNumber":"SC720"
         }
       }
     ],

--- a/docs/openapi/components/schemas/common/MasterBillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/common/MasterBillOfLadingCertificate.yml
@@ -48,16 +48,8 @@ example: |-
     "issuanceDate": "2022-03-04T13:40:00Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "MULTI CONTAINER LINE",
-      "address": {
-        "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
-        "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-        "addressLocality": "Kowloon Bay",
-        "addressRegion": "Hong Kong",
-        "addressCountry": "Hong Kong SAR"
-      }
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+      "name": "MULTI CONTAINER LINE"
     },
     "credentialSubject": {
       "type": "MasterBillOfLading",
@@ -68,57 +60,25 @@ example: |-
       "shipper": {
         "type": "Organization",
         "name": "Espresso Italiano Co.",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Via Vico Ferrovia 5",
-          "addressLocality": "Goro",
-          "addressRegion": "Ferrara",
-          "postalCode": "44020",
-          "addressCountry": "IT"
-        },
         "email": "sales@espresso-italiano.example.com",
         "phoneNumber": "+39 0351 9067195"
       },
       "consignee": {
         "type": "Organization",
         "name": "Prosumer Coffee Supplies, Ltd.",
-        "description": "Coffee Machine Imports",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "3934 Spinnaker Lane",
-          "addressLocality": "Joliet",
-          "addressRegion": "Illinois",
-          "postalCode": "60432",
-          "addressCountry": "US"
-        }
+        "description": "Coffee Machine Imports"
       },
       "notifyParty": [
         {
           "type": "Organization",
           "name": "Prosumer Coffee Supplies, Ltd.",
-          "description": "Coffee Machine Imports",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "3934 Spinnaker Lane",
-            "addressLocality": "Joliet",
-            "addressRegion": "Illinois",
-            "postalCode": "60432",
-            "addressCountry": "US"
-          }
+          "description": "Coffee Machine Imports"
         }
       ],
       "carrier": {
         "type": "Organization",
         "id": "did:key:z6Mku6sNEit2qhNyaKDoj6ozURx5ApD85Za5g6dmnpYi6Auv",
-        "name": "MULTI CONTAINER LINE",
-        "address": {
-          "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
-          "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-          "addressLocality": "Kowloon Bay",
-          "addressRegion": "Hong Kong",
-          "addressCountry": "Hong Kong SAR"
-        }
+        "name": "MULTI CONTAINER LINE"
       },
       "mainCarriageTransportMovement": {
         "type": "Transport",
@@ -212,9 +172,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-11T12:50:50Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:06:20Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..8XFp1gjL0zYjKeItwkMoUn4OJD7yv2cnZ2CYKqbQVx7UkKYfzu33ZUVrey1azgIeUiI_97T1Uquqii49EZ2dCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YsmtAoQiBfVMsSHTtOGjYUS7j6w3aD3oXTHU4hNyEG35n8A3JbpAz264BDLSXRuOWtu3fNGndVpAqMODhBVOAQ"
     }
   }

--- a/docs/openapi/components/schemas/common/MillTestReportCertificate.yml
+++ b/docs/openapi/components/schemas/common/MillTestReportCertificate.yml
@@ -61,18 +61,10 @@ example: |-
     ],
     "issuanceDate": "2019-12-11T03:50:55Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": "Organization",
       "name": "Bartell Inc",
       "description": "Realigned maximized alliance",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "713 Funk Parkway",
-        "addressLocality": "Dannyside",
-        "addressRegion": "Alabama",
-        "postalCode": "17321",
-        "addressCountry": "Peru"
-      },
       "email": "Dion_Stoltenberg@example.org",
       "phoneNumber": "555-987-1014",
       "faxNumber": "555-377-8843"
@@ -87,16 +79,6 @@ example: |-
         ],
         "name": "Pacocha Group",
         "description": "Cross-group motivating open system",
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "streetAddress": "3076 Bernier Radial",
-          "addressLocality": "Lake Cora",
-          "addressRegion": "Arizona",
-          "postalCode": "54215-6259",
-          "addressCountry": "Sweden"
-        },
         "email": "Ila_VonRueden14@example.net",
         "phoneNumber": "555-378-2057",
         "faxNumber": "555-317-8070"
@@ -323,9 +305,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2019-12-11T03:50:55Z",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..eYAe3tnAYLhfE7tbW6nVUeQclF63oi2Y8JK1Y9U5VTXx4l0Zo1qcsefsZvuwj3AhNZ1OisIwyTD-BccnOiXcBA",
+      "created": "2022-04-14T18:11:00Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..gfBf7txlIminGr3JzTfNqQN4JQIWLnWASmSHAi_rZCtA3k1_Hs3Osq6WF_lSgMzdvCVKq7ITnOjbkXIkG63XAA"
     }
   }

--- a/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
@@ -225,13 +225,28 @@ example: |-
     "shipper": {
       "type": "Organization",
       "name": "Espresso Italiano Co.",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Via Vico Ferrovia 5",
-        "addressLocality": "Goro",
-        "addressRegion": "Ferrara",
-        "postalCode": "44020",
-        "addressCountry": "IT"
+      "place": {
+        "type":[
+          "Place"
+        ],
+        "geo":{
+          "type":[
+            "GeoCoordinates"
+          ],
+          "latitude":"43.2557",
+          "longitude":"-79.8711"
+        },
+        "address":{
+          "type":[
+            "PostalAddress"
+          ],
+          "postalCode":"",
+          "addressRegion":"Ontario",
+          "streetAddress":"",
+          "addressCountry":"CANADA",
+          "addressLocality":"Hamilton"
+        },
+        "globalLocationNumber":"SC720"
       },
       "email": "sales@espresso-italiano.example.com",
       "phoneNumber": "+39 0351 9067195"
@@ -254,13 +269,30 @@ example: |-
         "type": "Organization",
         "name": "Prosumer Coffee Supplies, Ltd.",
         "description": "Coffee Machine Imports",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "3934 Spinnaker Lane",
-          "addressLocality": "Joliet",
-          "addressRegion": "Illinois",
-          "postalCode": "60432",
-          "addressCountry": "US"
+        "place": {
+          "type": [
+            "Place"
+          ],
+          "globalLocationNumber": "5449782976823",
+          "geo": {
+            "type": [
+              "GeoCoordinates"
+            ],
+            "latitude": "-79.6395",
+            "longitude": "178.5353"
+          },
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "Bednar - Kiehn",
+            "streetAddress": "853 Wisozk River",
+            "addressLocality": "New Noemyfort",
+            "addressRegion": "New Mexico",
+            "postalCode": "18047-2038",
+            "addressCountry": "Togo"
+          },
+          "unLocode": "DKCPH"
         }
       }
     ],

--- a/docs/openapi/components/schemas/common/MultiModalBillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/common/MultiModalBillOfLadingCertificate.yml
@@ -48,16 +48,8 @@ example: |-
     "issuanceDate": "2022-03-04T13:40:00Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "MULTI CONTAINER LINE",
-      "address": {
-        "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
-        "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-        "addressLocality": "Kowloon Bay",
-        "addressRegion": "Hong Kong",
-        "addressCountry": "Hong Kong SAR"
-      }
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+      "name": "MULTI CONTAINER LINE"
     },
     "credentialSubject": {
       "type": "MultiModalBillOfLading",
@@ -68,57 +60,25 @@ example: |-
       "shipper": {
         "type": "Organization",
         "name": "Espresso Italiano Co.",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Via Vico Ferrovia 5",
-          "addressLocality": "Goro",
-          "addressRegion": "Ferrara",
-          "postalCode": "44020",
-          "addressCountry": "IT"
-        },
         "email": "sales@espresso-italiano.example.com",
         "phoneNumber": "+39 0351 9067195"
       },
       "consignee": {
         "type": "Organization",
         "name": "Prosumer Coffee Supplies, Ltd.",
-        "description": "Coffee Machine Imports",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "3934 Spinnaker Lane",
-          "addressLocality": "Joliet",
-          "addressRegion": "Illinois",
-          "postalCode": "60432",
-          "addressCountry": "US"
-        }
+        "description": "Coffee Machine Imports"
       },
       "notifyParty": [
         {
           "type": "Organization",
           "name": "Prosumer Coffee Supplies, Ltd.",
-          "description": "Coffee Machine Imports",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "3934 Spinnaker Lane",
-            "addressLocality": "Joliet",
-            "addressRegion": "Illinois",
-            "postalCode": "60432",
-            "addressCountry": "US"
-          }
+          "description": "Coffee Machine Imports"
         }
       ],
       "carrier": {
         "type": "Organization",
         "id": "did:key:z6Mku6sNEit2qhNyaKDoj6ozURx5ApD85Za5g6dmnpYi6Auv",
-        "name": "MULTI CONTAINER LINE",
-        "address": {
-          "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
-          "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-          "addressLocality": "Kowloon Bay",
-          "addressRegion": "Hong Kong",
-          "addressCountry": "Hong Kong SAR"
-        }
+        "name": "MULTI CONTAINER LINE"
       },
       "mainCarriageTransportMovement": {
         "type": "Transport",
@@ -212,9 +172,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-11T13:58:12Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:24:52Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..MsBnzfwLcYL1BzTSvzgP9mfj5EwzM4Twh3DtEVHQVSK84TL-MEcMnEwRb7LrW20LkW9K273tiq268ZBc48mGBA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2Mu0RAvfgcnKkQwZOd6OPJPm_fmJYa7nakkjo-8bG_66f1rauWKhDc59fy1Y40mXcsgoopQotAs_g3x_K3vwDA"
     }
   }

--- a/docs/openapi/components/schemas/common/NaturalGasProduct.yml
+++ b/docs/openapi/components/schemas/common/NaturalGasProduct.yml
@@ -82,7 +82,7 @@ example: |-
       "VerifiableCredential"
     ],
     "issuanceDate": "2021-02-04T20:29:37+00:00",
-    "issuer": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+    "issuer": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
     "credentialSubject": {
       "type": "NaturalGasProduct",
       "HSCode": "270900",
@@ -135,14 +135,6 @@ example: |-
             "type": "Organization",
             "name": "Rowe Inc",
             "description": "Multi-tiered bandwidth-monitored system engine",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "2943 Cartwright Lock",
-              "addressLocality": "West Lanceburgh",
-              "addressRegion": "New Jersey",
-              "postalCode": "42420",
-              "addressCountry": "Russian Federation"
-            },
             "email": "Melisa.Monahan19@example.org",
             "phoneNumber": "555-564-1276",
             "faxNumber": "555-554-6557"
@@ -170,9 +162,9 @@ example: |-
     ],
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2019-12-11T03:50:55Z",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fW9K15vGPwhncFsd10qO5QjdmR_zJIRtKEj93BaK1NBYRzjBD9gQ8BBV4ReQs1-zvg-UPy3UPJd1zPvT9GHkAA",
+      "created": "2022-04-14T19:00:32Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..LSolEaA5EgkJaBszqIIEOsuq4Hu54bUt1ogkMC_S5PKzERi87Wo2imBP5aTwFrU5zbLIijwedOyLJwwW_3LEBw"
     }
   }

--- a/docs/openapi/components/schemas/common/Organization.yml
+++ b/docs/openapi/components/schemas/common/Organization.yml
@@ -50,20 +50,6 @@ properties:
     $linkedData:
       term: description
       '@id': https://schema.org/description
-  globalLocationNumber:
-    title: Global Location Number
-    description: The GS1 GLN of the organization.
-    type: string
-    $linkedData:
-      term: globalLocationNumber
-      '@id': https://schema.org/globalLocationNumber
-  address:
-    title: Postal Address
-    description: The postal address for an organization or place.
-    $ref: ./PostalAddress.yml
-    $linkedData:
-      term: address
-      '@id': https://schema.org/PostalAddress
   email:
     title: Email Address
     description: Organization's primary email address.
@@ -115,6 +101,41 @@ properties:
     $linkedData:
       term: iataCarrierCode
       '@id': https://onerecord.iata.org/cargo/Company#airlineCode
+  organizationType:
+    title: Organization Type
+    description: Type of organization (e.g. cold storage, meat processing).
+    type: string
+    $linkedData:
+      term: organizationType
+      '@id': https://w3id.org/traceability#organizationType
+  place:
+    title: Place
+    description: Information on organization place.
+    $ref: ./Place.yml
+    $linkedData:
+      term: place
+      '@id': https://schema.org/Place
+  gap:
+    title: GAP Certifications
+    description: List of GAP certifications and links.
+    type: string
+    $linkedData:
+      term: gap
+      '@id': https://w3id.org/traceability#gap
+  generalCerts:
+    title: General Certifications
+    description: List of general certificates (such as export certificates, etc.) possessed by the organization.
+    type: string
+    $linkedData:
+      term: generalCerts
+      '@id': https://w3id.org/traceability#generalCerts
+  trustedBy:
+    title: Trusted By
+    description: List of VCs issued showing that the organization is a known and trusted entity.
+    type: string
+    $linkedData:
+      term: trustedBy
+      '@id': https://w3id.org/traceability#trustedBy
 additionalProperties: false
 example: |-
   {
@@ -122,13 +143,30 @@ example: |-
     "name": "Glover - Gleason",
     "legalName": "Glover and Gleason, Llc.",
     "description": "Customs Brokering since 2012",
-    "address": {
-      "type": "PostalAddress",
-      "streetAddress": "210 Jermey Fort",
-      "addressLocality": "Lake Evalyn",
-      "addressRegion": "Montana",
-      "postalCode": "71172",
-      "addressCountry": "US"
+    "place": {
+      "type": [
+        "Place"
+      ],
+      "globalLocationNumber": "5449782976823",
+      "geo": {
+        "type": [
+          "GeoCoordinates"
+        ],
+        "latitude": "-79.6395",
+        "longitude": "178.5353"
+      },
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "Bednar - Kiehn",
+        "streetAddress": "853 Wisozk River",
+        "addressLocality": "New Noemyfort",
+        "addressRegion": "New Mexico",
+        "postalCode": "18047-2038",
+        "addressCountry": "Togo"
+      },
+      "unLocode": "DKCPH"
     },
     "email": "contact@glover-gleason.example.net",
     "phoneNumber": "555-758-8926",

--- a/docs/openapi/components/schemas/common/PGAStatusMessageCertificate.yml
+++ b/docs/openapi/components/schemas/common/PGAStatusMessageCertificate.yml
@@ -56,18 +56,10 @@ example: |-
     "relatedLink": [],
     "issuanceDate": "2019-12-11T03:50:55Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": "Organization",
       "name": "Food Border Force Agency",
       "description": "Food Related PGA",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "027 Brakus Knoll",
-        "addressLocality": "East Johnniemouth",
-        "addressRegion": "Arizona",
-        "postalCode": "25780-5840",
-        "addressCountry": "Grenada"
-      },
       "email": "Kendrick.Spinka57@fbf.example.gov",
       "phoneNumber": "555-322-9464",
       "faxNumber": "555-766-1744"
@@ -98,9 +90,9 @@ example: |-
     ],
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-14T14:06:41Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:23:59Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..OiJawjqsly83sWxcb_0WsUKmmGHi0pyyhCpE06NGZCmL4XQcStbjj1SmiCim9I2GAjN_NNR20twYOxDJ2ry0CQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..g6aGSc0TrfXI8qr0HuTLD6J0xGnYq3tz5F0xnYVGSHA0J4Tv9N7tmCJyTvOtjfX2gXH2BiZnAsqwTnsT7UDSBQ"
     }
   }

--- a/docs/openapi/components/schemas/common/PackingListCertificate.yml
+++ b/docs/openapi/components/schemas/common/PackingListCertificate.yml
@@ -50,17 +50,9 @@ example: |-
     "issuanceDate": "2019-12-11T03:50:55Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "name": "Xxinau Manufacturing Co. Ltd.",
-      "description": "Advanced Production - Delivered",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Xin Fei Da Dao 139",
-        "addressLocality": "Xindao",
-        "addressRegion": "Fujian Province",
-        "postalCode": "361100",
-        "addressCountry": "CN"
-      }
+      "description": "Advanced Production - Delivered"
     },
     "credentialSubject": {
       "@context": "https://w3id.org/traceability/v1",
@@ -69,50 +61,20 @@ example: |-
       "seller": {
         "type": "Organization",
         "name": "Xxinau Manufacturing Co. Ltd.",
-        "description": "Advanced Production - Delivered",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Xin Fei Da Dao 139",
-          "addressLocality": "Xindao",
-          "addressRegion": "Fujian Province",
-          "postalCode": "361100",
-          "addressCountry": "CN"
-        }
+        "description": "Advanced Production - Delivered"
       },
       "buyer": {
         "type": "Organization",
-        "name": "By ACRE",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "IC. Modewegs Vej 1",
-          "addressLocality": "Kgs. Lyngby",
-          "postalCode": "2800",
-          "addressCountry": "DK"
-        }
+        "name": "By ACRE"
       },
       "shipFromParty": {
         "type": "Organization",
         "name": "Xxinau Manufacturing Co. Ltd.",
-        "description": "Advanced Production - Delivered",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Xin Fei Da Dao 139",
-          "addressLocality": "Xindao",
-          "addressRegion": "Fujian Province",
-          "postalCode": "361100",
-          "addressCountry": "CN"
-        }
+        "description": "Advanced Production - Delivered"
       },
       "shipToParty": {
         "type": "Organization",
-        "name": "By ACRE",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "IC. Modewegs Vej 1",
-          "addressLocality": "Kgs. Lyngby",
-          "postalCode": "2800",
-          "addressCountry": "DK"
-        }
+        "name": "By ACRE"
       },
       "handlingInstructions": [
         {
@@ -236,9 +198,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-10T15:54:26Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:23:19Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..hML_zdfiGteNXdV83HzylkHrhOLL18wVEPSUhLIyG7QKsu3n_EDr84GXF5IcuGa3KVNRoIpljdfTAdtAbWHCAg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.._jS0Dj6TxNIiFZ5tykA9q0cSB_yZWIeBA1ATudo-c6mJ7uthli14v31uqHOX1n0x86khH5TX8IyLgOn5biP-AA"
     }
   }

--- a/docs/openapi/components/schemas/common/Person.yml
+++ b/docs/openapi/components/schemas/common/Person.yml
@@ -78,13 +78,30 @@ example: |-
       "type": "Organization",
       "name": "Toy - Spinka",
       "description": "Networked human-resource secured line",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "69628 Gorczany Port",
-        "addressLocality": "Joechester",
-        "addressRegion": "South Carolina",
-        "postalCode": "88805-6256",
-        "addressCountry": "Heard Island and McDonald Islands"
+      "place": {
+        "type": [
+            "Place"
+        ],
+        "globalLocationNumber": "9339929638102",
+        "geo": {
+            "type": [
+            "GeoCoordinates"
+            ],
+            "latitude": "40.9090",
+            "longitude": "151.8748"
+        },
+        "address": {
+            "type": [
+            "PostalAddress"
+            ],
+            "organizationName": "Bogisich LLC",
+            "streetAddress": "50938 Donavon Junctions",
+            "addressLocality": "Rhodastad",
+            "addressRegion": "Louisiana",
+            "postalCode": "26521-2810",
+            "addressCountry": "American Samoa"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "Greyson15@example.org",
       "phoneNumber": "555-738-4062",

--- a/docs/openapi/components/schemas/common/Phytosanitary.yml
+++ b/docs/openapi/components/schemas/common/Phytosanitary.yml
@@ -234,15 +234,30 @@ example: |-
           ],
           "name": "Koepp - Grant",
           "description": "Inverse disintermediate database",
-          "address": {
+          "place": {
             "type": [
-              "PostalAddress"
+              "Place"
             ],
-            "streetAddress": "3451 Annette Village",
-            "addressLocality": "Joelport",
-            "addressRegion": "Kentucky",
-            "postalCode": "57003",
-            "addressCountry": "Turkmenistan"
+            "globalLocationNumber": "5449782976823",
+            "geo": {
+              "type": [
+                "GeoCoordinates"
+              ],
+              "latitude": "-79.6395",
+              "longitude": "178.5353"
+            },
+            "address": {
+              "type": [
+                "PostalAddress"
+              ],
+              "organizationName": "Bednar - Kiehn",
+              "streetAddress": "853 Wisozk River",
+              "addressLocality": "New Noemyfort",
+              "addressRegion": "New Mexico",
+              "postalCode": "18047-2038",
+              "addressCountry": "Togo"
+            },
+            "unLocode": "DKCPH"
           },
           "email": "Adeline96@example.com",
           "phoneNumber": "555-837-1185",
@@ -347,21 +362,34 @@ example: |-
         "type": [
           "Organization"
         ],
-        "name": "Satterfield - Runte",
-        "description": "Organized context-sensitive website",
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "streetAddress": "6704 Stark Burgs",
-          "addressLocality": "Markfort",
-          "addressRegion": "Indiana",
-          "postalCode": "63763-6099",
-          "addressCountry": "Sudan"
-        },
-        "email": "Dell99@example.org",
-        "phoneNumber": "555-410-6827",
-        "faxNumber": "555-195-4073"
+        "name": "Leannon and Sons",
+        "description": "Fundamental multi-tasking service-desk",
+          "place": {
+            "type":[
+              "Place"
+            ],
+            "geo":{
+              "type":[
+                "GeoCoordinates"
+              ],
+              "latitude":"43.2557",
+              "longitude":"-79.8711"
+            },
+            "address":{
+              "type":[
+                "PostalAddress"
+              ],
+              "postalCode":"",
+              "addressRegion":"Ontario",
+              "streetAddress":"",
+              "addressCountry":"CANADA",
+              "addressLocality":"Hamilton"
+            },
+            "globalLocationNumber":"SC720"
+          },
+        "email": "Hipolito58@example.org",
+        "phoneNumber": "555-895-1661",
+        "faxNumber": "555-497-2527"
       },
       "AgPackage": [
         {
@@ -446,13 +474,28 @@ example: |-
       "type": "Organization",
       "name": "Morar - Nienow",
       "description": "Operative contextually-based archive",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "09107 Klein Place",
-        "addressLocality": "Port Diannaland",
-        "addressRegion": "West Virginia",
-        "postalCode": "30943",
-        "addressCountry": "Faroe Islands"
+      "place": {
+        "type":[
+          "Place"
+        ],
+        "geo":{
+          "type":[
+            "GeoCoordinates"
+          ],
+          "latitude":"43.2557",
+          "longitude":"-79.8711"
+        },
+        "address":{
+          "type":[
+            "PostalAddress"
+          ],
+          "postalCode":"",
+          "addressRegion":"Ontario",
+          "streetAddress":"",
+          "addressCountry":"CANADA",
+          "addressLocality":"Hamilton"
+        },
+        "globalLocationNumber":"SC720"
       },
       "email": "Irwin_OConnell83@example.com",
       "phoneNumber": "555-588-8829",

--- a/docs/openapi/components/schemas/common/Phytosanitary.yml
+++ b/docs/openapi/components/schemas/common/Phytosanitary.yml
@@ -364,29 +364,6 @@ example: |-
         ],
         "name": "Leannon and Sons",
         "description": "Fundamental multi-tasking service-desk",
-          "place": {
-            "type":[
-              "Place"
-            ],
-            "geo":{
-              "type":[
-                "GeoCoordinates"
-              ],
-              "latitude":"43.2557",
-              "longitude":"-79.8711"
-            },
-            "address":{
-              "type":[
-                "PostalAddress"
-              ],
-              "postalCode":"",
-              "addressRegion":"Ontario",
-              "streetAddress":"",
-              "addressCountry":"CANADA",
-              "addressLocality":"Hamilton"
-            },
-            "globalLocationNumber":"SC720"
-          },
         "email": "Hipolito58@example.org",
         "phoneNumber": "555-895-1661",
         "faxNumber": "555-497-2527"

--- a/docs/openapi/components/schemas/common/Product.yml
+++ b/docs/openapi/components/schemas/common/Product.yml
@@ -133,13 +133,28 @@ example: |-
         "type": "Organization",
         "name": "Zemlak - Wyman",
         "description": "Progressive fault-tolerant task-force",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "964 Mikayla Viaduct",
-          "addressLocality": "Runolfsdottirburgh",
-          "addressRegion": "Florida",
-          "postalCode": "48442-9522",
-          "addressCountry": "Barbados"
+        "place": {
+          "type":[
+            "Place"
+          ],
+          "geo":{
+            "type":[
+              "GeoCoordinates"
+            ],
+            "latitude":"43.2557",
+            "longitude":"-79.8711"
+          },
+          "address":{
+            "type":[
+              "PostalAddress"
+            ],
+            "postalCode":"",
+            "addressRegion":"Ontario",
+            "streetAddress":"",
+            "addressCountry":"CANADA",
+            "addressLocality":"Hamilton"
+          },
+          "globalLocationNumber":"SC720"
         },
         "email": "Reyna_Hamill56@example.com",
         "phoneNumber": "555-718-9023",

--- a/docs/openapi/components/schemas/common/ProformaInvoiceCertificate.yml
+++ b/docs/openapi/components/schemas/common/ProformaInvoiceCertificate.yml
@@ -49,26 +49,19 @@ example: |-
     "id": "did:key:z6MkhNsCYEQQWJdyAbfaMZHz4UG6UZoQUGot7z7tBNsbz1JG",
     "type": [
       "VerifiableCredential",
-      "CommercialInvoiceCertificate"
+      "ProformaInvoiceCertificate"
     ],
-    "name": "Commercial Invoice Certificate",
+    "name": "Proforma Invoice Certificate",
     "issuanceDate": "2022-02-23T11:55:00Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": [
         "Organization"
       ],
-      "address": {
-        "type": [
-          "PostalAddress"
-        ],
-        "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-        "streetAddress": "1651, Shimonakano, Yoshida",
-        "addressLocality": "Tsubame-shi",
-        "addressRegion": "Niigata-ken",
-        "postalCode": "959-0215",
-        "addressCountry": "Japan"
-      }
+      "name": "Better Life Tech",
+      "description": "Better Lives Products",
+      "email": "procurement@lifetech-example.org",
+      "phoneNumber": "+32-5555-8495"
     },
     "credentialSubject": {
       "type": [
@@ -84,65 +77,31 @@ example: |-
         "type": [
           "Organization"
         ],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-          "streetAddress": "1651, Shimonakano, Yoshida",
-          "addressLocality": "Tsubame-shi",
-          "addressRegion": "Niigata-ken",
-          "postalCode": "959-0215",
-          "addressCountry": "Japan"
-        }
+        "email": "Gustave.Dicki37@example.net",
+        "phoneNumber": "555-238-5681"
       },
       "buyer": {
         "type": [
           "Organization"
         ],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "organizationName": "Generic Motors of America",
-          "streetAddress": "12 Generic Motors Dr",
-          "addressLocality": "Detroit",
-          "addressRegion": "Michigain",
-          "postalCode": "48232-5170",
-          "addressCountry": "USA"
-        }
+        "name": "Better Life Tech",
+        "description": "Better Lives Products",
+        "email": "procurement@lifetech-example.org",
+        "phoneNumber": "+32-5555-8495"
       },
       "shipToParty": {
         "type": [
           "Organization"
         ],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "organizationName": "Generic Motors of America",
-          "streetAddress": "12 Generic Motors Dr",
-          "addressLocality": "Detroit",
-          "addressRegion": "Michigain",
-          "postalCode": "48232-5170",
-          "addressCountry": "USA"
-        }
+        "email": "Gustave.Dicki37@example.net",
+        "phoneNumber": "555-238-5681"
       },
       "itemsShipped": [
         {
           "type": "TradeLineItem",
           "product": {
             "manufacturer": {
-              "type": "Organization",
-              "address": {
-                "type": "PostalAddress",
-                "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-                "streetAddress": "1651, Shimonakano, Yoshida",
-                "addressLocality": "Tsubame-shi",
-                "addressRegion": "Niigata-ken",
-                "postalCode": "959-0215",
-                "addressCountry": "Japan"
-              }
+              "type": "Organization"
             },
             "description": "UNS S30400 chromium-nickel stainless steel rolls.",
             "weight": {
@@ -167,16 +126,7 @@ example: |-
           "type": "TradeLineItem",
           "product": {
             "manufacturer": {
-              "type": "Organization",
-              "address": {
-                "type": "PostalAddress",
-                "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-                "streetAddress": "1651, Shimonakano, Yoshida",
-                "addressLocality": "Tsubame-shi",
-                "addressRegion": "Niigata-ken",
-                "postalCode": "959-0215",
-                "addressCountry": "Japan"
-              }
+              "type": "Organization"
             },
             "description": "Galvalannealed ASTM A-653 zinc-iron alloy-coated steel sheets.",
             "weight": {
@@ -211,9 +161,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-15T12:14:36Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:50:09Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..gh9YT_MAL8XXATwFQX5UGBkIJuIICKxu31ojk7r3FNVQqkBd532WcLWGvcNJkvmCDn97Xzrp08ccbx8Ea0NtAA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..o_SYwtvAVx15h1VBNIMlBwkld_DAYAnn8E141KVHa-KStnabZDFagtOROkfAcJUCqKFNSoPZ8PErAH3Uv4YCCA"
     }
   }

--- a/docs/openapi/components/schemas/common/Purchase.yml
+++ b/docs/openapi/components/schemas/common/Purchase.yml
@@ -53,13 +53,28 @@ example: |-
         "type": "Organization",
         "name": "Powlowski - Roob",
         "description": "Balanced multimedia emulation",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "9592 Myrtis Shoal",
-          "addressLocality": "East Isom",
-          "addressRegion": "Tennessee",
-          "postalCode": "41990-3405",
-          "addressCountry": "Honduras"
+        "place": {
+          "type":[
+            "Place"
+          ],
+          "geo":{
+            "type":[
+              "GeoCoordinates"
+            ],
+            "latitude":"43.2557",
+            "longitude":"-79.8711"
+          },
+          "address":{
+            "type":[
+              "PostalAddress"
+            ],
+            "postalCode":"",
+            "addressRegion":"Ontario",
+            "streetAddress":"",
+            "addressCountry":"CANADA",
+            "addressLocality":"Hamilton"
+          },
+          "globalLocationNumber":"SC720"
         },
         "email": "Reece25@example.org",
         "phoneNumber": "555-464-6401",

--- a/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
@@ -64,18 +64,10 @@ example: |-
     "relatedLink": [],
     "issuanceDate": "2019-12-11T03:50:55Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": "Organization",
       "name": "Waters Inc",
       "description": "Stand-alone executive benchmark",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "027 Brakus Knoll",
-        "addressLocality": "East Johnniemouth",
-        "addressRegion": "Arizona",
-        "postalCode": "25780-5840",
-        "addressCountry": "Grenada"
-      },
       "email": "Kendrick.Spinka57@example.org",
       "phoneNumber": "555-322-9464",
       "faxNumber": "555-766-1744"
@@ -95,49 +87,26 @@ example: |-
         "type": [
           "Organization"
         ],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-          "streetAddress": "1651, Shimonakano, Yoshida",
-          "addressLocality": "Tsubame-shi",
-          "addressRegion": "Niigata-ken",
-          "postalCode": "959-0215",
-          "addressCountry": "Japan"
-        }
+        "name": "Xxinau Manufacturing Co. Ltd.",
+        "description": "Advanced Production - Delivered",
+        "email": "xxinau-sales@example.org",
+        "phoneNumber": "+86-555-865-8495"
       },
       "buyer": {
         "type": [
           "Organization"
         ],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "organizationName": "Generic Motors of America",
-          "streetAddress": "12 Generic Motors Dr",
-          "addressLocality": "Detroit",
-          "addressRegion": "Michigain",
-          "postalCode": "48232-5170",
-          "addressCountry": "USA"
-        }
+        "email": "Gustave.Dicki37@example.net",
+        "phoneNumber": "555-238-5681"
       },
       "consignee": {
         "type": [
           "Organization"
         ],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "organizationName": "Generic Motors of America",
-          "streetAddress": "12 Generic Motors Dr",
-          "addressLocality": "Detroit",
-          "addressRegion": "Michigain",
-          "postalCode": "48232-5170",
-          "addressCountry": "USA"
-        }
+        "name": "Better Life Tech",
+        "description": "Better Lives Products",
+        "email": "procurement@lifetech-example.org",
+        "phoneNumber": "+32-5555-8495"
       },
       "itemsShipped": [
         {
@@ -145,15 +114,10 @@ example: |-
           "product": {
             "manufacturer": {
               "type": "Organization",
-              "address": {
-                "type": "PostalAddress",
-                "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-                "streetAddress": "1651, Shimonakano, Yoshida",
-                "addressLocality": "Tsubame-shi",
-                "addressRegion": "Niigata-ken",
-                "postalCode": "959-0215",
-                "addressCountry": "Japan"
-              }
+              "name": "Xxinau Manufacturing Co. Ltd.",
+              "description": "Advanced Production - Delivered",
+              "email": "xxinau-sales@example.org",
+              "phoneNumber": "+86-555-865-8495"
             },
             "description": "UNS S30400 chromium-nickel stainless steel rolls.",
             "weight": {
@@ -179,15 +143,10 @@ example: |-
           "product": {
             "manufacturer": {
               "type": "Organization",
-              "address": {
-                "type": "PostalAddress",
-                "organizationName": "Aishi Metal Shinzo Co., Ltd.",
-                "streetAddress": "1651, Shimonakano, Yoshida",
-                "addressLocality": "Tsubame-shi",
-                "addressRegion": "Niigata-ken",
-                "postalCode": "959-0215",
-                "addressCountry": "Japan"
-              }
+              "name": "Better Life Tech",
+              "description": "Better Lives Products",
+              "email": "procurement@lifetech-example.org",
+              "phoneNumber": "+32-5555-8495"
             },
             "description": "Galvalannealed ASTM A-653 zinc-iron alloy-coated steel sheets.",
             "weight": {
@@ -222,9 +181,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-14T18:56:45Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:08:56Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..v0cnMAflvMI2aBBB3B8HSu80KR4hY9gSV8qu6k4uDoqcU4SjNdgCwOaSwmFMnwQ2A9FsCp1cXnM0FjkDe7UeCQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..4qJKMuXA1ysnPmJ7IHR9MmLHZXXYfC-KIduS5Y3K763Fslux3tWcykG1vnAbHIlT5yy0dkUPjdTy5PdKxkPaCg"
     }
   }

--- a/docs/openapi/components/schemas/common/SIMASteelImportLicense.yml
+++ b/docs/openapi/components/schemas/common/SIMASteelImportLicense.yml
@@ -110,13 +110,30 @@ example: |-
       "type": "Organization",
       "name": "Maxi Acero Mexicano",
       "description": "Fusión y fabricación de acero sólido",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Avenida Carlos 100",
-        "addressLocality": "Hernádez de Mara",
-        "addressRegion": "Nuevo Leon",
-        "postalCode": "32200",
-        "addressCountry": "Mexico"
+      "place": {
+        "type": [
+            "Place"
+        ],
+        "globalLocationNumber": "9339929638102",
+        "geo": {
+            "type": [
+            "GeoCoordinates"
+            ],
+            "latitude": "40.9090",
+            "longitude": "151.8748"
+        },
+        "address": {
+            "type": [
+            "PostalAddress"
+            ],
+            "organizationName": "Bogisich LLC",
+            "streetAddress": "50938 Donavon Junctions",
+            "addressLocality": "Rhodastad",
+            "addressRegion": "Louisiana",
+            "postalCode": "26521-2810",
+            "addressCountry": "American Samoa"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "info@example.net",
       "phoneNumber": "555-127-7813"
@@ -126,13 +143,30 @@ example: |-
       "type": "Organization",
       "name": "American Prime Steel Inc.",
       "description": "Quality Steel since 1952",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "1551 Keebler Knoll",
-        "addressLocality": "Vivianeburgh",
-        "addressRegion": "Oregon",
-        "postalCode": "47090",
-        "addressCountry": "US"
+      "place": {
+        "type": [
+          "Place"
+        ],
+        "globalLocationNumber": "5449782976823",
+        "geo": {
+          "type": [
+            "GeoCoordinates"
+          ],
+          "latitude": "-79.6395",
+          "longitude": "178.5353"
+        },
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Bednar - Kiehn",
+          "streetAddress": "853 Wisozk River",
+          "addressLocality": "New Noemyfort",
+          "addressRegion": "New Mexico",
+          "postalCode": "18047-2038",
+          "addressCountry": "Togo"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "contact@example.net",
       "phoneNumber": "555-716-2400"
@@ -141,13 +175,28 @@ example: |-
       "type": "Organization",
       "name": "Maxi Acero Mexicano",
       "description": "Fusión y fabricación de acero sólido",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Avenida Carlos 100",
-        "addressLocality": "Hernádez de Mara",
-        "addressRegion": "Nuevo Leon",
-        "postalCode": "32200",
-        "addressCountry": "Mexico"
+      "place": {
+        "type":[
+          "Place"
+        ],
+        "geo":{
+          "type":[
+            "GeoCoordinates"
+          ],
+          "latitude":"43.2557",
+          "longitude":"-79.8711"
+        },
+        "address":{
+          "type":[
+            "PostalAddress"
+          ],
+          "postalCode":"",
+          "addressRegion":"Ontario",
+          "streetAddress":"",
+          "addressCountry":"CANADA",
+          "addressLocality":"Hamilton"
+        },
+        "globalLocationNumber":"SC720"
       },
       "email": "info@example.net",
       "phoneNumber": "555-127-7813"
@@ -156,13 +205,30 @@ example: |-
       "type": "Organization",
       "name": "Maxi Acero Mexicano",
       "description": "Fusión y fabricación de acero sólido",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Avenida Carlos 100",
-        "addressLocality": "Hernádez de Mara",
-        "addressRegion": "Nuevo Leon",
-        "postalCode": "32200",
-        "addressCountry": "Mexico"
+      "place": {
+        "type": [
+            "Place"
+        ],
+        "globalLocationNumber": "9339929638102",
+        "geo": {
+            "type": [
+            "GeoCoordinates"
+            ],
+            "latitude": "40.9090",
+            "longitude": "151.8748"
+        },
+        "address": {
+            "type": [
+            "PostalAddress"
+            ],
+            "organizationName": "Bogisich LLC",
+            "streetAddress": "50938 Donavon Junctions",
+            "addressLocality": "Rhodastad",
+            "addressRegion": "Louisiana",
+            "postalCode": "26521-2810",
+            "addressCountry": "American Samoa"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "info@example.net",
       "phoneNumber": "555-127-7813"

--- a/docs/openapi/components/schemas/common/SIMASteelImportLicenseApplicationCertificate.yml
+++ b/docs/openapi/components/schemas/common/SIMASteelImportLicenseApplicationCertificate.yml
@@ -50,17 +50,9 @@ example: |-
     ],
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "name": "Maxi Acero Mexicano",
       "description": "Fusión y fabricación de acero sólido",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Avenida Carlos 100",
-        "addressLocality": "Hernádez de Mara",
-        "addressRegion": "Nuevo Leon",
-        "postalCode": "32200",
-        "addressCountry": "Mexico"
-      },
       "email": "info@example.net",
       "phoneNumber": "555-127-7813"
     },
@@ -71,14 +63,6 @@ example: |-
         "type": "Organization",
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Avenida Carlos 100",
-          "addressLocality": "Hernádez de Mara",
-          "addressRegion": "Nuevo Leon",
-          "postalCode": "32200",
-          "addressCountry": "Mexico"
-        },
         "email": "info@example.net",
         "phoneNumber": "555-127-7813"
       },
@@ -87,14 +71,6 @@ example: |-
         "type": "Organization",
         "name": "American Prime Steel Inc.",
         "description": "Quality Steel since 1952",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "1551 Keebler Knoll",
-          "addressLocality": "Vivianeburgh",
-          "addressRegion": "Oregon",
-          "postalCode": "47090",
-          "addressCountry": "US"
-        },
         "email": "contact@example.net",
         "phoneNumber": "555-716-2400"
       },
@@ -102,14 +78,6 @@ example: |-
         "type": "Organization",
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Avenida Carlos 100",
-          "addressLocality": "Hernádez de Mara",
-          "addressRegion": "Nuevo Leon",
-          "postalCode": "32200",
-          "addressCountry": "Mexico"
-        },
         "email": "info@example.net",
         "phoneNumber": "555-127-7813"
       },
@@ -117,14 +85,6 @@ example: |-
         "type": "Organization",
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Avenida Carlos 100",
-          "addressLocality": "Hernádez de Mara",
-          "addressRegion": "Nuevo Leon",
-          "postalCode": "32200",
-          "addressCountry": "Mexico"
-        },
         "email": "info@example.net",
         "phoneNumber": "555-127-7813"
       },
@@ -160,9 +120,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-02-28T12:53:22Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:22:34Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..AydApPJiIC4ox-3DxFgnjgjzc40jDDHwTobq_xpSS60qnq85vEONisyaxUzjmk3pevW8dU-vfqaGhc2fqZ4ZCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..17HjsN23rFp_CRX6WCw4wUvrzuwwfVe-oBfnjAvrXroGMsIjiySl7Bop6Qk08bQH6xq8NsM9WK4YAKwEd-54Bw"
     }
   }

--- a/docs/openapi/components/schemas/common/SIMASteelImportLicenseCertificate.yml
+++ b/docs/openapi/components/schemas/common/SIMASteelImportLicenseCertificate.yml
@@ -68,7 +68,7 @@ example: |-
     ],
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "name": "SIMA",
       "description": "The Steel Import Monitoring and Analysis (SIMA) System, under the Department of Commerce, collects and publishes early warning data of steel mill product imports.",
       "url": "https://www.trade.gov/steel-import-monitor"
@@ -82,14 +82,6 @@ example: |-
         "type": "Organization",
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Avenida Carlos 100",
-          "addressLocality": "Hernádez de Mara",
-          "addressRegion": "Nuevo Leon",
-          "postalCode": "32200",
-          "addressCountry": "Mexico"
-        },
         "email": "info@example.net",
         "phoneNumber": "555-127-7813"
       },
@@ -98,14 +90,6 @@ example: |-
         "type": "Organization",
         "name": "American Prime Steel Inc.",
         "description": "Quality Steel since 1952",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "1551 Keebler Knoll",
-          "addressLocality": "Vivianeburgh",
-          "addressRegion": "Oregon",
-          "postalCode": "47090",
-          "addressCountry": "US"
-        },
         "email": "contact@example.net",
         "phoneNumber": "555-716-2400"
       },
@@ -113,14 +97,6 @@ example: |-
         "type": "Organization",
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Avenida Carlos 100",
-          "addressLocality": "Hernádez de Mara",
-          "addressRegion": "Nuevo Leon",
-          "postalCode": "32200",
-          "addressCountry": "Mexico"
-        },
         "email": "info@example.net",
         "phoneNumber": "555-127-7813"
       },
@@ -128,14 +104,6 @@ example: |-
         "type": "Organization",
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Avenida Carlos 100",
-          "addressLocality": "Hernádez de Mara",
-          "addressRegion": "Nuevo Leon",
-          "postalCode": "32200",
-          "addressCountry": "Mexico"
-        },
         "email": "info@example.net",
         "phoneNumber": "555-127-7813"
       },
@@ -171,9 +139,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-02-28T12:50:37Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:21:34Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..rTVZD5spC0xOwwz6GDzh95JVH7XyNPLNJMJElPChghNhiNp_3Npn95JRAL-yqzTUS8i6JdCrz6du1q_jL49UAA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..aN6q23g5nhO6wAyU8kC8q6-09-WSxBQ3kv2XC2bRNyrODKVxFsRZA4B_gZeZ54MkmNRVUGVcmQOf4JjcHeD1BQ"
     }
   }

--- a/docs/openapi/components/schemas/common/SeaCargoManifestCertificate.yml
+++ b/docs/openapi/components/schemas/common/SeaCargoManifestCertificate.yml
@@ -44,16 +44,8 @@ example: |-
     "issuanceDate": "2022-03-16T14:13:30Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "MULTI CONTAINER LINE",
-      "address": {
-        "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
-        "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-        "addressLocality": "Kowloon Bay",
-        "addressRegion": "Hong Kong",
-        "addressCountry": "Hong Kong SAR"
-      }
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+      "name": "MULTI CONTAINER LINE"
     },
     "credentialSubject": {
       "type": "SeaCargoManifest",
@@ -93,57 +85,25 @@ example: |-
           "shipper": {
             "type": "Organization",
             "name": "Espresso Italiano Co.",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "Via Vico Ferrovia 5",
-              "addressLocality": "Goro",
-              "addressRegion": "Ferrara",
-              "postalCode": "44020",
-              "addressCountry": "IT"
-            },
             "email": "sales@espresso-italiano.example.com",
             "phoneNumber": "+39 0351 9067195"
           },
           "consignee": {
             "type": "Organization",
             "name": "Prosumer Coffee Supplies, Ltd.",
-            "description": "Coffee Machine Imports",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "3934 Spinnaker Lane",
-              "addressLocality": "Joliet",
-              "addressRegion": "Illinois",
-              "postalCode": "60432",
-              "addressCountry": "US"
-            }
+            "description": "Coffee Machine Imports"
           },
           "notifyParty": [
             {
               "type": "Organization",
               "name": "Prosumer Coffee Supplies, Ltd.",
-              "description": "Coffee Machine Imports",
-              "address": {
-                "type": "PostalAddress",
-                "streetAddress": "3934 Spinnaker Lane",
-                "addressLocality": "Joliet",
-                "addressRegion": "Illinois",
-                "postalCode": "60432",
-                "addressCountry": "US"
-              }
+              "description": "Coffee Machine Imports"
             }
           ],
           "carrier": {
             "type": "Organization",
             "id": "did:key:z6Mku6sNEit2qhNyaKDoj6ozURx5ApD85Za5g6dmnpYi6Auv",
-            "name": "MULTI CONTAINER LINE",
-            "address": {
-              "type": "PostalAddress",
-              "organizationName": "MCL Multi Container Line LTD.",
-              "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-              "addressLocality": "Kowloon Bay",
-              "addressRegion": "Hong Kong",
-              "addressCountry": "Hong Kong SAR"
-            }
+            "name": "MULTI CONTAINER LINE"
           },
           "mainCarriageTransportMovement": {
             "type": "Transport",
@@ -246,14 +206,6 @@ example: |-
               "type": "Organization",
               "name": "Xxinau Manufacturing Co. Ltd.",
               "description": "Advanced Production - Delivered",
-              "address": {
-                "type": "PostalAddress",
-                "streetAddress": "Xin Fei Da Dao 139",
-                "addressLocality": "Xindao",
-                "addressRegion": "Fujian Province",
-                "postalCode": "361100",
-                "addressCountry": "CN"
-              },
               "email": "xxinau-sales@example.org",
               "phoneNumber": "+86-555-865-8495"
             },
@@ -261,14 +213,6 @@ example: |-
               "type": "Organization",
               "name": "Better Life Tech",
               "description": "Better Lives Products",
-              "address": {
-                "type": "PostalAddress",
-                "streetAddress": "Rue de la Poste 272",
-                "addressLocality": "Ramegnies-Chin",
-                "addressRegion": "Hainaut",
-                "postalCode": "7520",
-                "addressCountry": "BE"
-              },
               "email": "procurement@lifetech-example.org",
               "phoneNumber": "+32-5555-8495"
             },
@@ -276,27 +220,12 @@ example: |-
               "type": "Organization",
               "name": "Better Life Tech",
               "description": "Better Lives Products",
-              "address": {
-                "type": "PostalAddress",
-                "streetAddress": "Rue de la Poste 272",
-                "addressLocality": "Ramegnies-Chin",
-                "addressRegion": "Hainaut",
-                "postalCode": "7520",
-                "addressCountry": "BE"
-              },
               "email": "procurement@lifetech-example.org",
               "phoneNumber": "+32-5555-8495"
             },
             "consigneesFreightForwarder": {
               "type": "Organization",
               "name": "Intertrans NV [378]",
-              "address": {
-                "type": "PostalAddress",
-                "streetAddress": "Belcrownlaan 25 - 3rd floor",
-                "addressLocality": "Antwerpen",
-                "postalCode": "BE-2100AN",
-                "addressCountry": "BE"
-              },
               "phoneNumber": "+32-3-201.98.10"
             },
             "cargoItems": [
@@ -370,15 +299,7 @@ example: |-
             "modeOfTransport": "Vessel",
             "carrier": {
               "type": "Organization",
-              "name": "MULTI CONTAINER LINE",
-              "address": {
-                "type": "PostalAddress",
-                "organizationName": "MCL Multi Container Line LTD.",
-                "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-                "addressLocality": "Kowloon Bay",
-                "addressRegion": "Hong Kong",
-                "addressCountry": "Hong Kong SAR"
-              }
+              "name": "MULTI CONTAINER LINE"
             },
             "vesselNumber": "HMM Algeciras",
             "voyageNumber": "V.0004W"
@@ -388,9 +309,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-16T13:20:18Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:20:44Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YhKy1kJ7LVHF9hdKV62blIAULB32X3YomCg0cute4zz40DBHMeKnheDv6dHOLugIgSxK8offqT8vvedWiTcJBg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..0efAI4cdCIpIbZTWGe0w2vIClnZpWY6hNIxA67rdBNwn9Bk_1pmr8gNegHmFtn--i06NsKK29uL29aRkeTacCg"
     }
   }

--- a/docs/openapi/components/schemas/common/ShippingInstructions.yml
+++ b/docs/openapi/components/schemas/common/ShippingInstructions.yml
@@ -190,13 +190,30 @@ example: |-
     "shipper": {
       "type": "Organization",
       "name": "Espresso Italiano Co.",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Via Vico Ferrovia 5",
-        "addressLocality": "Goro",
-        "addressRegion": "Ferrara",
-        "postalCode": "44020",
-        "addressCountry": "IT"
+      "place": {
+        "type": [
+          "Place"
+        ],
+        "globalLocationNumber": "5449782976823",
+        "geo": {
+          "type": [
+            "GeoCoordinates"
+          ],
+          "latitude": "-79.6395",
+          "longitude": "178.5353"
+        },
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Bednar - Kiehn",
+          "streetAddress": "853 Wisozk River",
+          "addressLocality": "New Noemyfort",
+          "addressRegion": "New Mexico",
+          "postalCode": "18047-2038",
+          "addressCountry": "Togo"
+        },
+        "unLocode": "DKCPH"
       },
       "email": "sales@espresso-italiano.example.com",
       "phoneNumber": "+39 0351 9067195"
@@ -219,13 +236,30 @@ example: |-
         "type": "Organization",
         "name": "Prosumer Coffee Supplies, Ltd.",
         "description": "Coffee Machine Imports",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "3934 Spinnaker Lane",
-          "addressLocality": "Joliet",
-          "addressRegion": "Illinois",
-          "postalCode": "60432",
-          "addressCountry": "US"
+        "place": {
+          "type": [
+              "Place"
+          ],
+          "globalLocationNumber": "9339929638102",
+          "geo": {
+              "type": [
+              "GeoCoordinates"
+              ],
+              "latitude": "40.9090",
+              "longitude": "151.8748"
+          },
+          "address": {
+              "type": [
+              "PostalAddress"
+              ],
+              "organizationName": "Bogisich LLC",
+              "streetAddress": "50938 Donavon Junctions",
+              "addressLocality": "Rhodastad",
+              "addressRegion": "Louisiana",
+              "postalCode": "26521-2810",
+              "addressCountry": "American Samoa"
+          },
+          "unLocode": "DKCPH"
         }
       }
     ],

--- a/docs/openapi/components/schemas/common/ShippingInstructionsCertificate.yml
+++ b/docs/openapi/components/schemas/common/ShippingInstructionsCertificate.yml
@@ -54,16 +54,8 @@ example: |-
     "issuanceDate": "2022-03-04T13:40:00Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "Espresso Italiano Co.",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Via Vico Ferrovia 5",
-        "addressLocality": "Goro",
-        "addressRegion": "Ferrara",
-        "postalCode": "44020",
-        "addressCountry": "IT"
-      }
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+      "name": "Espresso Italiano Co."
     },
     "credentialSubject": {
       "type": "ShippingInstructions",
@@ -74,57 +66,25 @@ example: |-
       "shipper": {
         "type": "Organization",
         "name": "Espresso Italiano Co.",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Via Vico Ferrovia 5",
-          "addressLocality": "Goro",
-          "addressRegion": "Ferrara",
-          "postalCode": "44020",
-          "addressCountry": "IT"
-        },
         "email": "sales@espresso-italiano.example.com",
         "phoneNumber": "+39 0351 9067195"
       },
       "consignee": {
         "type": "Organization",
         "name": "Prosumer Coffee Supplies, Ltd.",
-        "description": "Coffee Machine Imports",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "3934 Spinnaker Lane",
-          "addressLocality": "Joliet",
-          "addressRegion": "Illinois",
-          "postalCode": "60432",
-          "addressCountry": "US"
-        }
+        "description": "Coffee Machine Imports"
       },
       "notifyParty": [
         {
           "type": "Organization",
           "name": "Prosumer Coffee Supplies, Ltd.",
-          "description": "Coffee Machine Imports",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "3934 Spinnaker Lane",
-            "addressLocality": "Joliet",
-            "addressRegion": "Illinois",
-            "postalCode": "60432",
-            "addressCountry": "US"
-          }
+          "description": "Coffee Machine Imports"
         }
       ],
       "carrier": {
         "type": "Organization",
         "id": "did:key:z6Mku6sNEit2qhNyaKDoj6ozURx5ApD85Za5g6dmnpYi6Auv",
-        "name": "MULTI CONTAINER LINE",
-        "address": {
-          "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
-          "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-          "addressLocality": "Kowloon Bay",
-          "addressRegion": "Hong Kong",
-          "addressCountry": "Hong Kong SAR"
-        }
+        "name": "MULTI CONTAINER LINE"
       },
       "mainCarriageTransportMovement": {
         "type": "Transport",
@@ -200,9 +160,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-11T13:41:20Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:15:37Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..FrmsKFqRirLwQ1LOOIeNcoenGhNniaoT0hIj0prHVmUTzMPuhIsrcZFgPfMhDiJZW02ULD8_XpNbPjoiq8bEAw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..GcUgcZUGgRvDciGpquxZx8lhBRrs2uYp0KogfLtE7tq003wsmJJwymYTIejlC-AnQfRUVQDM0dZfy2KEmbWvDg"
     }
   }

--- a/docs/openapi/components/schemas/common/ShippingStop.yml
+++ b/docs/openapi/components/schemas/common/ShippingStop.yml
@@ -69,13 +69,28 @@ example: |-
       "type": "Organization",
       "name": "Koepp - Ratke",
       "description": "Fully-configurable 5th generation infrastructure",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "7070 Mohr Village",
-        "addressLocality": "Dereckmouth",
-        "addressRegion": "Washington",
-        "postalCode": "79586",
-        "addressCountry": "Equatorial Guinea"
+      "place": {
+        "type":[
+          "Place"
+        ],
+        "geo":{
+          "type":[
+            "GeoCoordinates"
+          ],
+          "latitude":"43.2557",
+          "longitude":"-79.8711"
+        },
+        "address":{
+          "type":[
+            "PostalAddress"
+          ],
+          "postalCode":"",
+          "addressRegion":"Ontario",
+          "streetAddress":"",
+          "addressCountry":"CANADA",
+          "addressLocality":"Hamilton"
+        },
+        "globalLocationNumber":"SC720"
       },
       "email": "Oliver16@example.com",
       "phoneNumber": "555-931-2101",

--- a/docs/openapi/components/schemas/common/SoftwareBillOfMaterialsCertificate.yml
+++ b/docs/openapi/components/schemas/common/SoftwareBillOfMaterialsCertificate.yml
@@ -57,18 +57,10 @@ example: |-
     "relatedLink": [],
     "issuanceDate": "2021-08-26T01:46:00Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": "Organization",
       "name": "Software Vendor Company",
       "description": "A company that provides software or libraries as a service",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "10612 Westheimer Rd",
-        "addressLocality": "Houston",
-        "addressRegion": "Texas",
-        "postalCode": "77042",
-        "addressCountry": "USA"
-      },
       "email": "Jerrell.Brakus73@soft-vendor.example.gov",
       "phoneNumber": "555-322-9464",
       "faxNumber": "555-766-1744"
@@ -160,11 +152,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-04-12T15:49:14Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:14:30Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h3eP5e3fm_Sj7x2sE9smg-OMdRdKDJcZVQDig_xE-XViDBrQpLcDnNGAnCo3RcLnrnQFvVHB9Ko6c_i7glC2CQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wYjpM_uOBtuotb2Aan9YH2qgMbg3qCiLQ3fquHdaW0R55I2ixszzxVozpdMbMONYJHBy7FIuVZfsBXtLBqhkBQ"
     }
   }
-
-

--- a/docs/openapi/components/schemas/common/TraceablePresentation.yml
+++ b/docs/openapi/components/schemas/common/TraceablePresentation.yml
@@ -12,18 +12,16 @@ required:
   - workflow
 example: |-
   {
-    "@context":
-      [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://w3id.org/security/suites/jws-2020/v1",
-        "https://w3id.org/traceability/v1"
-      ],
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/security/suites/jws-2020/v1",
+      "https://w3id.org/traceability/v1"
+    ],
     "id": "urn:uuid:83432751123654",
-    "type": 
-      [
-        "VerifiablePresentation",
-        "TraceablePresentation"
-      ],
+    "type": [
+      "VerifiablePresentation",
+      "TraceablePresentation"
+    ],
     "workflow": {
       "instance": [
         "f5fb6ce4-b0b1-41b8-89b0-331ni58b7ee0"
@@ -32,67 +30,57 @@ example: |-
         "n1552885-cc91-4bb3-91f1-5466a0be084e"
       ]
     },
-    "holder": "did:web:example-holder.org",
-    "verifiableCredential":
-      [
-        {
-          "@context": [
-            "https://www.w3.org/2018/credentials/v1",
-            "https://w3id.org/traceability/v1"
-          ],
-          "type": [
-            "VerifiableCredential",
-            "VerifiableBusinessCard"
-          ],
-          "name": "Verifiable Business Card",
-          "relatedLink": [
-            {
-              "type": "LinkRole",
-              "target": "https://example.com/organizations/example-org/presentations/available",
-              "linkRelationship": "OrganizationPresentationEndpoint"
-            }
-          ],
-          "issuanceDate": "2019-12-11T03:50:55Z",
-          "issuer": {
-            "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-            "type": "Organization",
-            "name": "Weber, Rolfson and Stroman",
-            "description": "Business-focused systemic paradigm",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "3263 Mohr Cape",
-              "addressLocality": "East Caleigh",
-              "addressRegion": "Tennessee",
-              "postalCode": "34278-9083",
-              "addressCountry": "Uruguay"
-            },
-            "email": "Julie.Muller31@example.net",
-            "phoneNumber": "555-433-6111",
-            "faxNumber": "555-356-2487"
-          },
-          "credentialSubject": {
-            "type": [
-              "Organization"
-            ],
-            "name": "Steel Manufacturer Org",
-            "url": "https://www.example.com/"
-          },
-          "proof": {
-            "type": "Ed25519Signature2018",
-            "created": "2019-12-11T03:50:55Z",
-            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..JkMUYvr__kGNGv8Mlj24QzDtBpCLekx9FYbCZjteUHtzXKMEVgNxgsHo53DVQTQ9EwoFBTEqgwmJPifC7HvHAg",
-            "proofPurpose": "assertionMethod",
-            "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U"
-          }
-        }
-      ],
-    "proof":
+    "holder": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+    "verifiableCredential": [
       {
-        "type": "JsonWebSignature2020",
-        "created": "2021-10-04T17:19:20Z",
-        "verificationMethod": "did:example:123#key-2",
-        "proofPurpose": "authentication",
-        "challenge": "123",
-        "jws": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Q0J7CcbM19fvfLdBZ44MlndvNACnmb0x1SM0cGnECye_-JC3Of29eroksqsVDTyXGAaQ_gnvcB4cqefK0jLIOg"
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://w3id.org/traceability/v1"
+        ],
+        "type": [
+          "VerifiableCredential",
+          "VerifiableBusinessCard"
+        ],
+        "name": "Verifiable Business Card",
+        "relatedLink": [
+          {
+            "type": "LinkRole",
+            "target": "https://example.com/organizations/example-org/presentations/available",
+            "linkRelationship": "OrganizationPresentationEndpoint"
+          }
+        ],
+        "issuanceDate": "2019-12-11T03:50:55Z",
+        "issuer": {
+          "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+          "type": "Organization",
+          "name": "Weber, Rolfson and Stroman",
+          "description": "Business-focused systemic paradigm",
+          "email": "Julie.Muller31@example.net",
+          "phoneNumber": "555-433-6111",
+          "faxNumber": "555-356-2487"
+        },
+        "credentialSubject": {
+          "type": [
+            "Organization"
+          ],
+          "name": "Steel Manufacturer Org",
+          "url": "https://www.example.com/"
+        },
+        "proof": {
+          "type": "Ed25519Signature2018",
+          "created": "2022-04-14T19:02:52Z",
+          "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+          "proofPurpose": "assertionMethod",
+          "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fa0OnUaLphFZPcLHzFBQZN2lp39j6nC8FG_LVyFEdeUbpphdBJdZF4bilQzjI-Vh2tEg6-c98n_AuZjZ2zlOCg"
+        }
       }
+    ],
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2022-04-14T19:05:41Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
+      "proofPurpose": "authentication",
+      "challenge": "e3ec7797-1987-4f6d-9df5-62ff8cea96c4",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..85KN0pUXpwjZ96L2Is-VgXWbJinWzIXVNVu-0b3uCF1M_HGw0Kc2dfzP8HY1ijXUBeDeAsvd_m9ducCKB2OcBw"
+    }
   }

--- a/docs/openapi/components/schemas/common/USMCACertificateOfOrigin.yml
+++ b/docs/openapi/components/schemas/common/USMCACertificateOfOrigin.yml
@@ -131,7 +131,7 @@ example: |-
     ],
     "issuanceDate": "2021-02-04T20:29:37+00:00",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": "USMCACertifier",
       "role": "Exporter",
       "certifierDetails": {
@@ -139,14 +139,6 @@ example: |-
         "id": "did:key:z6Mkj8LpyahD8sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Avenida Carlos 100",
-          "addressLocality": "Hernádez de Mara",
-          "addressRegion": "Nuevo Leon",
-          "postalCode": "32200",
-          "addressCountry": "Mexico"
-        },
         "email": "info@example.net",
         "phoneNumber": "555-127-7813"
       }
@@ -155,14 +147,6 @@ example: |-
       "type": "Organization",
       "name": "Maxi Acero Mexicano",
       "description": "Fusión y fabricación de acero sólido",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Avenida Carlos 100",
-        "addressLocality": "Hernádez de Mara",
-        "addressRegion": "Nuevo Leon",
-        "postalCode": "32200",
-        "addressCountry": "Mexico"
-      },
       "email": "info@example.net",
       "phoneNumber": "555-127-7813"
     },
@@ -171,14 +155,6 @@ example: |-
         "type": "Organization",
         "name": "American Prime Steel Inc.",
         "description": "Quality Steel since 1952",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "1551 Keebler Knoll",
-          "addressLocality": "Vivianeburgh",
-          "addressRegion": "Oregon",
-          "postalCode": "47090",
-          "addressCountry": "US"
-        },
         "email": "contact@example.net",
         "phoneNumber": "555-716-2400"
       }
@@ -188,14 +164,6 @@ example: |-
         "type": "Organization",
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Avenida Carlos 100",
-          "addressLocality": "Hernádez de Mara",
-          "addressRegion": "Nuevo Leon",
-          "postalCode": "32200",
-          "addressCountry": "Mexico"
-        },
         "email": "info@example.net",
         "phoneNumber": "555-127-7813"
       }
@@ -226,9 +194,9 @@ example: |-
     "blanketPeriodTo": "2022-06-21",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-02-28T13:51:43Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:13:07Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..vLP_D5EMn6lETU4_vBh4tMm47i65w4wrc5XvuGvygPtc3H_vvM8xxEoMWemo5Zx-Q0VNBEWNcCdp6s6vAxu3DQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pUJWdcsAusE4LodNl_0cYSy9aEZL0Elw4pMHE4HBpPyj3cH8NKzJ5g9-ICkxIOiFQAxmWJdK589m7164SS4lDg"
     }
   }

--- a/docs/openapi/components/schemas/common/USMCACertifier.yml
+++ b/docs/openapi/components/schemas/common/USMCACertifier.yml
@@ -48,13 +48,28 @@ example: |-
       "id": "did:key:z6Mkj8LpyahD8sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",
       "name": "Maxi Acero Mexicano",
       "description": "Fusión y fabricación de acero sólido",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Avenida Carlos 100",
-        "addressLocality": "Hernádez de Mara",
-        "addressRegion": "Nuevo Leon",
-        "postalCode": "32200",
-        "addressCountry": "Mexico"
+      "place": {
+        "type":[
+          "Place"
+        ],
+        "geo":{
+          "type":[
+            "GeoCoordinates"
+          ],
+          "latitude":"43.2557",
+          "longitude":"-79.8711"
+        },
+        "address":{
+          "type":[
+            "PostalAddress"
+          ],
+          "postalCode":"",
+          "addressRegion":"Ontario",
+          "streetAddress":"",
+          "addressCountry":"CANADA",
+          "addressLocality":"Hamilton"
+        },
+        "globalLocationNumber":"SC720"
       },
       "email": "info@example.net",
       "phoneNumber": "555-127-7813"

--- a/docs/openapi/components/schemas/common/UsdaSc6.yml
+++ b/docs/openapi/components/schemas/common/UsdaSc6.yml
@@ -320,29 +320,6 @@ example: |-
         ],
         "name": "Leannon and Sons",
         "description": "Fundamental multi-tasking service-desk",
-          "place": {
-            "type":[
-              "Place"
-            ],
-            "geo":{
-              "type":[
-                "GeoCoordinates"
-              ],
-              "latitude":"43.2557",
-              "longitude":"-79.8711"
-            },
-            "address":{
-              "type":[
-                "PostalAddress"
-              ],
-              "postalCode":"",
-              "addressRegion":"Ontario",
-              "streetAddress":"",
-              "addressCountry":"CANADA",
-              "addressLocality":"Hamilton"
-            },
-            "globalLocationNumber":"SC720"
-          },
         "email": "Hipolito58@example.org",
         "phoneNumber": "555-895-1661",
         "faxNumber": "555-497-2527"

--- a/docs/openapi/components/schemas/common/UsdaSc6.yml
+++ b/docs/openapi/components/schemas/common/UsdaSc6.yml
@@ -185,15 +185,30 @@ example: |-
           ],
           "name": "Stehr - Mertz",
           "description": "Optional zero administration paradigm",
-          "address": {
+          "place": {
             "type": [
-              "PostalAddress"
+                "Place"
             ],
-            "streetAddress": "54548 Osinski Neck",
-            "addressLocality": "North Dariana",
-            "addressRegion": "Montana",
-            "postalCode": "51346-1273",
-            "addressCountry": "Kuwait"
+            "globalLocationNumber": "9339929638102",
+            "geo": {
+                "type": [
+                "GeoCoordinates"
+                ],
+                "latitude": "40.9090",
+                "longitude": "151.8748"
+            },
+            "address": {
+                "type": [
+                "PostalAddress"
+                ],
+                "organizationName": "Bogisich LLC",
+                "streetAddress": "50938 Donavon Junctions",
+                "addressLocality": "Rhodastad",
+                "addressRegion": "Louisiana",
+                "postalCode": "26521-2810",
+                "addressCountry": "American Samoa"
+            },
+            "unLocode": "DKCPH"
           },
           "email": "Spencer.McClure32@example.net",
           "phoneNumber": "555-966-4160",
@@ -303,21 +318,34 @@ example: |-
         "type": [
           "Organization"
         ],
-        "name": "Christiansen - Hermiston",
-        "description": "Proactive value-added product",
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "streetAddress": "0202 Bryce Villages",
-          "addressLocality": "Quitzonview",
-          "addressRegion": "Arkansas",
-          "postalCode": "17524-0919",
-          "addressCountry": "Sri Lanka"
-        },
-        "email": "Sabina23@example.com",
-        "phoneNumber": "555-801-7580",
-        "faxNumber": "555-641-6979"
+        "name": "Leannon and Sons",
+        "description": "Fundamental multi-tasking service-desk",
+          "place": {
+            "type":[
+              "Place"
+            ],
+            "geo":{
+              "type":[
+                "GeoCoordinates"
+              ],
+              "latitude":"43.2557",
+              "longitude":"-79.8711"
+            },
+            "address":{
+              "type":[
+                "PostalAddress"
+              ],
+              "postalCode":"",
+              "addressRegion":"Ontario",
+              "streetAddress":"",
+              "addressCountry":"CANADA",
+              "addressLocality":"Hamilton"
+            },
+            "globalLocationNumber":"SC720"
+          },
+        "email": "Hipolito58@example.org",
+        "phoneNumber": "555-895-1661",
+        "faxNumber": "555-497-2527"
       },
       "AgPackage": [
         {

--- a/docs/openapi/components/schemas/common/VerifiableBusinessCard.yml
+++ b/docs/openapi/components/schemas/common/VerifiableBusinessCard.yml
@@ -59,19 +59,11 @@ example: |-
     ],
     "issuanceDate": "2019-12-11T03:50:55Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": "Organization",
       "name": "Glover - Gleason",
       "legalName": "Glover and Gleason, Llc.",
       "description": "Customs Brokering since 2012",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "210 Jermey Fort",
-        "addressLocality": "Lake Evalyn",
-        "addressRegion": "Montana",
-        "postalCode": "71172",
-        "addressCountry": "US"
-      },
       "email": "contact@glover-gleason.example.net",
       "phoneNumber": "555-758-8926",
       "faxNumber": "555-248-4575",
@@ -83,14 +75,6 @@ example: |-
       "name": "Glover - Gleason",
       "legalName": "Glover and Gleason, Llc.",
       "description": "Customs Brokering since 2012",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "210 Jermey Fort",
-        "addressLocality": "Lake Evalyn",
-        "addressRegion": "Montana",
-        "postalCode": "71172",
-        "addressCountry": "US"
-      },
       "email": "contact@glover-gleason.example.net",
       "phoneNumber": "555-758-8926",
       "faxNumber": "555-248-4575",
@@ -99,9 +83,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-25T14:58:05Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-14T18:12:14Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..4Bn--GdSHVheEcn0ARPVVMHkzrA2QdFhc0NdNYcGH-8nVIZgdguuTspxOPSAIDntcLDP49eR4eEQyTuC7EdMCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..o5cmbjNdDlqHfmNvWyGUs8cb0xm1AAiELldfXuVxKAhu4hUsdmkpsgVRy9kHORUAspsl3hnIZrbFeVVE4-YXCg"
     }
   }

--- a/docs/openapi/components/schemas/common/WayBillRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/common/WayBillRegistrationCredential.yml
@@ -91,13 +91,30 @@ example: |-
         "type": "Organization",
         "name": "Schuster Group",
         "description": "Progressive intermediate model",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "570 Dena Ranch",
-          "addressLocality": "Scarlettfurt",
-          "addressRegion": "Florida",
-          "postalCode": "08794",
-          "addressCountry": "Cuba"
+        "place": {
+          "type": [
+              "Place"
+          ],
+          "globalLocationNumber": "9339929638102",
+          "geo": {
+              "type": [
+              "GeoCoordinates"
+              ],
+              "latitude": "40.9090",
+              "longitude": "151.8748"
+          },
+          "address": {
+              "type": [
+              "PostalAddress"
+              ],
+              "organizationName": "Bogisich LLC",
+              "streetAddress": "50938 Donavon Junctions",
+              "addressLocality": "Rhodastad",
+              "addressRegion": "Louisiana",
+              "postalCode": "26521-2810",
+              "addressCountry": "American Samoa"
+          },
+          "unLocode": "DKCPH"
         },
         "email": "Gretchen_Reichel@example.org",
         "phoneNumber": "555-864-1793",

--- a/docs/openapi/components/schemas/common/ppq587.yml
+++ b/docs/openapi/components/schemas/common/ppq587.yml
@@ -171,31 +171,6 @@ example: |-
         ],
         "name": "Leannon and Sons",
         "description": "Fundamental multi-tasking service-desk",
-          "place": {
-            "type": [
-                "Place"
-            ],
-            "globalLocationNumber": "9339929638102",
-            "geo": {
-                "type": [
-                "GeoCoordinates"
-                ],
-                "latitude": "40.9090",
-                "longitude": "151.8748"
-            },
-            "address": {
-                "type": [
-                "PostalAddress"
-                ],
-                "organizationName": "Bogisich LLC",
-                "streetAddress": "50938 Donavon Junctions",
-                "addressLocality": "Rhodastad",
-                "addressRegion": "Louisiana",
-                "postalCode": "26521-2810",
-                "addressCountry": "American Samoa"
-            },
-            "unLocode": "DKCPH"
-          },
         "email": "Hipolito58@example.org",
         "phoneNumber": "555-895-1661",
         "faxNumber": "555-497-2527"

--- a/docs/openapi/components/schemas/common/ppq587.yml
+++ b/docs/openapi/components/schemas/common/ppq587.yml
@@ -169,21 +169,36 @@ example: |-
         "type": [
           "Organization"
         ],
-        "name": "Rogahn Inc",
-        "description": "Monitored intangible throughput",
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "streetAddress": "6149 Russel Terrace",
-          "addressLocality": "North Garrick",
-          "addressRegion": "New York",
-          "postalCode": "27589",
-          "addressCountry": "Puerto Rico"
-        },
-        "email": "Reta.Lowe@example.org",
-        "phoneNumber": "555-891-1199",
-        "faxNumber": "555-464-6083"
+        "name": "Leannon and Sons",
+        "description": "Fundamental multi-tasking service-desk",
+          "place": {
+            "type": [
+                "Place"
+            ],
+            "globalLocationNumber": "9339929638102",
+            "geo": {
+                "type": [
+                "GeoCoordinates"
+                ],
+                "latitude": "40.9090",
+                "longitude": "151.8748"
+            },
+            "address": {
+                "type": [
+                "PostalAddress"
+                ],
+                "organizationName": "Bogisich LLC",
+                "streetAddress": "50938 Donavon Junctions",
+                "addressLocality": "Rhodastad",
+                "addressRegion": "Louisiana",
+                "postalCode": "26521-2810",
+                "addressCountry": "American Samoa"
+            },
+            "unLocode": "DKCPH"
+          },
+        "email": "Hipolito58@example.org",
+        "phoneNumber": "555-895-1661",
+        "faxNumber": "555-497-2527"
       },
       "AgPackage": [
         {


### PR DESCRIPTION
This PR would  replace both the `globalLocationNumber` and `address` props of Organization with `place`.

Benefits:
- Place has its own `globalLocationNumber` and `address` props, so this would simplify Organization without any loss of information
- This would allow the association of additional location info (like geo coordinates) with organizations.

I was able to replace `address` with `place` in most examples, but ran into some difficulties doing this with certificates (CommercialInvoiceCertificate, DCSAShippingInstructionCertificate etc.). Even after adding a `place` prop to Organization, adding `place` props to example organizations in any of the certificates resulted in failed verification checks (from `packages/traceability-schemas/__tests__/credentials.sanity.test.js`).

As far as I can tell the verification checks _do_ check the credentials against the latest Organization schema (as removing `address` from Organization without removing all `address` props from certificate examples breaks them), so I'm really not sure why I'm not able to add `place` properties to certificate example organizations after adding `place` to the latest Organization schema. Is there maybe some cache of vocab related info being referenced by `credentials.sanity.test.js` that needs to be updated before I can update certificate example organizations? @OR13 maybe you could shine some light on this?

For now I've just removed `address` props for organizations in certificate examples (& updated the proofs).