### PR TITLE
feat: create Ag Grade Inspection & supporting schemas

### DIFF
--- a/docs/openapi/components/schemas/common/AgGradeInspection.yml
+++ b/docs/openapi/components/schemas/common/AgGradeInspection.yml
@@ -1,0 +1,513 @@
+$linkedData:
+  term: AgGradeInspection
+  '@id': https://w3id.org/traceability#AgGradeInspection
+title: Agriculture Grade Inspection
+description: Information regarding the grade inspection and results
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - AgGradeInspection
+      - type: string
+        const:
+          - AgGradeInspection
+  applicant:
+    title: Applicant
+    description: Entity that is applying for the inspection.
+    $ref: ./Entity.yml
+    $linkedData:
+      term: applicant
+      '@id': https://w3id.org/traceability#dfn-entities
+  facility:
+    title: Facility
+    description: Information on the inspection facility.
+    $ref: ./Place.yml
+    $linkedData:
+      term: facility
+      '@id': https://www.gs1.org/voc/Place
+  inspector:
+    title: Inspector
+    description: >-
+      Inspector performing the Agriculture Inspection.  The following link
+      provides further insight:
+      https://www.lawinsider.com/dictionary/food-inspector
+    $ref: ./Inspector.yml
+    $linkedData:
+      term: inspector
+      '@id': https://w3id.org/traceability#Inspector
+  delegateOf:
+    title: Delegate Of
+    description: Inspector is acting on behalf of this entity (common with many ag. inspections).
+    $ref: ./Entity.yml
+    $linkedData:
+      term: delegateOf
+      '@id': https://schema.org/Organization
+  regulatoryAgency:
+    title: Regulatory Agency
+    description: The regulatory agency responsible for the regulation (public or private) that mandates or implies the inspection.
+    $ref: ./Organization.yml
+    $linkedData:
+      term: regulatoryAgency
+      '@id': https://schema.org/Organization
+  inspectionStarted:
+    title: Inspection Started
+    description: Date and time inspection started in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    type: string
+    $linkedData:
+      term: inspectionStarted
+      '@id': https://schema.org/DateTime
+  inspectionEnded:
+    title: Inspection Ended
+    description: Date and time inspection ended in ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    type: string
+    $linkedData:
+      term: inspectionEnded
+      '@id': https://schema.org/DateTime
+  shipment:
+    title: Shipment
+    description: Details for a shipment of goods.
+    $ref: ./AgParcelDelivery.yml
+    $linkedData:
+      term: shipment
+      '@id': https://schema.org/ParcelDelivery
+  loadingStatus:
+    title: Loading Status Code
+    description: '"LO" for Loaded; "PU" for Partly Unloaded; "UL" for Unloaded; "LI" for Lot Inspection'
+    type: string
+    $linkedData:
+      term: loadingStatus
+      '@id': https://w3id.org/traceability#loadingStatus
+  carrierTypeName:
+    title: Carrier Type / Name
+    description: Type or name of carrier e.g. "Mechanical refrigerated", "open top trailer", "insulated box car".
+    type: string
+    $linkedData:
+      term: carrierTypeName
+      '@id': https://schema.org/additionalType
+  refrigerationUnitOn:
+    title: Refrigeration Unit On
+    description: Whether the carrier refrigeration unit was on.
+    type: boolean
+    $linkedData:
+      term: refrigerationUnitOn
+      '@id': https://w3id.org/traceability#refrigerationUnitOn
+  doorsOpen:
+    title: Doors Open
+    description: Whether the carrier doors were open.
+    type: boolean
+    $linkedData:
+      term: doorsOpen
+      '@id': https://w3id.org/traceability#doorsOpen
+  lots:
+    title: Lots
+    description: Information for each lot including samples, defects and grades.
+    type: array
+    items:
+      $ref: ./AgGradeInspectionLot.yml
+    $linkedData:
+      term: lot
+      '@id': https://w3id.org/traceability#AgGradeInspectionLot
+  generalRemarks:
+    title: General Remarks
+    description: Any general remarks containing information about the inspection. Note that remarks regarding specific lots should be in that lot entry's remarks section.
+    type: string
+    $linkedData:
+      term: generalRemarks
+      '@id': https://schema.org/description
+  estimatedCharges:
+    title: Estimated Charges
+    description: Estimated charges for inspection including fees, travel time, overtime, mileage, tolls, any other appropriate expenses.
+    $ref: ./PriceSpecification.yml
+    $linkedData:
+      term: estimatedCharges
+      '@id': https://schema.org/totalPrice
+additionalProperties: false
+example: |-
+  {
+    "type": "AgGradeInspection",
+    "facility": {
+      "type": [
+        "Place"
+      ],
+      "globalLocationNumber": "5449782976823",
+      "geo": {
+        "type": [
+          "GeoCoordinates"
+        ],
+        "latitude": "-79.6395",
+        "longitude": "178.5353"
+      },
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "Ace Foodstuffs",
+        "streetAddress": "853 Wisozk River",
+        "addressLocality": "New Noemyfort",
+        "addressRegion": "New Mexico",
+        "postalCode": "18047-2038",
+        "addressCountry": "Togo"
+      },
+      "unLocode": "DKCPH"
+    },
+    "inspector": {
+      "type": [
+        "Inspector"
+      ],
+      "person": {
+        "type": [
+          "Person"
+        ],
+        "firstName": "Jason",
+        "lastName": "Grant",
+        "email": "Santa43@example.org",
+        "phoneNumber": "555-460-4373",
+        "worksFor": {
+          "type": [
+            "Organization"
+          ],
+          "name": "Glayson & Co. Inspections",
+          "description": "Agricultural cleanliness & grade assurance",
+          "email": "Marina96@glaysonco.net",
+          "phoneNumber": "555-521-6143",
+          "faxNumber": "555-150-7668"
+        },
+        "jobTitle": "Principal Data Supervisor"
+      },
+      "qualification": [
+        {
+          "type": "Qualification",
+          "qualificationCategory": "Agricultural Security Analyst",
+          "qualificationValue": "Executive"
+        },
+        {
+          "type": "Qualification",
+          "qualificationCategory": "Future Metrics Planner",
+          "qualificationValue": "Coordinator"
+        },
+        {
+          "type": "Qualification",
+          "qualificationCategory": "Internal Identity Agent",
+          "qualificationValue": "Assistant"
+        }
+      ]
+    },
+    "regulatoryAgency": {
+      "type": "Organization",
+      "name": "CDFA",
+      "description": "California Department of Food and Agriculture",
+      "email": "Briana55@cdfa.ca.gov.org",
+      "phoneNumber": "555-467-2604",
+      "faxNumber": "+1-555-486-3154"
+    },
+    "delegateOf": {
+      "type": "Entity",
+      "entityType" : "Organization",
+      "name": "Glayson & Co. Inspections",
+      "description": "Agricultural cleanliness & grade assurance",
+      "email": "Marina96@glaysonco.net",
+      "phoneNumber": "555-521-6143",
+      "faxNumber": "555-150-7668"
+    },
+    "shipment": {
+      "type": [
+        "AgParcelDelivery"
+      ],
+      "deliveryAddress": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "Industrial Distributions",
+        "streetAddress": "853 Wisozk River",
+        "addressLocality": "New Noemyfort",
+        "addressRegion": "New Mexico",
+        "postalCode": "18047-2038",
+        "addressCountry": "Togo"
+      },
+      "originAddress": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "Green Fields",
+        "streetAddress": "97696 Weissnat Pines",
+        "addressLocality": "Reynabury",
+        "addressRegion": "North Dakota",
+        "postalCode": "51361-9603",
+        "addressCountry": "U.S."
+      },
+      "deliveryMethod": "Truck transport",
+      "trackingNumber": "866440000109",
+      "expectedArrival": "2021-03-14",
+      "specialInstructions": "The package is delicate so handle with appropriate caution.",
+      "consignee": {
+        "type": [
+          "Organization"
+        ],
+        "name": "Ace Foodstuffs",
+        "description": "Ag goods shipping & distribution",
+        "email": "Hipolito58@acefoodstuffs.org",
+        "phoneNumber": "555-895-1661",
+        "faxNumber": "555-497-2527"
+      },
+      "AgPackage": [
+        {
+          "type": [
+            "AgPackage"
+          ],
+          "packageName": "Avocados, Bulk",
+          "grade": "AA",
+          "responsibleParty": {
+            "type": "Entity",
+            "name": "Example Responsible Party Organization",
+            "email": "Chadrick_Gibson@example.com",
+            "phoneNumber": "+1-555-820-1520",
+            "entityType": "Organization"
+          },
+          "voicePickCode": "4642",
+          "date": "2021-03-14",
+          "labelImageUrl": "https://img.example.org/640/480/",
+          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "agProduct": [
+            {
+              "type": [
+                "AgProduct"
+              ],
+              "upc": "033383401508",
+              "plu": "94225",
+              "gtin": "033383401508",
+              "product": {
+                "type": [
+                  "Product"
+                ],
+                "manufacturer": {
+                  "type": [
+                    "Organization"
+                  ],
+                  "email": "Ashlee.Grady@example.net",
+                  "phoneNumber": "555-899-1399"
+                },
+                "name": "Avocados",
+                "description": "Avocados, 4 pack boxes",
+                "sizeOrAmount": {
+                  "type": [
+                    "QuantitativeValue"
+                  ],
+                  "unitCode": "hg/ha",
+                  "value": "60"
+                },
+                "weight": {
+                  "type": [
+                    "QuantitativeValue"
+                  ],
+                  "unitCode": "hg/ha",
+                  "value": "6960"
+                },
+                "sku": "81055399441"
+              },
+              "scientificName": "Persea americana",
+              "labelImageUrl": "https://img.example.org/033383401508/640/480/",
+              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "name": "Avocados",
+              "productImageUrl": "https://img.example.org/102934920857/937/903/",
+              "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+            }
+          ]
+        }
+      ],
+      "shipper": {
+        "type": "Organization",
+        "name": "Green Fields",
+        "description": "Growing & packaging for high quality produce",
+        "email": "sales@greenfields.org",
+        "phoneNumber": "+1-555-865-8495"
+      },
+      "purchaser": {
+        "type": "Organization",
+        "name": "Ace Foodstuffs",
+        "description": "Ag goods shipping & distribution",
+        "email": "Hipolito58@acefoodstuffs.org",
+        "phoneNumber": "555-895-1661",
+        "faxNumber": "555-497-2527"
+      },
+      "carrier": {
+        "type": [
+          "Organization"
+        ],
+        "email": "Adaline29@example.com",
+        "phoneNumber": "+1 555-234-9983"
+      },
+      "broker": {
+        "type": "Organization",
+        "name": "Cole United",
+        "leiCode": "54321351219389121979"
+      }
+    },
+    "applicant": {
+      "type" : "Entity",
+      "entityType": "Organization",
+      "name" : "Jessica Sherawat",
+      "email": "Jessica58@example.com",
+      "phoneNumber": "+1-555-581-2077"
+    },
+    "inspectionStarted": "2020-03-15T14:30-08:00",
+    "inspectionEnded": "2020-03-15T17:30-08:00",
+    "loadingStatus": "UL",
+    "carrierTypeName": "Mechanical refrigerated",
+    "refrigerationUnitOn": true,
+    "doorsOpen": true,
+    "lots": [
+      {
+        "type": "AgGradeInspectionLot",
+        "agProduct": {
+          "type": [
+            "AgProduct"
+          ],
+          "upc": "033383401508",
+          "plu": "94225",
+          "gtin": "033383401508",
+          "product": {
+            "type": [
+              "Product"
+            ],
+            "manufacturer": {
+              "type": [
+                "Organization"
+              ],
+              "email": "Ashlee.Grady@example.net",
+              "phoneNumber": "555-899-1399"
+            },
+            "name": "Avocados",
+            "description": "Avocados, 4 pack boxes",
+            "sizeOrAmount": {
+              "type": [
+                "QuantitativeValue"
+              ],
+              "unitCode": "hg/ha",
+              "value": "60"
+            },
+            "weight": {
+              "type": [
+                "QuantitativeValue"
+              ],
+              "unitCode": "hg/ha",
+              "value": "6960"
+            },
+            "sku": "81055399441"
+          },
+          "scientificName": "Persea americana",
+          "labelImageUrl": "https://img.example.org/033383401508/640/480/",
+          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "name": "Avocados",
+          "productImageUrl": "https://img.example.org/102934920857/937/903/",
+          "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+        },
+        "lotIdentifier": "Main Lot",
+        "numberContainers": 320,
+        "countInspected": true,
+        "brandMarkings": "\"Green Fields\"; Packed by Ace Foodstuffs; Produce of U.S.A.",
+        "samples": [
+          {
+            "type": "AgGradeInspectionSample",
+            "sampleSize": 10,
+            "sampleSizeUnits": "items",
+            "sampleProperties": [
+              {
+                "type": "AgGradeInspectionSampleProperty",
+                "propertyName": "Temp °F",
+                "propertyValue": "53"
+              },
+              {
+                "type": "AgGradeInspectionSampleProperty",
+                "propertyName": "BMR Quality D",
+                "propertyValue": "2"
+              },
+              {
+                "type": "AgGradeInspectionSampleProperty",
+                "propertyName": "BMR Quality SD",
+                "propertyValue": "0"
+              },
+              {
+                "type": "AgGradeInspectionSampleProperty",
+                "propertyName": "BMR Quality DK",
+                "propertyValue": "0"
+              },
+              {
+                "type": "AgGradeInspectionSampleProperty",
+                "propertyName": "Caked Dirt Quality D",
+                "propertyValue": "0"
+              },
+              {
+                "type": "AgGradeInspectionSampleProperty",
+                "propertyName": "Caked Dirt Quality SD",
+                "propertyValue": "0"
+              },
+              {
+                "type": "AgGradeInspectionSampleProperty",
+                "propertyName": "Caked Dirt Quality DK",
+                "propertyValue": "0"
+              },
+              {
+                "type": "AgGradeInspectionSampleProperty",
+                "propertyName": "< 1-3/4 In. Dia.",
+                "propertyValue": "1"
+              },
+              {
+                "type": "AgGradeInspectionSampleProperty",
+                "propertyName": "> 3 In. Dia.",
+                "propertyValue": "2"
+              }
+            ]
+          }
+        ],
+        "defects": [
+          {
+            "type": "AgGradeInspectionDefect",
+            "offsizeDefect": "Quality - Staining",
+            "averageDefects": 6,
+            "seriousDamage": 2,
+            "verySeriousDamage": 0
+          },
+          {
+            "type": "AgGradeInspectionDefect",
+            "offsizeDefect": "Quality - Dry Sunken Areas",
+            "averageDefects": 2,
+            "seriousDamage": 0,
+            "verySeriousDamage": 0
+          },
+          {
+            "type": "AgGradeInspectionDefect",
+            "offsizeDefect": "Quality - Surface Mold",
+            "averageDefects": 1,
+            "seriousDamage": 0,
+            "verySeriousDamage": 0
+          }
+        ],
+        "grade": {
+          "type": "AgGradeInspectionResult",
+          "gradeInspected": "U.S. No. 1",
+          "requirementsMet": true
+        },
+        "remarks": "Size: Mostly large, many medium, few small",
+        "minTemperature": {
+          "type": [
+            "MeasuredValue"
+          ],
+          "value": 51,
+          "unitCode": "FAH"
+        },
+        "maxTemperature": {
+          "type": [
+            "MeasuredValue"
+          ],
+          "value": 55,
+          "unitCode": "FAH"
+        },
+        "pli": "Fed-State ID-345-0515"
+      }
+    ],
+    "estimatedCharges": "$135.00"
+  }

