### PR TITLE
Update examples to reduce ajv errors

### DIFF
--- a/docs/openapi/components/schemas/common/CertificateOfOrigin.yml
+++ b/docs/openapi/components/schemas/common/CertificateOfOrigin.yml
@@ -70,7 +70,7 @@ example: |-
     "issuanceDate": "2019-12-11T03:50:55Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "name": "North Italy Chamber of Commerce"
     },
     "credentialSubject": [
@@ -86,13 +86,12 @@ example: |-
       }
     ],
     "manufacturingCountry": "IT",
-    "totalNumberOfPackages": 880,
     "dateOfExport": "2022-02-02T09:30:00Z",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-02T09:38:34Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-26T00:54:44Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..kT7zgcZ-ltCUle_fbkd9Nou6Gp29i7Frh3mCQgVNmATb6uL44il8b5MG5UyyDLoqKI7xw5m-Y_PmQYMpYNQyBA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..SJFeufGTUb18O6w_EEUjlpvjVKpLjTkuedHINSZxwUcudUS_JF_c4__e0SdYc9saugYuK9KBITPptr-BpM1uDA"
     }
   }

--- a/docs/openapi/components/schemas/common/Invoice.yml
+++ b/docs/openapi/components/schemas/common/Invoice.yml
@@ -293,22 +293,6 @@ example: |-
         "addressCountry": "USA"
       }
     },
-    "consignee": {
-      "type": [
-        "Organization"
-      ],
-      "address": {
-        "type": [
-          "PostalAddress"
-        ],
-        "organizationName": "Generic Motors of America",
-        "streetAddress": "12 Generic Motors Dr",
-        "addressLocality": "Detroit",
-        "addressRegion": "Michigain",
-        "postalCode": "48232-5170",
-        "addressCountry": "USA"
-      }
-    },
     "itemsShipped": [
       {
         "type": "TradeLineItem",

--- a/docs/openapi/components/schemas/common/PurchaseOrder.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrder.yml
@@ -249,22 +249,6 @@ example: |-
         "addressCountry": "USA"
       }
     },
-    "consignee": {
-      "type": [
-        "Organization"
-      ],
-      "address": {
-        "type": [
-          "PostalAddress"
-        ],
-        "organizationName": "Generic Motors of America",
-        "streetAddress": "12 Generic Motors Dr",
-        "addressLocality": "Detroit",
-        "addressRegion": "Michigain",
-        "postalCode": "48232-5170",
-        "addressCountry": "USA"
-      }
-    },
     "itemsShipped": [
       {
         "type": "TradeLineItem",

--- a/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrderCertificate.yml
@@ -64,7 +64,7 @@ example: |-
     "relatedLink": [],
     "issuanceDate": "2019-12-11T03:50:55Z",
     "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "type": "Organization",
       "name": "Waters Inc",
       "description": "Stand-alone executive benchmark",
@@ -108,22 +108,6 @@ example: |-
         }
       },
       "buyer": {
-        "type": [
-          "Organization"
-        ],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "organizationName": "Generic Motors of America",
-          "streetAddress": "12 Generic Motors Dr",
-          "addressLocality": "Detroit",
-          "addressRegion": "Michigain",
-          "postalCode": "48232-5170",
-          "addressCountry": "USA"
-        }
-      },
-      "consignee": {
         "type": [
           "Organization"
         ],
@@ -222,9 +206,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-14T18:56:45Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-26T00:57:27Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..v0cnMAflvMI2aBBB3B8HSu80KR4hY9gSV8qu6k4uDoqcU4SjNdgCwOaSwmFMnwQ2A9FsCp1cXnM0FjkDe7UeCQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..6In4yH706p8UGDjRZbnlLIjPIkB9yjnejIydslMoWsKYjcok8hYssVeTh4WwP-Lfs_S9MTF8ikZQWBu4vb9RDQ"
     }
   }

