### PR TITLE
Serialize context JSON deterministically

### DIFF
--- a/packages/traceability-schemas/package-lock.json
+++ b/packages/traceability-schemas/package-lock.json
@@ -18,7 +18,8 @@
 				"@transmute/security-context": "^0.7.0-unstable.30",
 				"@transmute/vc.js": "^0.7.0-unstable.37",
 				"ajv": "^7.1.1",
-				"js-yaml": "^4.1.0"
+				"js-yaml": "^4.1.0",
+				"json-stringify-deterministic": "^1.0.7"
 			},
 			"devDependencies": {
 				"eslint": "^7.11.0",
@@ -6197,6 +6198,14 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
+		},
+		"node_modules/json-stringify-deterministic": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.7.tgz",
+			"integrity": "sha512-VGSL+V2s/AqL25ixC4459kAlyIYsS+VUJ3owa/FKr4ZeMJeTZERlzGXJ2xWIHcTfd/fwgTvNyh7/RWMDvkFciw==",
+			"engines": {
+				"node": ">= 4"
+			}
 		},
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
@@ -13870,6 +13879,11 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
+		},
+		"json-stringify-deterministic": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.7.tgz",
+			"integrity": "sha512-VGSL+V2s/AqL25ixC4459kAlyIYsS+VUJ3owa/FKr4ZeMJeTZERlzGXJ2xWIHcTfd/fwgTvNyh7/RWMDvkFciw=="
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",

--- a/packages/traceability-schemas/package.json
+++ b/packages/traceability-schemas/package.json
@@ -26,7 +26,8 @@
     "@transmute/security-context": "^0.7.0-unstable.30",
     "@transmute/vc.js": "^0.7.0-unstable.37",
     "ajv": "^7.1.1",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "json-stringify-deterministic": "^1.0.7"
   },
   "devDependencies": {
     "eslint": "^7.11.0",

--- a/packages/traceability-schemas/scripts/openapi-to-context.js
+++ b/packages/traceability-schemas/scripts/openapi-to-context.js
@@ -6,6 +6,7 @@ const path = require('path');
 const jsonldSchema = require('@transmute/jsonld-schema');
 const { schemas } = require('../services/schemas');
 const rootTerms = require('./rootTerms.json');
+const stringify = require('json-stringify-deterministic')
 
 const contextPath = path.resolve(
   __dirname,
@@ -21,5 +22,5 @@ const contextPath = path.resolve(
     type: '@type',
     rootTerms,
   });
-  fs.writeFileSync(contextPath, JSON.stringify(context, null, 2));
+  fs.writeFileSync(contextPath, stringify(context, { space: '  ' }));
 })();


### PR DESCRIPTION
A recent change in the constructed/published context file consisted solely of reordering of properties:
https://github.com/w3c-ccg/traceability-vocab/commit/17060eacf1269a565f18169b462b645612c20962#diff-90421741a2d21ee4772ed49f297a37c7e6ac8e0c8b28bf1bae5159816642787e
17060eacf1269a565f18169b462b645612c20962 from cf24c12b4aaa0070fe727106f1b1be0d1fc171ef (#405).

Order of the properties does not affect the meaning in JSON-LD. It was not immediately obvious to me when examining the change that there were no actual/substantive changes - until passing both the old and new version through a deterministic serialization.

Diffing the changed context file shows a large diff:
```
diff <(git show 17060eacf1269a565f18169b462b645612c20962:contexts/traceability-v1.jsonld) <(git show 17060eacf1269a565f18169b462b645612c20962^:contexts/traceability-v1.jsonld)
```

But after piping the old and new version through `jq -S` to sort the properties, the resulting diff is empty:
```
diff <(git show 17060eacf1269a565f18169b462b645612c20962:contexts/traceability-v1.jsonld | jq -S .) <(git show 17060eacf1269a565f18169b462b645612c20962^:contexts/traceability-v1.jsonld | jq -S .)
```
Minimizing changes that have no effect helps make diffs to the context files more readable to see what actual changes are taking place.

This PR proposes to deterministically serialize the context file serialized using [json-stringify-deterministic](https://github.com/Kikobeats/json-stringify-deterministic), rather than using `JSON.stringify` which is not deterministic. This should help make future changes to the generated context file more readable in the commit history and diffs.

This is not a JSON-LD-significant serialization change; it is only for reducing variance in the JSON serialization, which is insignificant to JSON-LD processing (and to JSON parsing if your JSON implementation does not preserve property order).