### PR TITLE
Fix for bugged indent on IATA AWB example

### DIFF
--- a/docs/openapi/components/schemas/common/IATAAirWaybill.yml
+++ b/docs/openapi/components/schemas/common/IATAAirWaybill.yml
@@ -481,118 +481,118 @@ example: |-
       "address": {
         "type": "PostalAddress",
         "addressLocality": "Xiamen"
-      },
-      "carrier": {
-        "type": "Organization",
-        "name": "On Time Express Limited",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Suite 605, 6/F, Hai Tian Logistics Centre, #1 Hai Tian Road",
-          "addressLocality": "Hu-Li District",
-          "addressRegion": "Xiamen",
-          "addressCountry": "CN"
-        }
-      },
-      "conditionsOfContract": "It is agreed that the goods described herein are accepted in apparent good order and condition (except as noted) for carriage SUBJECT TO THE CONDITIONS OF CONTRACT ON THE REVERSE HEREOF. ALL GOODS MAY BE CARRIED BY ANY OTHER MEANS INCLUDING ROAD OR ANY OTHER CARRIER UNLESS SPECIFIC CONTRARY INSTRUCTIONS ARE GIVEN HEREON BY THE SHIPPER, AND SHIPPER AGREES THAT THE SHIPMENT MAY BE CARRIED VIA INTERMEDIATE STOPPING PLACES WHICH THE CARRIER DEEMS APPROPRIATE. THE SHIPPER'S ATTENTION IS DRAWN TO THE NOTICE CONCERNING CARRIER'S LIMITATION OF LIABILITY. Shipper may increase such limitation of liability by declaring a higher value for carriage and paying a supplemental charge if required.",
-      "shipper": {
-        "type": "Organization",
-        "name": "Xxinau Manufacturing Co. Ltd.",
-        "description": "Advanced Production - Delivered",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "Xin Fei Da Dao 139",
-          "addressLocality": "Xindao",
-          "addressRegion": "Fujian Province",
-          "postalCode": "361100",
-          "addressCountry": "CN"
-        }
-      },
-      "shippersAccountNumber": "Trade",
-      "consignee": {
-        "type": "Organization",
-        "name": "By Acre",
-        "address": {
-          "type": "PostalAddress",
-          "streetAddress": "I.C.Modewegs Vej 1",
-          "addressLocality": "Kgs. Lyngby",
-          "postalCode": "2800",
-          "addressCountry": "DK"
-        }
-      },
-      "requestedRouting": [
-        {
-          "type": "ShippingStop",
-          "from": {
-            "type": "Place",
-            "address": {
-              "type": "PostalAddress",
-              "addressLocality": "Xiamen"
-            }
-          },
-          "to": {
-            "type": "Place",
-            "iataAirportCode": "LUX"
-          },
-          "by": {
-            "type": "Organization",
-            "iataCarrierCode": "CV"
+      }
+    },
+    "carrier": {
+      "type": "Organization",
+      "name": "On Time Express Limited",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "Suite 605, 6/F, Hai Tian Logistics Centre, #1 Hai Tian Road",
+        "addressLocality": "Hu-Li District",
+        "addressRegion": "Xiamen",
+        "addressCountry": "CN"
+      }
+    },
+    "conditionsOfContract": "It is agreed that the goods described herein are accepted in apparent good order and condition (except as noted) for carriage SUBJECT TO THE CONDITIONS OF CONTRACT ON THE REVERSE HEREOF. ALL GOODS MAY BE CARRIED BY ANY OTHER MEANS INCLUDING ROAD OR ANY OTHER CARRIER UNLESS SPECIFIC CONTRARY INSTRUCTIONS ARE GIVEN HEREON BY THE SHIPPER, AND SHIPPER AGREES THAT THE SHIPMENT MAY BE CARRIED VIA INTERMEDIATE STOPPING PLACES WHICH THE CARRIER DEEMS APPROPRIATE. THE SHIPPER'S ATTENTION IS DRAWN TO THE NOTICE CONCERNING CARRIER'S LIMITATION OF LIABILITY. Shipper may increase such limitation of liability by declaring a higher value for carriage and paying a supplemental charge if required.",
+    "shipper": {
+      "type": "Organization",
+      "name": "Xxinau Manufacturing Co. Ltd.",
+      "description": "Advanced Production - Delivered",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "Xin Fei Da Dao 139",
+        "addressLocality": "Xindao",
+        "addressRegion": "Fujian Province",
+        "postalCode": "361100",
+        "addressCountry": "CN"
+      }
+    },
+    "shippersAccountNumber": "Trade",
+    "consignee": {
+      "type": "Organization",
+      "name": "By Acre",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "I.C.Modewegs Vej 1",
+        "addressLocality": "Kgs. Lyngby",
+        "postalCode": "2800",
+        "addressCountry": "DK"
+      }
+    },
+    "requestedRouting": [
+      {
+        "type": "ShippingStop",
+        "from": {
+          "type": "Place",
+          "address": {
+            "type": "PostalAddress",
+            "addressLocality": "Xiamen"
           }
         },
-        {
-          "type": "ShippingStop",
-          "to": {
-            "type": "Place",
-            "iataAirportCode": "CPH"
-          },
-          "by": {
-            "type": "Organization",
-            "iataCarrierCode": "CV"
-          }
-        }
-      ],
-      "destinationAirport": {
-        "type": "Place",
-        "iataAirportCode": "CPH",
-        "address": {
-          "type": "PostalAddress",
-          "addressLocality": "Copenhagen"
+        "to": {
+          "type": "Place",
+          "iataAirportCode": "LUX"
+        },
+        "by": {
+          "type": "Organization",
+          "iataCarrierCode": "CV"
         }
       },
-      "requestedFlight": "CV9586",
-      "requestedDate": "2021-07-31",
-      "accountingInformation": "Freight Collect",
-      "currency": "USD",
-      "chargeCodes": "CP—destination collect cash",
-      "weightValuationChargesType": "Collect",
-      "otherChargesType": "Prepaid",
-      "declaredValueForCarriage": "NVD",
-      "declaredValueForCustoms": "As per invoice",
-      "amountOfInsurance": "NIL",
-      "handlingInformation": "TOTAL: 13PLT (S) ONLY. INVOICE & PACKING LIST ATTD",
-      "consignmentRatingDetails": [
-        {
-          "type": "ConsignmentRatingDetail",
-          "numberOfPieces": 13,
-          "grossWeight": 971,
-          "grossWeightUnit": "Kg",
-          "rateClass": "Q—quantity rate",
-          "chargeableWeight": 2480.5,
-          "total": "As arranged",
-          "natureAndVolumeOfGoods": "ROLLATORS; DIMS: 2 / 118 X 89 X 87 CM, 11 /118 x 89 X 113 CM, 14.88 CBM"
+      {
+        "type": "ShippingStop",
+        "to": {
+          "type": "Place",
+          "iataAirportCode": "CPH"
+        },
+        "by": {
+          "type": "Organization",
+          "iataCarrierCode": "CV"
         }
-      ],
-      "totalNumberOfPieces": 13,
-      "totalGrossWeight": 971,
-      "totalCharge": "As arranged",
-      "collectChargeDeclaration": {
-        "weightCharge": "As arranged",
-        "total": "As arranged"
-      },
-      "shippersCertificationBox": "On Time Express Limited, Suite 605, 6/F, Hai Tian Logistics Centre, #1 Hai Tian Road, Hu-Li District, Xiamen, P.R.China",
-      "executedOn": "2021-07-31",
-      "executedAt": {
-        "type": "Place",
-        "iataAirportCode": "XMN"
       }
+    ],
+    "destinationAirport": {
+      "type": "Place",
+      "iataAirportCode": "CPH",
+      "address": {
+        "type": "PostalAddress",
+        "addressLocality": "Copenhagen"
+      }
+    },
+    "requestedFlight": "CV9586",
+    "requestedDate": "2021-07-31",
+    "accountingInformation": "Freight Collect",
+    "currency": "USD",
+    "chargeCodes": "CP—destination collect cash",
+    "weightValuationChargesType": "Collect",
+    "otherChargesType": "Prepaid",
+    "declaredValueForCarriage": "NVD",
+    "declaredValueForCustoms": "As per invoice",
+    "amountOfInsurance": "NIL",
+    "handlingInformation": "TOTAL: 13PLT (S) ONLY. INVOICE & PACKING LIST ATTD",
+    "consignmentRatingDetails": [
+      {
+        "type": "ConsignmentRatingDetail",
+        "numberOfPieces": 13,
+        "grossWeight": 971,
+        "grossWeightUnit": "Kg",
+        "rateClass": "Q—quantity rate",
+        "chargeableWeight": 2480.5,
+        "total": "As arranged",
+        "natureAndVolumeOfGoods": "ROLLATORS; DIMS: 2 / 118 X 89 X 87 CM, 11 /118 x 89 X 113 CM, 14.88 CBM"
+      }
+    ],
+    "totalNumberOfPieces": 13,
+    "totalGrossWeight": 971,
+    "totalCharge": "As arranged",
+    "collectChargeDeclaration": {
+      "weightCharge": "As arranged",
+      "total": "As arranged"
+    },
+    "shippersCertificationBox": "On Time Express Limited, Suite 605, 6/F, Hai Tian Logistics Centre, #1 Hai Tian Road, Hu-Li District, Xiamen, P.R.China",
+    "executedOn": "2021-07-31",
+    "executedAt": {
+      "type": "Place",
+      "iataAirportCode": "XMN"
     }
   }

--- a/docs/openapi/components/schemas/credentials/IATAAirWaybillCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/IATAAirWaybillCertificate.yml
@@ -73,126 +73,126 @@ example: |-
         "address": {
           "type": "PostalAddress",
           "addressLocality": "Xiamen"
-        },
-        "carrier": {
-          "type": "Organization",
-          "name": "On Time Express Limited",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "Suite 605, 6/F, Hai Tian Logistics Centre, #1 Hai Tian Road",
-            "addressLocality": "Hu-Li District",
-            "addressRegion": "Xiamen",
-            "addressCountry": "CN"
-          }
-        },
-        "conditionsOfContract": "It is agreed that the goods described herein are accepted in apparent good order and condition (except as noted) for carriage SUBJECT TO THE CONDITIONS OF CONTRACT ON THE REVERSE HEREOF. ALL GOODS MAY BE CARRIED BY ANY OTHER MEANS INCLUDING ROAD OR ANY OTHER CARRIER UNLESS SPECIFIC CONTRARY INSTRUCTIONS ARE GIVEN HEREON BY THE SHIPPER, AND SHIPPER AGREES THAT THE SHIPMENT MAY BE CARRIED VIA INTERMEDIATE STOPPING PLACES WHICH THE CARRIER DEEMS APPROPRIATE. THE SHIPPER'S ATTENTION IS DRAWN TO THE NOTICE CONCERNING CARRIER'S LIMITATION OF LIABILITY. Shipper may increase such limitation of liability by declaring a higher value for carriage and paying a supplemental charge if required.",
-        "shipper": {
-          "type": "Organization",
-          "name": "Xxinau Manufacturing Co. Ltd.",
-          "description": "Advanced Production - Delivered",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "Xin Fei Da Dao 139",
-            "addressLocality": "Xindao",
-            "addressRegion": "Fujian Province",
-            "postalCode": "361100",
-            "addressCountry": "CN"
-          }
-        },
-        "shippersAccountNumber": "Trade",
-        "consignee": {
-          "type": "Organization",
-          "name": "By Acre",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "I.C.Modewegs Vej 1",
-            "addressLocality": "Kgs. Lyngby",
-            "postalCode": "2800",
-            "addressCountry": "DK"
-          }
-        },
-        "requestedRouting": [
-          {
-            "type": "ShippingStop",
-            "from": {
-              "type": "Place",
-              "address": {
-                "type": "PostalAddress",
-                "addressLocality": "Xiamen"
-              }
-            },
-            "to": {
-              "type": "Place",
-              "iataAirportCode": "LUX"
-            },
-            "by": {
-              "type": "Organization",
-              "iataCarrierCode": "CV"
+        }
+      },
+      "carrier": {
+        "type": "Organization",
+        "name": "On Time Express Limited",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "Suite 605, 6/F, Hai Tian Logistics Centre, #1 Hai Tian Road",
+          "addressLocality": "Hu-Li District",
+          "addressRegion": "Xiamen",
+          "addressCountry": "CN"
+        }
+      },
+      "conditionsOfContract": "It is agreed that the goods described herein are accepted in apparent good order and condition (except as noted) for carriage SUBJECT TO THE CONDITIONS OF CONTRACT ON THE REVERSE HEREOF. ALL GOODS MAY BE CARRIED BY ANY OTHER MEANS INCLUDING ROAD OR ANY OTHER CARRIER UNLESS SPECIFIC CONTRARY INSTRUCTIONS ARE GIVEN HEREON BY THE SHIPPER, AND SHIPPER AGREES THAT THE SHIPMENT MAY BE CARRIED VIA INTERMEDIATE STOPPING PLACES WHICH THE CARRIER DEEMS APPROPRIATE. THE SHIPPER'S ATTENTION IS DRAWN TO THE NOTICE CONCERNING CARRIER'S LIMITATION OF LIABILITY. Shipper may increase such limitation of liability by declaring a higher value for carriage and paying a supplemental charge if required.",
+      "shipper": {
+        "type": "Organization",
+        "name": "Xxinau Manufacturing Co. Ltd.",
+        "description": "Advanced Production - Delivered",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "Xin Fei Da Dao 139",
+          "addressLocality": "Xindao",
+          "addressRegion": "Fujian Province",
+          "postalCode": "361100",
+          "addressCountry": "CN"
+        }
+      },
+      "shippersAccountNumber": "Trade",
+      "consignee": {
+        "type": "Organization",
+        "name": "By Acre",
+        "address": {
+          "type": "PostalAddress",
+          "streetAddress": "I.C.Modewegs Vej 1",
+          "addressLocality": "Kgs. Lyngby",
+          "postalCode": "2800",
+          "addressCountry": "DK"
+        }
+      },
+      "requestedRouting": [
+        {
+          "type": "ShippingStop",
+          "from": {
+            "type": "Place",
+            "address": {
+              "type": "PostalAddress",
+              "addressLocality": "Xiamen"
             }
           },
-          {
-            "type": "ShippingStop",
-            "to": {
-              "type": "Place",
-              "iataAirportCode": "CPH"
-            },
-            "by": {
-              "type": "Organization",
-              "iataCarrierCode": "CV"
-            }
-          }
-        ],
-        "destinationAirport": {
-          "type": "Place",
-          "iataAirportCode": "CPH",
-          "address": {
-            "type": "PostalAddress",
-            "addressLocality": "Copenhagen"
+          "to": {
+            "type": "Place",
+            "iataAirportCode": "LUX"
+          },
+          "by": {
+            "type": "Organization",
+            "iataCarrierCode": "CV"
           }
         },
-        "requestedFlight": "CV9586",
-        "requestedDate": "2021-07-31",
-        "accountingInformation": "Freight Collect",
-        "currency": "USD",
-        "chargeCodes": "CP—destination collect cash",
-        "weightValuationChargesType": "Collect",
-        "otherChargesType": "Prepaid",
-        "declaredValueForCarriage": "NVD",
-        "declaredValueForCustoms": "As per invoice",
-        "amountOfInsurance": "NIL",
-        "handlingInformation": "TOTAL: 13PLT (S) ONLY. INVOICE & PACKING LIST ATTD",
-        "consignmentRatingDetails": [
-          {
-            "type": "ConsignmentRatingDetail",
-            "numberOfPieces": 13,
-            "grossWeight": 971,
-            "grossWeightUnit": "Kg",
-            "rateClass": "Q—quantity rate",
-            "chargeableWeight": 2480.5,
-            "total": "As arranged",
-            "natureAndVolumeOfGoods": "ROLLATORS; DIMS: 2 / 118 X 89 X 87 CM, 11 /118 x 89 X 113 CM, 14.88 CBM"
+        {
+          "type": "ShippingStop",
+          "to": {
+            "type": "Place",
+            "iataAirportCode": "CPH"
+          },
+          "by": {
+            "type": "Organization",
+            "iataCarrierCode": "CV"
           }
-        ],
-        "totalNumberOfPieces": 13,
-        "totalGrossWeight": 971,
-        "totalCharge": "As arranged",
-        "collectChargeDeclaration": {
-          "weightCharge": "As arranged",
-          "total": "As arranged"
-        },
-        "shippersCertificationBox": "On Time Express Limited, Suite 605, 6/F, Hai Tian Logistics Centre, #1 Hai Tian Road, Hu-Li District, Xiamen, P.R.China",
-        "executedOn": "2021-07-31",
-        "executedAt": {
-          "type": "Place",
-          "iataAirportCode": "XMN"
         }
+      ],
+      "destinationAirport": {
+        "type": "Place",
+        "iataAirportCode": "CPH",
+        "address": {
+          "type": "PostalAddress",
+          "addressLocality": "Copenhagen"
+        }
+      },
+      "requestedFlight": "CV9586",
+      "requestedDate": "2021-07-31",
+      "accountingInformation": "Freight Collect",
+      "currency": "USD",
+      "chargeCodes": "CP—destination collect cash",
+      "weightValuationChargesType": "Collect",
+      "otherChargesType": "Prepaid",
+      "declaredValueForCarriage": "NVD",
+      "declaredValueForCustoms": "As per invoice",
+      "amountOfInsurance": "NIL",
+      "handlingInformation": "TOTAL: 13PLT (S) ONLY. INVOICE & PACKING LIST ATTD",
+      "consignmentRatingDetails": [
+        {
+          "type": "ConsignmentRatingDetail",
+          "numberOfPieces": 13,
+          "grossWeight": 971,
+          "grossWeightUnit": "Kg",
+          "rateClass": "Q—quantity rate",
+          "chargeableWeight": 2480.5,
+          "total": "As arranged",
+          "natureAndVolumeOfGoods": "ROLLATORS; DIMS: 2 / 118 X 89 X 87 CM, 11 /118 x 89 X 113 CM, 14.88 CBM"
+        }
+      ],
+      "totalNumberOfPieces": 13,
+      "totalGrossWeight": 971,
+      "totalCharge": "As arranged",
+      "collectChargeDeclaration": {
+        "weightCharge": "As arranged",
+        "total": "As arranged"
+      },
+      "shippersCertificationBox": "On Time Express Limited, Suite 605, 6/F, Hai Tian Logistics Centre, #1 Hai Tian Road, Hu-Li District, Xiamen, P.R.China",
+      "executedOn": "2021-07-31",
+      "executedAt": {
+        "type": "Place",
+        "iataAirportCode": "XMN"
       }
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-06-03T15:28:14Z",
+      "created": "2022-06-14T09:49:47Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..CSpskV2O6utBIn1g0qWUWPQ8Ku00vck6MCp_2eb4UpZxFlq8x7pXjhWaAfqipsooxfmQ-mPkSRVZaOpYXM96DQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..9fX3a9UXdOTA9inTEbhCyR7Arm0_g5iq3VXomN9uYSdscQL-e2J2b0_iNcdcPoZRTFbl_FNrY5n7DnFuB7TJAA"
     }
   }


### PR DESCRIPTION
All of the credentialSubject was within the airportOfDeparture object. This just moves a `}` up, closing airportOfDeparture properly. 

This should fix a bunch of these undefined terms: 
![image](https://user-images.githubusercontent.com/34443212/173555764-2aed2136-1851-4e10-a9eb-1ab7daacd55f.png)
