### PR TITLE
Fix credential subject array bug

### DIFF
--- a/docs/openapi/components/schemas/common/CertificateOfOrigin.yml
+++ b/docs/openapi/components/schemas/common/CertificateOfOrigin.yml
@@ -56,7 +56,7 @@ properties:
       '@type': http://www.w3.org/2001/XMLSchema#dateTime
 additionalProperties: false
 example: |-
-  {
+   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
       "https://w3id.org/traceability/v1"
@@ -73,26 +73,28 @@ example: |-
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "name": "North Italy Chamber of Commerce"
     },
-    "credentialSubject": [
-      {
-        "type": "TradeLineItem",
-        "name": "Espresso Italiano",
-        "description": "Premium Prosumer Espresso Makers - Model Dolce",
-        "commodity": {
-          "type": "Commodity",
-          "commodityCode": "851671",
-          "commodityCodeType": "HS"
+    "credentialSubject": {
+      "items": [
+        {
+          "type": "TradeLineItem",
+          "name": "Espresso Italiano",
+          "description": "Premium Prosumer Espresso Makers - Model Dolce",
+          "commodity": {
+            "type": "Commodity",
+            "commodityCode": "851671",
+            "commodityCodeType": "HS"
+          }
         }
-      }
-    ],
+      ]
+    },
     "manufacturingCountry": "IT",
     "totalNumberOfPackages": 880,
     "dateOfExport": "2022-02-02T09:30:00Z",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-02T09:38:34Z",
+      "created": "2022-04-27T18:37:24Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..kT7zgcZ-ltCUle_fbkd9Nou6Gp29i7Frh3mCQgVNmATb6uL44il8b5MG5UyyDLoqKI7xw5m-Y_PmQYMpYNQyBA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..VO0XBuQCyfQ-A0fi1qLE1NO9f-dkdzsCplp-l7D4ynJkLAEdWLBlzgpEFF2GrVMJyOjUKw5NM1y5F0C_ug1KAw"
     }
   }

--- a/docs/openapi/components/schemas/common/PGAStatusMessageCertificate.yml
+++ b/docs/openapi/components/schemas/common/PGAStatusMessageCertificate.yml
@@ -76,35 +76,37 @@ example: |-
       "phoneNumber": "555-322-9464",
       "faxNumber": "555-766-1744"
     },
-    "credentialSubject": [
-      {
-        "type": "PGAStatusMessage",
-        "recordNo": "SO70",
-        "entryNo": "AAA-1234567-8",
-        "entryLineSequence": "L1:S1",
-        "statusCode": "O2",
-        "statusCodeDescription": "Hold Intact",
-        "validCodeReason": "25",
-        "validCodeReasonDescription": "Additional Verification Needed",
-        "subReasonCode": "132",
-        "subReasonCodeDescription": "Documentation Needed"
-      },
-      {
-        "type": "PGAStatusMessage",
-        "recordNo": "SO70",
-        "entryNo": "AAA-1234567-8",
-        "entryLineSequence": "L1:S2",
-        "statusCode": "O7",
-        "statusCodeDescription": "May Proceed",
-        "validCodeReason": "23",
-        "validCodeReasonDescription": "Released"
-      }
-    ],
+    "credentialSubject": {
+      "items": [
+        {
+          "type": "PGAStatusMessage",
+          "recordNo": "SO70",
+          "entryNo": "AAA-1234567-8",
+          "entryLineSequence": "L1:S1",
+          "statusCode": "O2",
+          "statusCodeDescription": "Hold Intact",
+          "validCodeReason": "25",
+          "validCodeReasonDescription": "Additional Verification Needed",
+          "subReasonCode": "132",
+          "subReasonCodeDescription": "Documentation Needed"
+        },
+        {
+          "type": "PGAStatusMessage",
+          "recordNo": "SO70",
+          "entryNo": "AAA-1234567-8",
+          "entryLineSequence": "L1:S2",
+          "statusCode": "O7",
+          "statusCodeDescription": "May Proceed",
+          "validCodeReason": "23",
+          "validCodeReasonDescription": "Released"
+        }
+      ]
+    },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-03-14T14:06:41Z",
+      "created": "2022-04-27T18:39:53Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..OiJawjqsly83sWxcb_0WsUKmmGHi0pyyhCpE06NGZCmL4XQcStbjj1SmiCim9I2GAjN_NNR20twYOxDJ2ry0CQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..mYJZpYWqhqJLXVpiKpKK1aseFFx7Y3aUZHgp3DvwNcIiWfc0cwvn9eDI5_Bi1cK4fLVRP-PMhtv7n4L1a83aDw"
     }
   }

