### PR TITLE
Replace Postal Address with Place for Contact Point

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,7 @@
 ## Testing
 
+Small change to test CI
+
 There is also a [**test
 suite**](https://w3c-ccg.github.io/traceability-vocab/testsuite/) that is run
 against PRs, checking separately both the JSON Schema-based data shape

--- a/docs/openapi/components/schemas/common/ContactPoint.yml
+++ b/docs/openapi/components/schemas/common/ContactPoint.yml
@@ -13,8 +13,7 @@ properties:
           enum:
             - ContactPoint
       - type: string
-        const:
-          - ContactPoint 
+        const: ContactPoint 
   name:
     title: Name
     description: Name of the entity.

--- a/docs/openapi/components/schemas/common/ContactPoint.yml
+++ b/docs/openapi/components/schemas/common/ContactPoint.yml
@@ -21,13 +21,13 @@ properties:
     $linkedData:
       term: name
       '@id': https://schema.org/name
-  address:
-    title: Postal Address
-    description: The postal address for an organization or place.
-    $ref: ./PostalAddress.yml
+  place:
+    title: Place
+    description: The address and geocoordinates for the contact point
+    $ref: ./Place.yml
     $linkedData:
-      term: address
-      '@id': https://schema.org/PostalAddress
+      term: place
+      '@id': https://w3id.org/traceability#place
   email:
     title: Email Address
     description: Contact email address.
@@ -47,13 +47,16 @@ example: |-
   {
     "type": "ContactPoint",
     "name": "Cassin, Mayer and Auer",
-    "address": {
-      "type": "PostalAddress",
-      "streetAddress": "3595 Reilly Freeway",
-      "addressLocality": "Port Vincenzo",
-      "addressRegion": "Arizona",
-      "postalCode": "36734-7272",
-      "addressCountry": "Macedonia"
+    "place" : {
+      "type" : "Place",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "3595 Reilly Freeway",
+        "addressLocality": "Port Vincenzo",
+        "addressRegion": "Arizona",
+        "postalCode": "36734-7272",
+        "addressCountry": "Macedonia"
+      }
     },
     "email": "Okey.Homenick12@example.org",
     "phoneNumber": "555-218-9784"

--- a/docs/openapi/components/schemas/common/ContactPoint.yml
+++ b/docs/openapi/components/schemas/common/ContactPoint.yml
@@ -6,14 +6,11 @@ description: Contact information for entities.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ContactPoint
-      - type: string
-        const: ContactPoint 
+    type: array
+    items:
+      type: string
+      enum:
+        - ContactPoint
   name:
     title: Name
     description: Name of the entity.
@@ -45,7 +42,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "ContactPoint",
+    "type": [ "ContactPoint" ],
     "name": "Cassin, Mayer and Auer",
     "place" : {
       "type" : "Place",


### PR DESCRIPTION
### Contact Point

This schema uses `Postal Address`, which is replaced with `Place` in this PR to allow for latitude and longitude to be defined along with the postal address. As a side note, none of the example JSON files use the `Postal Address` attribute. 

```mermaid
flowchart TB
A(ContactPoint.yml)
B[string array]
C(Place.yml)
D[PostalAddress.yml]
E[string]
F[string]
G[string]
A -->|type| B
A -->|name| E
A -->|place| C
C -->|address| D
A -->|email| F
A -->|phoneNumber| G
```