--- a/docs/openapi/components/schemas/common/AgGradeInspectionDefect.yml
+++ b/docs/openapi/components/schemas/common/AgGradeInspectionDefect.yml
@@ -1,0 +1,61 @@
+$linkedData:
+  term: AgGradeInspectionDefect
+  '@id': https://w3id.org/traceability#AgGradeInspectionDefect
+title: Agriculture Grade Inspection Defect
+description: Information on a type of offsize / defect observed.
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - AgGradeInspectionDefect
+      - type: string
+        const:
+          - AgGradeInspectionDefect
+  offsizeDefect:
+    title: Offsize / Defect
+    description: Brief description of this offsize / defect.
+    type: string
+    $linkedData:
+      term: offsizeDefect
+      '@id': https://schema.org/description
+  averageDefects:
+    title: Average Defects
+    description: Percent of sample items with defects for the grade standards.
+    type: number
+    $linkedData:
+      term: averageDefects
+      '@id': https://schema.org/Number
+  damage:
+    title: Percent Damage
+    description: Percent of sample items with damage (but not serious or very serious damage).
+    type: number
+    $linkedData:
+      term: damage
+      '@id': https://schema.org/Number
+  seriousDamage:
+    title: Serious Damage
+    description: Number of sample items with serious damage (incl. decay, soft rot, or soft).
+    type: number
+    $linkedData:
+      term: seriousDamage
+      '@id': https://schema.org/Number
+  verySeriousDamage:
+    title: Very Serious Damage
+    description: Number of sample items with very serious damage (incl. significant decay, soft rot, or soft).
+    type: number
+    $linkedData:
+      term: verySeriousDamage
+      '@id': https://schema.org/Number
+additionalProperties: false
+example: |-
+  {
+    "type": "AgGradeInspectionDefect",
+    "offsizeDefect": "Quality - Dry Sunken Areas",
+    "averageDefects": 2,
+    "seriousDamage": 0,
+    "verySeriousDamage": 0
+  }