--- a/docs/openapi/components/schemas/common/SeaCargoManifest.yml
+++ b/docs/openapi/components/schemas/common/SeaCargoManifest.yml
@@ -121,11 +121,11 @@ example: |-
     "plannedArrivalDateTime": "2022-03-13T06:30:00Z",
     "portOfDeparture": {
       "type": "Place",
-      "unlocode": "DEBRV"
+      "unLocode": "DEBRV"
     },
     "portOfArrival": {
       "type": "Place",
-      "unlocode": "DKAAR"
+      "unLocode": "DKAAR"
     },
     "netTonnage": {
       "type": "QuantitativeValue",

--- a/docs/openapi/components/schemas/common/SeaCargoManifestCertificate.yml
+++ b/docs/openapi/components/schemas/common/SeaCargoManifestCertificate.yml
@@ -44,7 +44,7 @@ example: |-
     "issuanceDate": "2022-03-16T14:13:30Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "name": "MULTI CONTAINER LINE",
       "address": {
         "type": "PostalAddress",
@@ -65,11 +65,11 @@ example: |-
       "plannedArrivalDateTime": "2022-03-13T06:30:00Z",
       "portOfDeparture": {
         "type": "Place",
-        "unlocode": "DEBRV"
+        "unLocode": "DEBRV"
       },
       "portOfArrival": {
         "type": "Place",
-        "unlocode": "DKAAR"
+        "unLocode": "DKAAR"
       },
       "netTonnage": {
         "type": "QuantitativeValue",
@@ -388,9 +388,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-16T13:20:18Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-26T00:58:07Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YhKy1kJ7LVHF9hdKV62blIAULB32X3YomCg0cute4zz40DBHMeKnheDv6dHOLugIgSxK8offqT8vvedWiTcJBg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..8VT1-kZqrQbZzlXWILaIfqvh7qNO46-uPGih_D-x8OmIBwJVw458yPcW84zUWNkn-unExc3T3xf-3FwCK2aTCw"
     }
   }

--- a/docs/openapi/components/schemas/common/ShippingInstructions.yml
+++ b/docs/openapi/components/schemas/common/ShippingInstructions.yml
@@ -229,19 +229,6 @@ example: |-
         }
       }
     ],
-    "carrier": {
-      "type": "Organization",
-      "id": "did:key:z6Mku6sNEit2qhNyaKDoj6ozURx5ApD85Za5g6dmnpYi6Auv",
-      "name": "MULTI CONTAINER LINE",
-      "address": {
-        "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
-        "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-        "addressLocality": "Kowloon Bay",
-        "addressRegion": "Hong Kong",
-        "addressCountry": "Hong Kong SAR"
-      }
-    },
     "mainCarriageTransportMovement": {
       "type": "Transport",
       "vesselNumber": "MS Seven Seas",

--- a/docs/openapi/components/schemas/common/ShippingInstructionsCertificate.yml
+++ b/docs/openapi/components/schemas/common/ShippingInstructionsCertificate.yml
@@ -54,7 +54,7 @@ example: |-
     "issuanceDate": "2022-03-04T13:40:00Z",
     "issuer": {
       "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "id": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "name": "Espresso Italiano Co.",
       "address": {
         "type": "PostalAddress",
@@ -113,19 +113,6 @@ example: |-
           }
         }
       ],
-      "carrier": {
-        "type": "Organization",
-        "id": "did:key:z6Mku6sNEit2qhNyaKDoj6ozURx5ApD85Za5g6dmnpYi6Auv",
-        "name": "MULTI CONTAINER LINE",
-        "address": {
-          "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
-          "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-          "addressLocality": "Kowloon Bay",
-          "addressRegion": "Hong Kong",
-          "addressCountry": "Hong Kong SAR"
-        }
-      },
       "mainCarriageTransportMovement": {
         "type": "Transport",
         "vesselNumber": "MS Seven Seas",
@@ -200,9 +187,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-11T13:41:20Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "created": "2022-04-26T00:56:38Z",
+      "verificationMethod": "did:key:z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn#z6MktiSzqF9kqwdU8VkdBKx56EYzXfpgnNPUAGznpicNiWfn",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..FrmsKFqRirLwQ1LOOIeNcoenGhNniaoT0hIj0prHVmUTzMPuhIsrcZFgPfMhDiJZW02ULD8_XpNbPjoiq8bEAw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.._nnWVHjm09dENL7Gm1jM6Tv_ZYSEm6sHIPOe1QgGrKYYYG1v5Fh8MFQj6OWewDjL0N2LTbXStLvcyY2gSKxLBQ"
     }
   }

--- a/docs/openapi/components/schemas/common/TransformEvent.yml
+++ b/docs/openapi/components/schemas/common/TransformEvent.yml
@@ -75,8 +75,8 @@ example: |-
         "type":[
           "GeoCoordinates"
         ],
-        "latitude":42.8864,
-        "longitude":-78.8784
+        "latitude": "42.8864",
+        "longitude": "-78.8784"
       },
       "type":[
         "Place"


### PR DESCRIPTION
This PR makes a few minor changes to schema examples in response to AJV error messages, including:

- Remove old / out of date props (like `consignee` in `Invoice`, or `totalNumberPackages` in `CertificateOfOrigin`)
- Change `latitude` value to string (in `TransformEvent`)
- `unlocode` -> `unLocode`
