### PR TITLE
Updated Schemas to use Place instead of Postal Address

### DIFF
--- a/docs/openapi/components/schemas/common/ContactPoint.yml
+++ b/docs/openapi/components/schemas/common/ContactPoint.yml
@@ -5,16 +5,11 @@ title: Contact Point
 description: Contact information for entities.
 type: object
 properties:
-  type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ContactPoint
-      - type: string
-        const:
-          - ContactPoint 
+  type: array
+  items:
+    type: string
+    enum:
+      - ContactPoint
   name:
     title: Name
     description: Name of the entity.
@@ -22,13 +17,13 @@ properties:
     $linkedData:
       term: name
       '@id': https://schema.org/name
-  address:
-    title: Postal Address
-    description: The postal address for an organization or place.
-    $ref: ./PostalAddress.yml
+  location:
+    title: Location
+    description: The location of, for example, where an event is happening, where an organization is located, or where an action takes place.
+    $ref: ./Place.yml
     $linkedData:
-      term: address
-      '@id': https://schema.org/PostalAddress
+      term: location
+      '@id': https://schema.org/location
   email:
     title: Email Address
     description: Contact email address.
@@ -46,15 +41,18 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "ContactPoint",
+    "type": ["ContactPoint"],
     "name": "Cassin, Mayer and Auer",
-    "address": {
-      "type": "PostalAddress",
-      "streetAddress": "3595 Reilly Freeway",
-      "addressLocality": "Port Vincenzo",
-      "addressRegion": "Arizona",
-      "postalCode": "36734-7272",
-      "addressCountry": "Macedonia"
+    "location": {
+      "type": "Place",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "3595 Reilly Freeway",
+        "addressLocality": "Port Vincenzo",
+        "addressRegion": "Arizona",
+        "postalCode": "36734-7272",
+        "addressCountry": "Macedonia"
+      }
     },
     "email": "Okey.Homenick12@example.org",
     "phoneNumber": "555-218-9784"

--- a/docs/openapi/components/schemas/credentials/MillTestReportCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCertificate.yml
@@ -483,9 +483,9 @@ example: |-
     "issuanceDate": "2022-06-06T08:10:00+00:00",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-06-14T09:32:03Z",
+      "created": "2022-07-06T09:02:44Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..08hYC81PIysZsbDNANxgf2vqlfWWcHzpKp51K31QEOQoAyl5EjUqlkmFqKVVuctkLGHPUs9llgwgsTGhFSMgBw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..e4jXyC4Gyi01txk7w4uC5VJCQLTqeeP5otWMer0ab_8OZBbtZuZJvtnY2X4eWGDFeYaKJVZlQCZnS3C5PhygAg"
     }
   }


### PR DESCRIPTION
This pull request makes the following changes so that schemas use `Place` which allows for coordinates and along with Postal Addressed. 

### Contact Point

`address` has been changed to `location`. This schema is only referenced by organization, and never used in any of the example JSON. 

![mermaid-diagram-2022-07-05-231145](https://user-images.githubusercontent.com/86194145/177512336-a0712548-d706-40dd-afbd-831e082eb321.png)

