### PR TITLE
Add descriptions to credentials

### DIFF
--- a/docs/openapi/components/schemas/openssf/VerifiableScorecard.yml
+++ b/docs/openapi/components/schemas/openssf/VerifiableScorecard.yml
@@ -1,5 +1,10 @@
 title: Verifiable Scorecard
-description: A digital, verifiable scorecard.
+description: >-
+  Scorecards is an automated tool that assesses a number of important heuristics ("checks") 
+  associated with software security and assigns each check a score of 0-10. You can use these 
+  scores to understand specific areas to improve in order to strengthen the security posture of 
+  your project. 
+  Learn more at [github.com/ossf/scorecard](https://github.com/ossf/scorecard#what-is-scorecards)
 $linkedData:
   term: VerifiableScorecard
   '@id': https://w3id.org/traceability#VerifiableScorecard

--- a/docs/openapi/components/schemas/postman/VerifiablePostmanCollection.yml
+++ b/docs/openapi/components/schemas/postman/VerifiablePostmanCollection.yml
@@ -1,5 +1,8 @@
 title: Verifiable Postman Collection
-description: A verifiable postman collection.
+description: >-
+  Postman is an API platform for developers to design, build, test and iterate their APIs. 
+  A Verifiable Postman Collection is a Postman collection that has been signed by an 
+  issuier to verify the source of a collection as origininating from a specific entity. 
 $linkedData:
   term: VerifiablePostmanCollection
   '@id': https://w3id.org/traceability#VerifiablePostmanCollection


### PR DESCRIPTION
`Verifiable Scorecard` and `Verifiable Postman Collection` had short one line descriptions. Added more details for context on the purpose of each credential type. 