--- a/docs/openapi/components/schemas/common/USMCACertificateOfOrigin.yml
+++ b/docs/openapi/components/schemas/common/USMCACertificateOfOrigin.yml
@@ -124,115 +124,117 @@ additionalProperties: true
 required: []
 example: |-
   {
-    "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/traceability/v1"
-    ],
-    "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-    "type": [
-      "VerifiableCredential",
-      "USMCACertificateOfOrigin"
-    ],
-    "issuanceDate": "2021-02-04T20:29:37+00:00",
-    "issuer": {
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "type": "USMCACertifier",
-      "role": "Exporter",
-      "certifierDetails": {
-        "type": "Organization",
-        "id": "did:key:z6Mkj8LpyahD8sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",
-        "name": "Maxi Acero Mexicano",
-        "description": "Fusión y fabricación de acero sólido",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Avenida Carlos 100",
-          "addressLocality": "Hernádez de Mara",
-          "addressRegion": "Nuevo Leon",
-          "postalCode": "32200",
-          "addressCountry": "Mexico"
-        },
-        "email": "info@example.net",
-        "phoneNumber": "555-127-7813"
-      }
-    },
-    "exporterDetails": {
-      "type": "Organization",
-      "name": "Maxi Acero Mexicano",
-      "description": "Fusión y fabricación de acero sólido",
-      "address": {
-        "type": "PostalAddress",
-        "streetAddress": "Avenida Carlos 100",
-        "addressLocality": "Hernádez de Mara",
-        "addressRegion": "Nuevo Leon",
-        "postalCode": "32200",
-        "addressCountry": "Mexico"
-      },
-      "email": "info@example.net",
-      "phoneNumber": "555-127-7813"
-    },
-    "importerDetails": [
-      {
-        "type": "Organization",
-        "name": "American Prime Steel Inc.",
-        "description": "Quality Steel since 1952",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "1551 Keebler Knoll",
-          "addressLocality": "Vivianeburgh",
-          "addressRegion": "Oregon",
-          "postalCode": "47090",
-          "addressCountry": "US"
-        },
-        "email": "contact@example.net",
-        "phoneNumber": "555-716-2400"
-      }
-    ],
-    "producerDetails": [
-      {
-        "type": "Organization",
-        "name": "Maxi Acero Mexicano",
-        "description": "Fusión y fabricación de acero sólido",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Avenida Carlos 100",
-          "addressLocality": "Hernádez de Mara",
-          "addressRegion": "Nuevo Leon",
-          "postalCode": "32200",
-          "addressCountry": "Mexico"
-        },
-        "email": "info@example.net",
-        "phoneNumber": "555-127-7813"
-      }
-    ],
-    "credentialSubject": [
-      {
-        "type": "USMCAProductSpecifier",
-        "product": {
-          "type": [
-            "Product"
-          ],
-          "sku": "323050346937",
-          "description": "Non-alloy steel rolls",
-          "commodity": {
-            "type": [
-              "Commodity"
-            ],
-            "commodityCode": "721320",
-            "commodityCodeType": "HS",
-            "description": "Steel Coils"
-          }
-        },
-        "originCriterion": "A",
-        "countryOfOrigin": "MX"
-      }
-    ],
-    "blanketPeriodFrom": "2021-06-22",
-    "blanketPeriodTo": "2022-06-21",
-    "proof": {
-      "type": "Ed25519Signature2018",
-      "created": "2022-02-28T13:51:43Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..vLP_D5EMn6lETU4_vBh4tMm47i65w4wrc5XvuGvygPtc3H_vvM8xxEoMWemo5Zx-Q0VNBEWNcCdp6s6vAxu3DQ"
-    }
-  }
+     "@context": [
+       "https://www.w3.org/2018/credentials/v1",
+       "https://w3id.org/traceability/v1"
+     ],
+     "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+     "type": [
+       "VerifiableCredential",
+       "USMCACertificateOfOrigin"
+     ],
+     "issuanceDate": "2021-02-04T20:29:37+00:00",
+     "issuer": {
+       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+       "type": "USMCACertifier",
+       "role": "Exporter",
+       "certifierDetails": {
+         "type": "Organization",
+         "id": "did:key:z6Mkj8LpyahD8sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",
+         "name": "Maxi Acero Mexicano",
+         "description": "Fusión y fabricación de acero sólido",
+         "address": {
+           "type": "PostalAddress",
+           "streetAddress": "Avenida Carlos 100",
+           "addressLocality": "Hernádez de Mara",
+           "addressRegion": "Nuevo Leon",
+           "postalCode": "32200",
+           "addressCountry": "Mexico"
+         },
+         "email": "info@example.net",
+         "phoneNumber": "555-127-7813"
+       }
+     },
+     "exporterDetails": {
+       "type": "Organization",
+       "name": "Maxi Acero Mexicano",
+       "description": "Fusión y fabricación de acero sólido",
+       "address": {
+         "type": "PostalAddress",
+         "streetAddress": "Avenida Carlos 100",
+         "addressLocality": "Hernádez de Mara",
+         "addressRegion": "Nuevo Leon",
+         "postalCode": "32200",
+         "addressCountry": "Mexico"
+       },
+       "email": "info@example.net",
+       "phoneNumber": "555-127-7813"
+     },
+     "importerDetails": [
+       {
+         "type": "Organization",
+         "name": "American Prime Steel Inc.",
+         "description": "Quality Steel since 1952",
+         "address": {
+           "type": "PostalAddress",
+           "streetAddress": "1551 Keebler Knoll",
+           "addressLocality": "Vivianeburgh",
+           "addressRegion": "Oregon",
+           "postalCode": "47090",
+           "addressCountry": "US"
+         },
+         "email": "contact@example.net",
+         "phoneNumber": "555-716-2400"
+       }
+     ],
+     "producerDetails": [
+       {
+         "type": "Organization",
+         "name": "Maxi Acero Mexicano",
+         "description": "Fusión y fabricación de acero sólido",
+         "address": {
+           "type": "PostalAddress",
+           "streetAddress": "Avenida Carlos 100",
+           "addressLocality": "Hernádez de Mara",
+           "addressRegion": "Nuevo Leon",
+           "postalCode": "32200",
+           "addressCountry": "Mexico"
+         },
+         "email": "info@example.net",
+         "phoneNumber": "555-127-7813"
+       }
+     ],
+     "credentialSubject": {
+       "items": [
+         {
+           "type": "USMCAProductSpecifier",
+           "product": {
+             "type": [
+               "Product"
+             ],
+             "sku": "323050346937",
+             "description": "Non-alloy steel rolls",
+             "commodity": {
+               "type": [
+                 "Commodity"
+               ],
+               "commodityCode": "721320",
+               "commodityCodeType": "HS",
+               "description": "Steel Coils"
+             }
+           },
+           "originCriterion": "A",
+           "countryOfOrigin": "MX"
+         }
+       ]
+     },
+     "blanketPeriodFrom": "2021-06-22",
+     "blanketPeriodTo": "2022-06-21",
+     "proof": {
+       "type": "Ed25519Signature2018",
+       "created": "2022-04-27T18:38:43Z",
+       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+       "proofPurpose": "assertionMethod",
+       "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..lE9woHa6ZMdujPSTs83BV-YYH9ffLkuZcZIz7N38yNtFgIia2fTlPkQzSX3VPf9R_bk5an0UjXRoHAgdVPN-Cg"
+     }
+   }


### PR DESCRIPTION
3 Credential examples contained credential subjects that were arrays... this prevents mapping to JWT and introduces errors in many VC libraries which don't support credentialSubject as an array.