--- a/docs/openapi/components/schemas/common/AgGradeInspectionLot.yml
+++ b/docs/openapi/components/schemas/common/AgGradeInspectionLot.yml
@@ -1,0 +1,255 @@
+$linkedData:
+  term: AgGradeInspectionLot
+  '@id': https://w3id.org/traceability#AgGradeInspectionLot
+title: Agriculture Grade Inspection Lot
+description: Information regarding the inspected lot including samples, defects and grades.
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - AgGradeInspectionLot
+      - type: string
+        const:
+          - AgInspectionLotesult
+  agProduct:
+    title: Product
+    description: The product inspected.
+    $ref: ./AgProduct.yml
+    $linkedData:
+      term: agProduct
+      '@id': https://w3id.org/traceability#AgProduct
+  lotIdentifier:
+    title: Lot Identifier
+    description: Use to further add to identification of the lot inspected, or to distinguish between lots / sublots for certification purposes (e.g. "Loaded", "Main Lot", "U.S. Fancy", "Film Wrapped").
+    type: string
+    $linkedData:
+      term: lotIdentifier
+      '@id': https://schema.org/identifier
+  numberContainers:
+    title: Number of Containers
+    description: Number of containers in the lot or portion of lot inspected, as well as type of package or container in which the product was shipped (e.g. "672 cartons", "20,000 LBS.").
+    type: number
+    $linkedData:
+      term: numberContainers
+      '@id': https://schema.org/Integer
+  countInspected:
+    title: Count Inspected
+    description: Whether the number of containers was accurately inspected. If false, report the reason for not being able to count the containers in the "Remarks" section.
+    type: boolean
+    $linkedData:
+      term: countInspected
+      '@id': https://w3id.org/traceability#countInspected
+  brandMarkings:
+    title: Brand / Markings
+    description: Brand or Markings on inspected product. ALways have brand name enclosed in quotation marks as first entry (e.g. "Unkle Okey's Onions"), with other markings as necessary to identify lot NOT enclosed in quotation marks (e.g. U.S. No. 1; or Grown & Packed by Unkle Okey, Inc.; or Produce of U.S.A.).
+    type: string
+    $linkedData:
+      term: brandMarkings
+      '@id': https://schema.org/description    
+  samples:
+    title: Samples
+    description: List of samples taken for this lot.
+    type: array
+    items:
+      $ref: ./AgGradeInspectionSample.yml
+    $linkedData:
+      term: sample
+      '@id': https://w3id.org/traceability#AgGradeInspectionSample
+  defects:
+    title: Defects
+    description: List of defects observed for this lot.
+    type: array
+    items:
+      $ref: ./AgGradeInspectionDefect.yml
+    $linkedData:
+      term: defect
+      '@id': https://w3id.org/traceability#AgGradeInspectionDefect
+  grade:
+    title: Grade
+    description: The grade assigned to this lot.
+    $ref: ./AgGradeInspectionResult.yml
+    $linkedData:
+      term: grade
+      '@id': https://w3id.org/traceability#AgGradeInspectionResult
+  remarks:
+    title: Remarks
+    description: Additional information, such as a description of the lot (e.g. size, color, quality). Generally includes factors which do not affect grade.
+    type: string
+    $linkedData:
+      term: remarks
+      '@id': https://schema.org/description
+  minTemperature:
+    title: Minimum Temperature
+    description: Minimum product temperature measured.
+    $ref: ./MeasuredValue.yml
+    $linkedData:
+      term: minTemperature
+      '@id': https://schema.org/MeasuredValue
+  maxTemperature:
+    title: Maximum Temperature
+    description: Maximum product temperature measured.
+    $ref: ./MeasuredValue.yml
+    $linkedData:
+      term: maxTemperature
+      '@id': https://schema.org/MeasuredValue
+  pli:
+    title: PLI
+    description: "Positive Lot Identification (PLI) is the application of identifying marks to an inspected lot. For more information see: https://www.ams.usda.gov/publications/content/positive-lot-identification-pli-manual-worksheets"
+    type: string
+    $linkedData:
+      term: pli
+      '@id': https://w3id.org/traceability#pli
+additionalProperties: false
+example: |-
+  {
+    "type": "AgGradeInspectionLot",
+    "agProduct": {
+      "type": [
+        "AgProduct"
+      ],
+      "upc": "033383401508",
+      "plu": "94225",
+      "gtin": "033383401508",
+      "product": {
+        "type": [
+          "Product"
+        ],
+        "manufacturer": {
+          "type": [
+            "Organization"
+          ],
+          "email": "Ashlee.Grady@example.net",
+          "phoneNumber": "555-899-1399"
+        },
+        "name": "Avocados",
+        "description": "Avocados, 4 pack boxes",
+        "sizeOrAmount": {
+          "type": [
+            "QuantitativeValue"
+          ],
+          "unitCode": "hg/ha",
+          "value": "60"
+        },
+        "weight": {
+          "type": [
+            "QuantitativeValue"
+          ],
+          "unitCode": "hg/ha",
+          "value": "6960"
+        },
+        "sku": "81055399441"
+      },
+      "scientificName": "Persea americana",
+      "labelImageUrl": "https://img.example.org/033383401508/640/480/",
+      "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "name": "Avocados",
+      "productImageUrl": "https://img.example.org/102934920857/937/903/",
+      "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+    },
+    "lotIdentifier": "Main Lot",
+    "numberContainers": 320,
+    "countInspected": true,
+    "brandMarkings": "\"Green Fields\"; Packed by Ace Foodstuffs; Produce of U.S.A.",
+    "samples": [
+      {
+        "type": "AgGradeInspectionSample",
+        "sampleSize": 10,
+        "sampleSizeUnits": "items",
+        "sampleProperties": [
+          {
+            "type": "AgGradeInspectionSampleProperty",
+            "propertyName": "Temp °F",
+            "propertyValue": "53"
+          },
+          {
+            "type": "AgGradeInspectionSampleProperty",
+            "propertyName": "BMR Quality D",
+            "propertyValue": "2"
+          },
+          {
+            "type": "AgGradeInspectionSampleProperty",
+            "propertyName": "BMR Quality SD",
+            "propertyValue": "0"
+          },
+          {
+            "type": "AgGradeInspectionSampleProperty",
+            "propertyName": "BMR Quality DK",
+            "propertyValue": "0"
+          },
+          {
+            "type": "AgGradeInspectionSampleProperty",
+            "propertyName": "Caked Dirt Quality D",
+            "propertyValue": "0"
+          },
+          {
+            "type": "AgGradeInspectionSampleProperty",
+            "propertyName": "Caked Dirt Quality SD",
+            "propertyValue": "0"
+          },
+          {
+            "type": "AgGradeInspectionSampleProperty",
+            "propertyName": "Caked Dirt Quality DK",
+            "propertyValue": "0"
+          },
+          {
+            "type": "AgGradeInspectionSampleProperty",
+            "propertyName": "< 1-3/4 In. Dia.",
+            "propertyValue": "1"
+          },
+          {
+            "type": "AgGradeInspectionSampleProperty",
+            "propertyName": "> 3 In. Dia.",
+            "propertyValue": "2"
+          }
+        ]
+      }
+    ],
+    "defects": [
+      {
+        "type": "AgGradeInspectionDefect",
+        "offsizeDefect": "Quality - Staining",
+        "averageDefects": 6,
+        "seriousDamage": 2,
+        "verySeriousDamage": 0
+      },
+      {
+        "type": "AgGradeInspectionDefect",
+        "offsizeDefect": "Quality - Dry Sunken Areas",
+        "averageDefects": 2,
+        "seriousDamage": 0,
+        "verySeriousDamage": 0
+      },
+      {
+        "type": "AgGradeInspectionDefect",
+        "offsizeDefect": "Quality - Surface Mold",
+        "averageDefects": 1,
+        "seriousDamage": 0,
+        "verySeriousDamage": 0
+      }
+    ],
+    "grade": {
+      "type": "AgGradeInspectionResult",
+      "gradeInspected": "U.S. No. 1",
+      "requirementsMet": true
+    },
+    "remarks": "Size: Mostly large, many medium, few small",
+    "minTemperature": {
+      "type": [
+        "MeasuredValue"
+      ],
+      "value": 51,
+      "unitCode": "FAH"
+    },
+    "maxTemperature": {
+      "type": [
+        "MeasuredValue"
+      ],
+      "value": 55,
+      "unitCode": "FAH"
+    },
+    "pli": "Fed-State ID-345-0515"
+  }

--- a/docs/openapi/components/schemas/common/AgGradeInspectionResult.yml
+++ b/docs/openapi/components/schemas/common/AgGradeInspectionResult.yml
@@ -1,0 +1,45 @@
+$linkedData:
+  term: AgGradeInspectionResult
+  '@id': https://w3id.org/traceability#AgGradeInspectionResult
+title: Agriculture Grade Inspection Result
+description: Information on the grade assigned to an inspected lot.
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - AgGradeInspectionResult
+      - type: string
+        const:
+          - AgGradeInspectionResult
+  gradeInspected:
+    title: Grade Inspected
+    description: Grade the lot was inspected for, even if the requirements were not met. When there is no U.S. grade standard for a product, and a quality and condition inspection is performed, enter "No established U.S. Grade".
+    type: string
+    $linkedData:
+      term: gradeInspected
+      '@id': https://w3id.org/traceability#gradeInspected
+  requirementsMet:
+    title: Requirements Met
+    description: Whether the inspected lot meets grade standards or other specifications on which the inspection was based.
+    type: boolean
+    $linkedData:
+      term: requirementsMet
+      '@id': https://w3id.org/traceability#requirementsMet
+  details:
+    title: Details
+    description: Additional information regarding inspection grade. In some circumstances failing lots should include account condition details such as "Green peppers in a red lot", or "Staining". For certain fruits condition details should be included even for passing lots, e.g. "Decay being a factor of condition".
+    type: string
+    $linkedData:
+      term: details
+      '@id': https://schema.org/description
+additionalProperties: false
+example: |-
+  {
+    "type": "AgGradeInspectionResult",
+    "gradeInspected": "U.S. No. 1",
+    "requirementsMet": true
+  }

--- a/docs/openapi/components/schemas/common/AgGradeInspectionSample.yml
+++ b/docs/openapi/components/schemas/common/AgGradeInspectionSample.yml
@@ -1,0 +1,94 @@
+$linkedData:
+  term: AgGradeInspectionSample
+  '@id': https://w3id.org/traceability#AgGradeInspectionSample
+title: Agriculture Grade Inspection Sample
+description: Details regarding a sample taken from an inspected lot.
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - AgGradeInspectionSample
+      - type: string
+        const:
+          - AgGradeInspectionSample
+  sampleSizeValue:
+    title: Sample Size Value
+    description: Value for sample size (not including units used), e.g. "24".
+    type: number
+    $linkedData:
+      term: sampleSizeValue
+      '@id': https://schema.org/Number
+  sampleSizeUnits:
+    title: Sample Size Unit
+    description: Unit used, e.g. "items", "lbs", "kg".
+    type: string
+    $linkedData:
+      term: sampleSizeUnit
+      '@id': https://schema.org/unitText
+  sampleProperties:
+    title: Sample Properties
+    description: Properties of the current sample, indicating information such as "25 green/breakers", "4 percent decay or soft", "0 percent off-size".
+    type: array
+    items:
+      $ref: ./AgGradeInspectionSampleProperty.yml
+    $linkedData:
+      term: sampleProperty
+      '@id': https://w3id.org/traceability#AgGradeInspectionSampleProperty
+additionalProperties: false
+example: |-
+  {
+    "type": "AgGradeInspectionSample",
+    "sampleSize": 10,
+    "sampleSizeUnits": "items",
+    "sampleProperties": [
+      {
+        "type": "AgGradeInspectionSampleProperty",
+        "propertyName": "Temp °F",
+        "propertyValue": "53"
+      },
+      {
+        "type": "AgGradeInspectionSampleProperty",
+        "propertyName": "BMR Quality D",
+        "propertyValue": "2"
+      },
+      {
+        "type": "AgGradeInspectionSampleProperty",
+        "propertyName": "BMR Quality SD",
+        "propertyValue": "0"
+      },
+      {
+        "type": "AgGradeInspectionSampleProperty",
+        "propertyName": "BMR Quality DK",
+        "propertyValue": "0"
+      },
+      {
+        "type": "AgGradeInspectionSampleProperty",
+        "propertyName": "Caked Dirt Quality D",
+        "propertyValue": "0"
+      },
+      {
+        "type": "AgGradeInspectionSampleProperty",
+        "propertyName": "Caked Dirt Quality SD",
+        "propertyValue": "0"
+      },
+      {
+        "type": "AgGradeInspectionSampleProperty",
+        "propertyName": "Caked Dirt Quality DK",
+        "propertyValue": "0"
+      },
+      {
+        "type": "AgGradeInspectionSampleProperty",
+        "propertyName": "< 1-3/4 In. Dia.",
+        "propertyValue": "1"
+      },
+      {
+        "type": "AgGradeInspectionSampleProperty",
+        "propertyName": "> 3 In. Dia.",
+        "propertyValue": "2"
+      }
+    ]
+  }

--- a/docs/openapi/components/schemas/common/AgGradeInspectionSampleProperty.yml
+++ b/docs/openapi/components/schemas/common/AgGradeInspectionSampleProperty.yml
@@ -1,0 +1,38 @@
+$linkedData:
+  term: AgGradeInspectionSampleProperty
+  '@id': https://w3id.org/traceability#AgGradeInspectionSampleProperty
+title: Agriculture Grade Inspection Sample Property
+description: A property of some agriculture grade inspection sample.
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - AgGradeInspectionSampleProperty
+      - type: string
+        const:
+          - AgGradeInspectionSampleProperty
+  propertyName:
+    title: Property Name
+    description: Name of the sample property observed (e.g. "Percent off-size", "Type of Defects", "Net Wt. Within 2 lb. Range").
+    type: string
+    $linkedData:
+      term: propertyName
+      '@id': https://schema.org/name
+  propertyValue:
+    title: Property Value
+    description: Value of the sample property observed (e.g. "0", "SIL CT", "Yes").
+    type: string
+    $linkedData:
+      term: propertValue
+      '@id': https://schema.org/description
+additionalProperties: false
+example: |-
+  {
+    "type": "AgGradeInspectionSampleProperty",
+    "propertyName": "Temp °F",
+    "propertyValue": "53"
+  }

--- a/docs/openapi/components/schemas/common/AgParcelDelivery.yml
+++ b/docs/openapi/components/schemas/common/AgParcelDelivery.yml
@@ -85,7 +85,7 @@ properties:
     description: Item(s) being shipped.
     type: array
     items:
-      $ref: ./Product.yml
+      $ref: ./AgPackage.yml
     $linkedData:
       term: AgPackage
       '@id': https://w3id.org/traceability#AgPackage
@@ -216,7 +216,71 @@ example: |-
       "phoneNumber": "555-895-1661",
       "faxNumber": "555-497-2527"
     },
