### PR TITLE
Add description to commercial invoice

### DIFF
--- a/docs/openapi/components/schemas/credentials/CommercialInvoiceCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CommercialInvoiceCertificate.yml
@@ -56,6 +56,7 @@ example: |-
       "CommercialInvoiceCertificate"
     ],
     "name": "Commercial Invoice Certificate",
+    "description": "Document recording a transaction between the seller and the buyer",
     "issuanceDate": "2022-02-23T11:55:00Z",
     "issuer": {
       "type": "Organization",
@@ -235,9 +236,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-06-22T08:47:25Z",
+      "created": "2022-07-13T14:49:59Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..g9YJTN-JPsu7T6ZqFExmBqxUGC0blBLaeIo9JXE02u6QSeujbLES6tmmTYtKaqA9f3mvbA3ZZBdkGea1F0MhAg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..gLBnRiIIKitEeLcWutBBab1U3AEJ0DIFZMGoo2k_F0iLsZ45H6f9LCNKMPzI7o5CYOu3UaSQn94HsjjD4EFJCQ"
     }
   }


### PR DESCRIPTION
Commercial Invoice Certificate is missing a description in the example JSON. This PR addresses that. 