-    "AgPackage": [],
+    "AgPackage": [
+      {
+        "type": [
+          "AgPackage"
+        ],
+        "packageName": "Avocados, Bulk",
+        "grade": "AA",
+        "responsibleParty": {
+          "type": "Entity",
+          "name": "Example Responsible Party Organization",
+          "email": "Chadrick_Gibson@example.com",
+          "phoneNumber": "+1-555-820-1520",
+          "entityType": "Organization"
+        },
+        "voicePickCode": "4642",
+        "date": "2021-03-14",
+        "labelImageUrl": "https://img.example.org/640/480/",
+        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "agProduct": [
+          {
+            "type": [
+              "AgProduct"
+            ],
+            "upc": "033383401508",
+            "plu": "94225",
+            "gtin": "033383401508",
+            "product": {
+              "type": [
+                "Product"
+              ],
+              "manufacturer": {
+                "type": [
+                  "Organization"
+                ],
+                "email": "Ashlee.Grady@example.net",
+                "phoneNumber": "555-899-1399"
+              },
+              "name": "Avocados",
+              "description": "Avocados, 4 pack boxes",
+              "sizeOrAmount": {
+                "type": [
+                  "QuantitativeValue"
+                ],
+                "unitCode": "hg/ha",
+                "value": "60"
+              },
+              "weight": {
+                "type": [
+                  "QuantitativeValue"
+                ],
+                "unitCode": "hg/ha",
+                "value": "6960"
+              },
+              "sku": "81055399441"
+            },
+            "scientificName": "Persea americana",
+            "labelImageUrl": "https://img.example.org/033383401508/640/480/",
+            "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "name": "Avocados",
+            "productImageUrl": "https://img.example.org/102934920857/937/903/",
+            "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+          }
+        ]
+      }
+    ],
     "shipper": {
       "type": "Organization",
       "name": "Green Fields",

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -32,6 +32,78 @@ paths:
                 $ref: './components/schemas/common/AgActivity.yml'
     
 
+  /schemas/common/AgGradeInspection.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/AgGradeInspection.yml'
+    
+
+  /schemas/common/AgGradeInspectionDefect.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/AgGradeInspectionDefect.yml'
+    
+
+  /schemas/common/AgGradeInspectionLot.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/AgGradeInspectionLot.yml'
+    
+
+  /schemas/common/AgGradeInspectionResult.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/AgGradeInspectionResult.yml'
+    
+
+  /schemas/common/AgGradeInspectionSample.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/AgGradeInspectionSample.yml'
+    
+
+  /schemas/common/AgGradeInspectionSampleProperty.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/AgGradeInspectionSampleProperty.yml'
+    
+
   /schemas/common/AgInspectionReport.yml:
     get:
       tags:


### PR DESCRIPTION
This PR introduces a new `AgGradeInspection` schema, as well as a number of additional supporting schemas. A minor fix in `AgParcelDelivery` was necessary as well.

The original intention was to replace `AgInspectionReport`, but after investigating I believe it wouldn't be possible to create a general ag inspection form that encompasses all of the information necessary to describe ag grade inspections. I'll likely update `AgInspectionReport` as well as other ag inspection schemas in later PRs.