### PR TITLE
feat: create schemas & credentials for oft ctes & kdes

### DIFF
--- a/docs/openapi/components/schemas/common/FSMAAbstractKDE.yml
+++ b/docs/openapi/components/schemas/common/FSMAAbstractKDE.yml
@@ -1,0 +1,41 @@
+$linkedData:
+  term: FSMAAbstractKDE
+  '@id': https://w3id.org/traceability#FSMAAbstractKDE
+title: FSMA Abstract KDE
+description: >-
+  "An FSMA abstract KDE (Key Data Element), a key/value pair representing a KDE attached to some
+  CTE (Critical Tracking Event). This schema is designed to meet reporting requirements for the FDA
+  Traceability Rule as specified here:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability"
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - FSMAAbstractKDE
+      - type: string
+        const: FSMAAbstractKDE
+  name:
+    title: Name
+    description: The name of the KDE.
+    type: string
+    $linkedData:
+      term: name
+      '@id': https://schema.org/propertyID
+  value:
+    title: Value
+    description: The value of the KDE.
+    type: string
+    $linkedData:
+      term: value
+      '@id': https://schema.org/value
+additionalProperties: false
+example: |-
+  {
+    "type": "FSMAAbstractKDE",
+    "name": "Reference record type and number",
+    "value": "BOL 1324"
+  }

--- a/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
@@ -1,0 +1,125 @@
+$linkedData:
+  term: FSMACreatingCTE
+  '@id': https://w3id.org/traceability#FSMACreatingCTE
+title: FSMA Creating CTE
+description: >-
+  "Information regarding an FSMA Creating CTE (Critical Tracking Event), designed to meet reporting
+  requirements for the FDA Traceability Rule as specified here:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability"
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - FSMACreatingCTE
+      - type: string
+        const: FSMACreatingCTE
+  foodCreated:
+    title: Food Created
+    description: The traceability food that was created.
+    $ref: ./FSMAProduct.yml
+    $linkedData:
+      term: foodCreated
+      '@id': https://w3id.org/traceability#FSMAProduct
+  locationCreated:
+    title: Location Created
+    description: Where the product was created.
+    $ref: ./Place.yml
+    $linkedData:
+      term: locationCreated
+      '@id': https://schema.org/Place
+  dateCompleted:
+    title: Date Completed
+    description: The date creation was completed in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    type: string
+    $linkedData:
+      term: dateCompleted
+      '@id': https://schema.org/DateTime
+  additionalData:
+    title: Additional Data
+    description: Additional Key Data Elements (KDEs).
+    type: array
+    items:
+      $ref: ./FSMAAbstractKDE.yml
+    $linkedData:
+      term: additionalData
+      '@id': https://w3id.org/traceability#FSMAAbstractKDE
+additionalProperties: false
+example: |-
+  {
+    "type": "FSMACreatingCTE",
+    "foodCreated": {
+      "type": "FSMAProduct",
+      "traceabilityLot": {
+        "type": "FSMATraceabilityLot",
+        "lotCode": "2b1ed51f-f1da-49f6-8130-ac81d1e5e61d",
+        "lotCodeAssignmentMethod": "Lot codes are generated as a random UUID.",
+        "lotType": "created"
+      },
+      "quantityUnitMeasure": {
+        "type": [
+          "QuantitativeValue"
+        ],
+        "unitCode": "Crates",
+        "value": "50"
+      },
+      "additionalData": [
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Category code",
+          "value": "659351253"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Category name",
+          "value": "Nut butter"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Brand name",
+          "value": "Delicious Dips"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Commodity",
+          "value": "Peanut Butter"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Product name",
+          "value": "DD PB"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Packaging size",
+          "value": "24 LB"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Packaging style",
+          "value": "Crates"
+        }
+      ]
+    },
+    "locationCreated": {
+      "type": [
+        "Place"
+      ],
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "Delicious Dips",
+        "streetAddress": "755 Stephanie Gardens",
+        "addressLocality": "Rasmussenborough",
+        "addressRegion": "KS",
+        "postalCode": "90819",
+        "addressCountry": "United States"
+      },
+      "locationName": "Delicious Dips Production Center"
+    },
+    "dateCompleted": "2022-02-01T00:00Z"
+  }

--- a/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
@@ -30,14 +30,14 @@ properties:
     $ref: ./Place.yml
     $linkedData:
       term: location
-      '@id': https://schema.org/Place
+      '@id': https://schema.org/location
   dateCompleted:
     title: Date Completed
     description: The date creation was completed in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
     type: string
     $linkedData:
       term: dateCompleted
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
@@ -59,13 +59,8 @@ example: |-
         "lotCodeAssignmentMethod": "Lot codes are generated as a random UUID.",
         "lotType": "created"
       },
-      "quantityUnitMeasure": {
-        "type": [
-          "QuantitativeValue"
-        ],
-        "unitCode": "Crates",
-        "value": "50"
-      },
+      "quantity": 50,
+      "unit": "Crates",
       "additionalData": [
         {
           "type": "FSMAAbstractKDE",

--- a/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
@@ -17,19 +17,19 @@ properties:
             - FSMACreatingCTE
       - type: string
         const: FSMACreatingCTE
-  foodCreated:
-    title: Food Created
+  food:
+    title: Food
     description: The traceability food that was created.
     $ref: ./FSMAProduct.yml
     $linkedData:
-      term: foodCreated
+      term: food
       '@id': https://w3id.org/traceability#FSMAProduct
-  locationCreated:
-    title: Location Created
+  location:
+    title: Location
     description: Where the product was created.
     $ref: ./Place.yml
     $linkedData:
-      term: locationCreated
+      term: location
       '@id': https://schema.org/Place
   dateCompleted:
     title: Date Completed
@@ -51,7 +51,7 @@ additionalProperties: false
 example: |-
   {
     "type": "FSMACreatingCTE",
-    "foodCreated": {
+    "food": {
       "type": "FSMAProduct",
       "traceabilityLot": {
         "type": "FSMATraceabilityLot",
@@ -104,7 +104,7 @@ example: |-
         }
       ]
     },
-    "locationCreated": {
+    "location": {
       "type": [
         "Place"
       ],

--- a/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
+++ b/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
@@ -105,8 +105,8 @@ example: |-
         "type": "Entity",
         "entityType" : "Person",
         "name" : "John Davis",
-        "email": "jdavis@johnsproduce.com",
-        "phoneNumber": "129.697.0673"
+        "email": "produce@example.com",
+        "phoneNumber": "129-697-0673"
       },
       "lotType": "originated"
     },

--- a/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
+++ b/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
@@ -1,0 +1,133 @@
+$linkedData:
+  term: FSMAFirstReceiverCTE
+  '@id': https://w3id.org/traceability#FSMAFirstReceiverCTE
+title: FSMA First Receiver Data
+description: >-
+  "Information regarding FSMA First Receiver data, a collection of KDEs (Key Data Elements) for
+  which a product's first receiver is responsible. This schema is designed to meet reporting
+  requirements for the FDA Traceability Rule as specified here:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability"
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - FSMAFirstReceiverCTE
+      - type: string
+        const: FSMAFirstReceiverCTE
+  traceabilityLot:
+    title: Traceability Lot
+    description: The lot of food being tracked.
+    $ref: ./FSMATraceabilityLot.yml
+    $linkedData:
+      term: traceabilityLot
+      '@id': https://w3id.org/traceability#FSMATraceabilityLot
+  originatorLocation:
+    title: Originator Location
+    description: Where the product originated.
+    $ref: ./Place.yml
+    $linkedData:
+      term: originatorLocation
+      '@id': https://schema.org/Place
+  harvestDate:
+    title: Harvest Date
+    description: The date and time product was harvested in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    type: string
+    $linkedData:
+      term: harvestDate
+      '@id': https://schema.org/DateTime
+  coolingLocation:
+    title: Cooling location
+    description: Where the food was cooled.
+    $ref: ./Place.yml
+    $linkedData:
+      term: coolingLocation
+      '@id': https://schema.org/Place
+  coolingDate:
+    title: Cooling Date
+    description: The Date and time product was cooled in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    type: string
+    $linkedData:
+      term: coolingDate
+      '@id': https://schema.org/DateTime
+  packingLocation:
+    title: Packing Location
+    description: Where the food was packed.
+    $ref: ./Place.yml
+    $linkedData:
+      term: packingLocation
+      '@id': https://schema.org/Place
+  packingDate:
+    title: Packing Date
+    description: The date and time product was packed in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    type: string
+    $linkedData:
+      term: packingDate
+      '@id': https://schema.org/DateTime
+  additionalData:
+    title: Additional Data
+    description: Additional Key Data Elements (KDEs).
+    type: array
+    items:
+      $ref: ./FSMAAbstractKDE.yml
+    $linkedData:
+      term: additionalData
+      '@id': https://w3id.org/traceability#FSMAAbstractKDE
+additionalProperties: false
+example: |-
+  {
+    "type": "FSMAFirstReceiverData",
+    "traceabilityLot": {
+      "type": "FSMATraceabilityLot",
+      "lotCode": "CHE-MIG-TTF1-061321-H37J",
+      "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+      "lotCodeGeneratorLocation": {
+        "type": [
+          "Place"
+        ],
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "John's Produce",
+          "streetAddress": "4335 Walsh Underpass",
+          "addressLocality": "Port Mark",
+          "addressRegion": "LA",
+          "postalCode": "67391",
+          "addressCountry": "United States"
+        },
+        "locationName": "John's Tomato Farm #1"
+      },
+      "lotCodeGeneratorPOC": {
+        "type": "Entity",
+        "entityType" : "Person",
+        "name" : "John Davis",
+        "email": "jdavis@johnsproduce.com",
+        "phoneNumber": "129.697.0673"
+      },
+      "lotType": "originated"
+    },
+    "originatorLocation": {
+      "type": [
+        "Place"
+      ],
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "John's Produce",
+        "streetAddress": "4335 Walsh Underpass",
+        "addressLocality": "Port Mark",
+        "addressRegion": "LA",
+        "postalCode": "67391",
+        "addressCountry": "United States"
+      },
+      "locationName": "John's Tomato Farm #1"
+    },
+    "harvestDate": "2022-01-03T00:00Z",
+    "coolingDate": "2022-01-07T00:00Z",
+    "packingDate": "2022-02-03T00:00Z"
+  }

--- a/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
+++ b/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
@@ -31,42 +31,42 @@ properties:
     $ref: ./Place.yml
     $linkedData:
       term: originatorLocation
-      '@id': https://schema.org/Place
+      '@id': https://schema.org/location
   harvestDate:
     title: Harvest Date
-    description: The date and time product was harvested in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    description: The date and time product harvest was completed in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
     type: string
     $linkedData:
       term: harvestDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
   coolingLocation:
     title: Cooling location
     description: Where the food was cooled.
     $ref: ./Place.yml
     $linkedData:
       term: coolingLocation
-      '@id': https://schema.org/Place
+      '@id': https://schema.org/location
   coolingDate:
     title: Cooling Date
-    description: The Date and time product was cooled in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    description: The Date and time product cooling was completed in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
     type: string
     $linkedData:
       term: coolingDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
   packingLocation:
     title: Packing Location
     description: Where the food was packed.
     $ref: ./Place.yml
     $linkedData:
       term: packingLocation
-      '@id': https://schema.org/Place
+      '@id': https://schema.org/location
   packingDate:
     title: Packing Date
-    description: The date and time product was packed in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    description: The date and time product packing was completed in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
     type: string
     $linkedData:
       term: packingDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FSMAGrowingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAGrowingCTE.yml
@@ -30,7 +30,7 @@ properties:
     $ref: ./GeoCoordinates.yml
     $linkedData:
       term: growingAreaCoordinates
-      '@id': https://schema.org/GeoCoordinates
+      '@id': https://w3id.org/traceability#GeoCoordinates
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FSMAGrowingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAGrowingCTE.yml
@@ -25,7 +25,7 @@ properties:
       term: traceabilityLot
       '@id': https://w3id.org/traceability#FSMATraceabilityLot
   growingAreaCoordinates:
-    title: Growing Area Coordinates [TODO this could be attached to lot directly removing need for this schema - but should it? Won't be used by other schemas that ref trace lot... I think?]
+    title: Growing Area Coordinates
     description: Coordinates of the area the product was grown.
     $ref: ./GeoCoordinates.yml
     $linkedData:

--- a/docs/openapi/components/schemas/common/FSMAGrowingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAGrowingCTE.yml
@@ -1,0 +1,84 @@
+$linkedData:
+  term: FSMAGrowingCTE
+  '@id': https://w3id.org/traceability#FSMAGrowingCTE
+title: FSMA Growing CTE
+description: >-
+  "Information regarding an FSMA Growing CTE (Critical Tracking Event), designed to meet reporting
+  requirements for the FDA Traceability Rule as specified here:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability"
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - FSMAGrowingCTE
+      - type: string
+        const: FSMAGrowingCTE
+  traceabilityLot:
+    title: Traceability Lot
+    description: The lot of food being tracked.
+    $ref: ./FSMATraceabilityLot.yml
+    $linkedData:
+      term: traceabilityLot
+      '@id': https://w3id.org/traceability#FSMATraceabilityLot
+  growingAreaCoordinates:
+    title: Growing Area Coordinates [TODO this could be attached to lot directly removing need for this schema - but should it? Won't be used by other schemas that ref trace lot... I think?]
+    description: Coordinates of the area the product was grown.
+    $ref: ./GeoCoordinates.yml
+    $linkedData:
+      term: growingAreaCoordinates
+      '@id': https://schema.org/GeoCoordinates
+  additionalData:
+    title: Additional Data
+    description: Additional Key Data Elements (KDEs).
+    type: array
+    items:
+      $ref: ./FSMAAbstractKDE.yml
+    $linkedData:
+      term: additionalData
+      '@id': https://w3id.org/traceability#FSMAAbstractKDE
+additionalProperties: false
+example: |-
+  {
+    "type": "FSMAGrowingCTE",
+    "traceabilityLot": {
+      "type": "FSMATraceabilityLot",
+      "lotCode": "CHE-MIG-TTF1-061321-H37J",
+      "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+      "lotCodeGeneratorLocation": {
+        "type": [
+          "Place"
+        ],
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "John's Produce",
+          "streetAddress": "4335 Walsh Underpass",
+          "addressLocality": "Port Mark",
+          "addressRegion": "LA",
+          "postalCode": "67391",
+          "addressCountry": "United States"
+        },
+        "locationName": "John's Tomato Farm #1"
+      },
+      "lotCodeGeneratorPOC": {
+        "type": "Entity",
+        "entityType" : "Person",
+        "name" : "John Davis",
+        "email": "jdavis@johnsproduce.com",
+        "phoneNumber": "129.697.0673"
+      },
+      "lotType": "originated"
+    },
+    "growingAreaCoordinates": {
+      "type": [
+        "GeoCoordinates"
+      ],
+      "latitude": "44.859038",
+      "longitude": "70.916213"
+    }
+  }

--- a/docs/openapi/components/schemas/common/FSMAGrowingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAGrowingCTE.yml
@@ -69,8 +69,8 @@ example: |-
         "type": "Entity",
         "entityType" : "Person",
         "name" : "John Davis",
-        "email": "jdavis@johnsproduce.com",
-        "phoneNumber": "129.697.0673"
+        "email": "produce@example.com",
+        "phoneNumber": "129-697-0673"
       },
       "lotType": "originated"
     },

--- a/docs/openapi/components/schemas/common/FSMAProduct.yml
+++ b/docs/openapi/components/schemas/common/FSMAProduct.yml
@@ -1,0 +1,127 @@
+$linkedData:
+  term: FSMAProduct
+  '@id': https://w3id.org/traceability#FSMAProduct
+title: FSMA Product
+description: >-
+  "Information regarding an FSMA Product, a collection of KDEs (Key Data Elements) common to several
+  CTEs (Critical Tracking Events). This schema is designed to meet reporting requirements for the
+  FDA Traceability Rule as specified here:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability"
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - FSMAProduct
+      - type: string
+        const: FSMAProduct
+  traceabilityLot:
+    title: Traceability Lot
+    description: The lot of food being tracked.
+    $ref: ./FSMATraceabilityLot.yml
+    $linkedData:
+      term: traceabilityLot
+      '@id': https://w3id.org/traceability#FSMATraceabilityLot
+  quantityUnitMeasure:
+    title: Quantity and unit of measure
+    description: The quantity and unit measure of this product (e.g. 10 Cartons, or 20 Crates).
+    $ref: ./QuantitativeValue.yml
+    $linkedData:
+      term: quantityUnitMeasure
+      '@id': https://schema.org/QuantitativeValue
+  additionalData:
+    title: Additional Data
+    description: Additional Key Data Elements (KDEs).
+    type: array
+    items:
+      $ref: ./FSMAAbstractKDE.yml
+    $linkedData:
+      term: additionalData
+      '@id': https://w3id.org/traceability#FSMAAbstractKDE
+additionalProperties: false
+example: |-
+  {
+    "type": "FSMAProduct",
+    "traceabilityLot": {
+      "type": "FSMATraceabilityLot",
+      "lotCode": "CHE-MIG-TTF1-061321-H37J",
+      "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+      "lotCodeGeneratorLocation": {
+        "type": [
+          "Place"
+        ],
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "John's Produce",
+          "streetAddress": "4335 Walsh Underpass",
+          "addressLocality": "Port Mark",
+          "addressRegion": "LA",
+          "postalCode": "67391",
+          "addressCountry": "United States"
+        },
+        "locationName": "John's Tomato Farm #1"
+      },
+      "lotCodeGeneratorPOC": {
+        "type": "Entity",
+        "entityType" : "Person",
+        "name" : "John Davis",
+        "email": "jdavis@johnsproduce.com",
+        "phoneNumber": "129.697.0673"
+      },
+      "lotType": "originated"
+    },
+    "quantityUnitMeasure": {
+      "type": [
+        "QuantitativeValue"
+      ],
+      "unitCode": "Boxes",
+      "value": "82"
+    },
+    "additionalData": [
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Category code",
+        "value": "659351253"
+      },
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Category name",
+        "value": "Tomatoes"
+      },
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Brand name",
+        "value": "John's Produce"
+      },
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Commodity",
+        "value": "Cherry Tomatoes"
+      },
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Variety",
+        "value": "Mighty Sweet Hybrid"
+      },
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Product name",
+        "value": "N/A"
+      },
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Packaging size",
+        "value": "Bulk"
+      },
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Packaging style",
+        "value": "Field Bins"
+      }
+    ]
+  }

--- a/docs/openapi/components/schemas/common/FSMAProduct.yml
+++ b/docs/openapi/components/schemas/common/FSMAProduct.yml
@@ -25,13 +25,21 @@ properties:
     $linkedData:
       term: traceabilityLot
       '@id': https://w3id.org/traceability#FSMATraceabilityLot
-  quantityUnitMeasure:
-    title: Quantity and unit of measure
-    description: The quantity and unit measure of this product (e.g. 10 Cartons, or 20 Crates).
-    $ref: ./QuantitativeValue.yml
+  quantity:
+    title: Quantity
+    description: The quantity of some unit of measure for this product.
+    type: number
     $linkedData:
-      term: quantityUnitMeasure
-      '@id': https://schema.org/QuantitativeValue
+      term: quantity
+      '@id': https://schema.org/value
+  unit:
+    title: Unit
+    description: The unit of measure used to describe this product.
+    type: string
+    $linkedData:
+      term: unit
+      '@id': https://schema.org/unitText
+  quantity:
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).
@@ -70,18 +78,13 @@ example: |-
         "type": "Entity",
         "entityType" : "Person",
         "name" : "John Davis",
-        "email": "jdavis@johnsproduce.com",
-        "phoneNumber": "129.697.0673"
+        "email": "produce@example.com",
+        "phoneNumber": "129-697.-673"
       },
       "lotType": "originated"
     },
-    "quantityUnitMeasure": {
-      "type": [
-        "QuantitativeValue"
-      ],
-      "unitCode": "Boxes",
-      "value": "82"
-    },
+    "quantity": 82,
+    "unit": "Boxes",
     "additionalData": [
       {
         "type": "FSMAAbstractKDE",

--- a/docs/openapi/components/schemas/common/FSMAProduct.yml
+++ b/docs/openapi/components/schemas/common/FSMAProduct.yml
@@ -39,7 +39,6 @@ properties:
     $linkedData:
       term: unit
       '@id': https://schema.org/unitText
-  quantity:
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
@@ -1,0 +1,194 @@
+$linkedData:
+  term: FSMAReceivingCTE
+  '@id': https://w3id.org/traceability#FSMAReceivingCTE
+title: FSMA Receiving CTE
+description: >-
+  "Information regarding an FSMA Receiving CTE (Critical Tracking Event), designed to meet
+  reporting requirements for the FDA Traceability Rule as specified here:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability"
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - FSMAReceivingCTE
+      - type: string
+        const: FSMAReceivingCTE
+  shipment:
+    title: Shipment
+    description: The shipment being tracked.
+    $ref: ./FSMAShipment.yml
+    $linkedData:
+      term: shipment
+      '@id': https://w3id.org/traceability#FSMAShipment
+  dateReceived:
+    title: Date Received
+    description: The date shipment was received in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    type: string
+    $linkedData:
+      term: dateReceived
+      '@id': https://schema.org/DateTime
+  additionalData:
+    title: Additional Data
+    description: Additional Key Data Elements (KDEs).
+    type: array
+    items:
+      $ref: ./FSMAAbstractKDE.yml
+    $linkedData:
+      term: additionalData
+      '@id': https://w3id.org/traceability#FSMAAbstractKDE
+additionalProperties: false
+example: |-
+  {
+    "type": "FSMAReceivingCTE",
+    "shipment": {
+      "type": "FSMAShipment",
+      "product": {
+        "type": "FSMAProduct",
+        "traceabilityLot": {
+          "type": "FSMATraceabilityLot",
+          "lotCode": "CHE-MIG-TTF1-061321-H37J",
+          "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+          "lotCodeGeneratorLocation": {
+            "type": [
+              "Place"
+            ],
+            "address": {
+              "type": [
+                "PostalAddress"
+              ],
+              "organizationName": "John's Produce",
+              "streetAddress": "4335 Walsh Underpass",
+              "addressLocality": "Port Mark",
+              "addressRegion": "LA",
+              "postalCode": "67391",
+              "addressCountry": "United States"
+            },
+            "locationName": "John's Tomato Farm #1"
+          },
+          "lotCodeGeneratorPOC": {
+            "type": "Entity",
+            "entityType" : "Person",
+            "name" : "John Davis",
+            "email": "jdavis@johnsproduce.com",
+            "phoneNumber": "129.697.0673"
+          },
+          "lotType": "originated"
+        },
+        "quantityUnitMeasure": {
+          "type": [
+            "QuantitativeValue"
+          ],
+          "unitCode": "Field Bins",
+          "value": "103"
+        },
+       "additionalData": [
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Category code",
+            "value": "659351253"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Category name",
+            "value": "Tomatoes"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Brand name",
+            "value": "John's Produce"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Commodity",
+            "value": "Cherry Tomatoes"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Variety",
+            "value": "Mighty Sweet Hybrid"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Product name",
+            "value": "N/A"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Packaging size",
+            "value": "Bulk"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Packaging style",
+            "value": "Field Bins"
+          }
+        ]
+      },
+      "from": {
+        "type": [
+          "Place"
+        ],
+        "geo": {
+          "type": "GeoCoordinates",
+          "latitude": "44.859038",
+          "longitude": "70.916213"
+        },
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "John's Produce",
+          "streetAddress": "4335 Walsh Underpass",
+          "addressLocality": "Port Mark",
+          "addressRegion": "LA",
+          "postalCode": "67391",
+          "addressCountry": "United States"
+        },
+        "locationName": "John's Tomato Farm #1"
+      },
+      "to": {
+        "type": [
+          "Place"
+        ],
+        "geo": {
+          "type": "GeoCoordinates",
+          "latitude": "31.319706",
+          "longitude": "-92.117524"
+        },
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Pattie's Packers",
+          "streetAddress": "8974 Bolton Drive",
+          "addressLocality": "Port Mark",
+          "addressRegion": "LA",
+          "postalCode": "67391",
+          "addressCountry": "United States"
+        },
+        "locationName": "PP Packing Shed"
+      },
+      "additionalData": [
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Reference record type and number",
+          "value": "BOL 24884"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Import entry number",
+          "value": "N/A"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Transporter name",
+          "value": "Local Trucking Co."
+        }
+      ]
+    },
+    "dateShipped": "2022-01-03T00:00Z"
+  }

--- a/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
@@ -73,19 +73,14 @@ example: |-
             "type": "Entity",
             "entityType" : "Person",
             "name" : "John Davis",
-            "email": "jdavis@johnsproduce.com",
-            "phoneNumber": "129.697.0673"
+            "email": "produce@example.com",
+            "phoneNumber": "129-697-0673"
           },
           "lotType": "originated"
         },
-        "quantityUnitMeasure": {
-          "type": [
-            "QuantitativeValue"
-          ],
-          "unitCode": "Field Bins",
-          "value": "103"
-        },
-       "additionalData": [
+        "quantity": 103,
+        "unit": "Field Bins",
+        "additionalData": [
           {
             "type": "FSMAAbstractKDE",
             "name": "Category code",

--- a/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
@@ -30,7 +30,7 @@ properties:
     type: string
     $linkedData:
       term: dateReceived
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FSMAShipment.yml
+++ b/docs/openapi/components/schemas/common/FSMAShipment.yml
@@ -79,18 +79,13 @@ example: |-
           "type": "Entity",
           "entityType" : "Person",
           "name" : "John Davis",
-          "email": "jdavis@johnsproduce.com",
-          "phoneNumber": "129.697.0673"
+          "email": "produce@example.com",
+          "phoneNumber": "129-697-0673"
         },
         "lotType": "originated"
       },
-      "quantityUnitMeasure": {
-        "type": [
-          "QuantitativeValue"
-        ],
-        "unitCode": "Field Bins",
-        "value": "103"
-      },
+      "quantity": 103,
+      "unit": "Field Bins",
       "additionalData": [
         {
           "type": "FSMAAbstractKDE",

--- a/docs/openapi/components/schemas/common/FSMAShipment.yml
+++ b/docs/openapi/components/schemas/common/FSMAShipment.yml
@@ -31,14 +31,14 @@ properties:
     $ref: ./Place.yml
     $linkedData:
       term: from
-      '@id': https://schema.org/Place
+      '@id': https://schema.org/fromLocation
   to:
     title: Ships To
     description: The shipment's immediate destination.
     $ref: ./Place.yml
     $linkedData:
       term: to
-      '@id': https://schema.org/Place
+      '@id': https://schema.org/toLocation
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FSMAShipment.yml
+++ b/docs/openapi/components/schemas/common/FSMAShipment.yml
@@ -1,0 +1,198 @@
+$linkedData:
+  term: FSMAShipment
+  '@id': https://w3id.org/traceability#FSMAShipment
+title: FSMA Shipment
+description: >-
+  "Information regarding an FSMA Shipment, a collection of KDEs (Key Data Elements) common to the
+  Shipping and Receiving CTEs (Critical Tracking Events). This schema is designed to meet reporting
+  requirements for the FDA Traceability Rule as specified here:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability"
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - FSMAShipment
+      - type: string
+        const: FSMAShipment
+  product:
+    title: Product
+    description: The product being tracked.
+    $ref: ./FSMAProduct.yml
+    $linkedData:
+      term: product
+      '@id': https://w3id.org/traceability#FSMAProduct
+  from:
+    title: From
+    description: The shipment's immediate origin. 
+    $ref: ./Place.yml
+    $linkedData:
+      term: from
+      '@id': https://schema.org/Place
+  to:
+    title: Ships To
+    description: The shipment's immediate destination.
+    $ref: ./Place.yml
+    $linkedData:
+      term: to
+      '@id': https://schema.org/Place
+  additionalData:
+    title: Additional Data
+    description: Additional Key Data Elements (KDEs).
+    type: array
+    items:
+      $ref: ./FSMAAbstractKDE.yml
+    $linkedData:
+      term: additionalData
+      '@id': https://w3id.org/traceability#FSMAAbstractKDE
+additionalProperties: false
+example: |-
+  {
+    "type": "FSMAShipment",
+    "product": {
+      "type": "FSMAProduct",
+      "traceabilityLot": {
+        "type": "FSMATraceabilityLot",
+        "lotCode": "CHE-MIG-TTF1-061321-H37J",
+        "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+        "lotCodeGeneratorLocation": {
+          "type": [
+            "Place"
+          ],
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "John's Produce",
+            "streetAddress": "4335 Walsh Underpass",
+            "addressLocality": "Port Mark",
+            "addressRegion": "LA",
+            "postalCode": "67391",
+            "addressCountry": "United States"
+          },
+          "locationName": "John's Tomato Farm #1"
+        },
+        "lotCodeGeneratorPOC": {
+          "type": "Entity",
+          "entityType" : "Person",
+          "name" : "John Davis",
+          "email": "jdavis@johnsproduce.com",
+          "phoneNumber": "129.697.0673"
+        },
+        "lotType": "originated"
+      },
+      "quantityUnitMeasure": {
+        "type": [
+          "QuantitativeValue"
+        ],
+        "unitCode": "Field Bins",
+        "value": "103"
+      },
+      "additionalData": [
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Category code",
+          "value": "659351253"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Category name",
+          "value": "Tomatoes"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Brand name",
+          "value": "John's Produce"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Commodity",
+          "value": "Cherry Tomatoes"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Variety",
+          "value": "Mighty Sweet Hybrid"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Product name",
+          "value": "N/A"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Packaging size",
+          "value": "Bulk"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Packaging style",
+          "value": "Field Bins"
+        }
+      ]
+    },
+    "from": {
+      "type": [
+        "Place"
+      ],
+      "geo": {
+        "type": "GeoCoordinates",
+        "latitude": "44.859038",
+        "longitude": "70.916213"
+      },
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "John's Produce",
+        "streetAddress": "4335 Walsh Underpass",
+        "addressLocality": "Port Mark",
+        "addressRegion": "LA",
+        "postalCode": "67391",
+        "addressCountry": "United States"
+      },
+      "locationName": "John's Tomato Farm #1"
+    },
+    "to": {
+      "type": [
+        "Place"
+      ],
+      "geo": {
+        "type": "GeoCoordinates",
+        "latitude": "31.319706",
+        "longitude": "-92.117524"
+      },
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "Pattie's Packers",
+        "streetAddress": "8974 Bolton Drive",
+        "addressLocality": "Port Mark",
+        "addressRegion": "LA",
+        "postalCode": "67391",
+        "addressCountry": "United States"
+      },
+      "locationName": "PP Packing Shed"
+    },
+    "additionalData": [
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Reference record type and number",
+        "value": "BOL 24884"
+      },
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Import entry number",
+        "value": "N/A"
+      },
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Transporter name",
+        "value": "Local Trucking Co."
+      }
+    ]
+  }

--- a/docs/openapi/components/schemas/common/FSMAShippingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAShippingCTE.yml
@@ -30,16 +30,7 @@ properties:
     type: string
     $linkedData:
       term: dateShipped
-      '@id': https://schema.org/DateTime
-  additionalData:
-    title: Additional Data
-    description: Additional Key Data Elements (KDEs).
-    type: array
-    items:
-      $ref: ./FSMAAbstractKDE.yml
-    $linkedData:
-      term: additionalData
-      '@id': https://w3id.org/traceability#FSMAAbstractKDE
+      '@id': https://schema.org/startDate
 additionalProperties: false
 example: |-
   {

--- a/docs/openapi/components/schemas/common/FSMAShippingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAShippingCTE.yml
@@ -1,0 +1,201 @@
+$linkedData:
+  term: FSMAShippingCTE
+  '@id': https://w3id.org/traceability#FSMAShippingCTE
+title: FSMA Shipping CTE
+description: >-
+  "Information regarding an FSMA Shipping CTE (Critical Tracking Event), designed to meet reporting
+  requirements for the FDA Traceability Rule as specified here:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability"
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - FSMAShippingCTE
+      - type: string
+        const: FSMAShippingCTE
+  shipment:
+    title: Shipment
+    description: The shipment being tracked.
+    $ref: ./FSMAShipment.yml
+    $linkedData:
+      term: shipment
+      '@id': https://w3id.org/traceability#FSMAShipment
+  dateShipped:
+    title: Date Shipped
+    description: The date shipment was shipped in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    type: string
+    $linkedData:
+      term: dateShipped
+      '@id': https://schema.org/DateTime
+  additionalData:
+    title: Additional Data
+    description: Additional Key Data Elements (KDEs).
+    type: array
+    items:
+      $ref: ./FSMAAbstractKDE.yml
+    $linkedData:
+      term: additionalData
+      '@id': https://w3id.org/traceability#FSMAAbstractKDE
+additionalProperties: false
+example: |-
+  {
+    "type": "FSMAShippingCTE",
+    "shipment": {
+      "type": "FSMAShipment",
+      "product": {
+        "type": "FSMAProduct",
+        "traceabilityLot": {
+          "type": "FSMATraceabilityLot",
+          "lotCode": "CHE-MIG-TTF1-061321-H37J",
+          "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+          "lotCodeGeneratorLocation": {
+            "type": [
+              "Place"
+            ],
+            "address": {
+              "type": [
+                "PostalAddress"
+              ],
+              "organizationName": "John's Produce",
+              "streetAddress": "4335 Walsh Underpass",
+              "addressLocality": "Port Mark",
+              "addressRegion": "LA",
+              "postalCode": "67391",
+              "addressCountry": "United States"
+            },
+            "locationName": "John's Tomato Farm #1"
+          },
+          "lotCodeGeneratorPOC": {
+            "type": "Entity",
+            "entityType" : "Person",
+            "name" : "John Davis",
+            "email": "jdavis@johnsproduce.com",
+            "phoneNumber": "129.697.0673"
+          },
+          "lotType": "originated"
+        },
+        "quantityUnitMeasure": {
+          "type": [
+            "QuantitativeValue"
+          ],
+          "unitCode": "Field Bins",
+          "value": "103"
+        },
+        "additionalData": [
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Category code",
+            "value": "659351253"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Category name",
+            "value": "Tomatoes"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Brand name",
+            "value": "John's Produce"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Commodity",
+            "value": "Cherry Tomatoes"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Variety",
+            "value": "Mighty Sweet Hybrid"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Product name",
+            "value": "N/A"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Packaging size",
+            "value": "Bulk"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Packaging style",
+            "value": "Field Bins"
+          }
+        ]
+      },
+      "from": {
+        "type": [
+          "Place"
+        ],
+        "geo": {
+          "type": "GeoCoordinates",
+          "latitude": "44.859038",
+          "longitude": "70.916213"
+        },
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "John's Produce",
+          "streetAddress": "4335 Walsh Underpass",
+          "addressLocality": "Port Mark",
+          "addressRegion": "LA",
+          "postalCode": "67391",
+          "addressCountry": "United States"
+        },
+        "locationName": "John's Tomato Farm #1"
+      },
+      "to": {
+        "type": [
+          "Place"
+        ],
+        "geo": {
+          "type": "GeoCoordinates",
+          "latitude": "31.319706",
+          "longitude": "-92.117524"
+        },
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Pattie's Packers",
+          "streetAddress": "8974 Bolton Drive",
+          "addressLocality": "Port Mark",
+          "addressRegion": "LA",
+          "postalCode": "67391",
+          "addressCountry": "United States"
+        },
+        "locationName": "PP Packing Shed"
+      },
+      "additionalData": [
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Reference record type and number",
+          "value": "BOL 24884"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Import entry number",
+          "value": "N/A"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Transporter name",
+          "value": "Local Trucking Co."
+        }
+      ]
+    },
+    "dateShipped": "2022-01-01T00:00Z",
+    "additionalData": [
+      {
+        "type": "FSMAAbstractKDE",
+        "name": "Statement if the shipper is a farm",
+        "value": "TRUE"
+      }
+    ]
+  }

--- a/docs/openapi/components/schemas/common/FSMAShippingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAShippingCTE.yml
@@ -73,18 +73,13 @@ example: |-
             "type": "Entity",
             "entityType" : "Person",
             "name" : "John Davis",
-            "email": "jdavis@johnsproduce.com",
-            "phoneNumber": "129.697.0673"
+            "email": "produce@example.com",
+            "phoneNumber": "129-697-0673"
           },
           "lotType": "originated"
         },
-        "quantityUnitMeasure": {
-          "type": [
-            "QuantitativeValue"
-          ],
-          "unitCode": "Field Bins",
-          "value": "103"
-        },
+        "quantity": 103,
+        "unit": "Field Bins",
         "additionalData": [
           {
             "type": "FSMAAbstractKDE",

--- a/docs/openapi/components/schemas/common/FSMATraceabilityLot.yml
+++ b/docs/openapi/components/schemas/common/FSMATraceabilityLot.yml
@@ -34,14 +34,14 @@ properties:
       '@id': https://schema.org/description
   lotCodeGeneratorLocation:
     title: Lot Code Generator Location
-    description: The location of the entity responsible for generating this lot code. [TODO is that right?]
+    description: The location of the entity responsible for generating this lot code.
     $ref: ./Place.yml
     $linkedData:
       term: lotCodeGeneratorLocation
       '@id': https://www.gs1.org/voc/Place
   lotCodeGeneratorPOC:
-    title: Lot Code Generator Point of Contact [TODO should I also include the org? or is this enough? or is this even necessary, if we have the farm entity info?]
-    description: The point of contact for the party responsible for generating this lot code. [TODO is that right?]
+    title: Lot Code Generator Point of Contact
+    description: The point of contact for the party responsible for generating this lot code.
     $ref: ./Entity.yml
     $linkedData:
       term: lotCodeGeneratorPOC

--- a/docs/openapi/components/schemas/common/FSMATraceabilityLot.yml
+++ b/docs/openapi/components/schemas/common/FSMATraceabilityLot.yml
@@ -89,8 +89,8 @@ example: |-
       "type": "Entity",
       "entityType" : "Person",
       "name" : "John Davis",
-      "email": "jdavis@johnsproduce.com",
-      "phoneNumber": "129.697.0673"
+      "email": "produce@example.com",
+      "phoneNumber": "129-697-0673"
     },
     "lotType": "originated"
   }

--- a/docs/openapi/components/schemas/common/FSMATraceabilityLot.yml
+++ b/docs/openapi/components/schemas/common/FSMATraceabilityLot.yml
@@ -1,0 +1,96 @@
+$linkedData:
+  term: FSMATraceabilityLot
+  '@id': https://w3id.org/traceability#FSMATraceabilityLot
+title: FSMA Traceability Lot
+description: >-
+  "Information regarding an FSMA Traceability Lot, a collection of KDEs (Key Data Elements) common
+  to several CTEs (Critical Tracking Events). This schema is designed to meet reporting
+  requirements for the FDA Traceability Rule as specified here:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability"
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - FSMATraceabilityLot
+      - type: string
+        const: FSMATraceabilityLot
+  lotCode:
+    title: Lot Code
+    description: The code used to track this traceability lot along the supply chain.
+    type: string
+    $linkedData:
+      term: lotCode
+      '@id': https://www.gs1.org/voc/hasBatchLotNumber
+  lotCodeAssignmentMethod:
+    title: Lot Code Assignment Method
+    description: The method used to determine the code assigned to this traceability lot.
+    type: string
+    $linkedData:
+      term: lotCodeAssignmentMethod
+      '@id': https://schema.org/description
+  lotCodeGeneratorLocation:
+    title: Lot Code Generator Location
+    description: The location of the entity responsible for generating this lot code. [TODO is that right?]
+    $ref: ./Place.yml
+    $linkedData:
+      term: lotCodeGeneratorLocation
+      '@id': https://www.gs1.org/voc/Place
+  lotCodeGeneratorPOC:
+    title: Lot Code Generator Point of Contact [TODO should I also include the org? or is this enough? or is this even necessary, if we have the farm entity info?]
+    description: The point of contact for the party responsible for generating this lot code. [TODO is that right?]
+    $ref: ./Entity.yml
+    $linkedData:
+      term: lotCodeGeneratorPOC
+      '@id': https://schema.org/Person
+  lotType:
+    title: Lot Type
+    description: Value should be one of "originated" (i.e. grown), "transformed", or "created" (i.e. created from multiple ingredients NOT on traceability list).
+    type: string
+    $linkedData:
+      term: lotType
+      '@id': https://schema.org/additionalType
+  additionalData:
+    title: Additional Data
+    description: Additional Key Data Elements (KDEs).
+    type: array
+    items:
+      $ref: ./FSMAAbstractKDE.yml
+    $linkedData:
+      term: additionalData
+      '@id': https://w3id.org/traceability#FSMAAbstractKDE
+additionalProperties: false
+example: |-
+  {
+    "type": "FSMATraceabilityLot",
+    "lotCode": "CHE-MIG-TTF1-061321-H37J",
+    "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+    "lotCodeGeneratorLocation": {
+      "type": [
+        "Place"
+      ],
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "John's Produce",
+        "streetAddress": "4335 Walsh Underpass",
+        "addressLocality": "Port Mark",
+        "addressRegion": "LA",
+        "postalCode": "67391",
+        "addressCountry": "United States"
+      },
+      "locationName": "John's Tomato Farm #1"
+    },
+    "lotCodeGeneratorPOC": {
+      "type": "Entity",
+      "entityType" : "Person",
+      "name" : "John Davis",
+      "email": "jdavis@johnsproduce.com",
+      "phoneNumber": "129.697.0673"
+    },
+    "lotType": "originated"
+  }

--- a/docs/openapi/components/schemas/common/FSMATraceabilityLot.yml
+++ b/docs/openapi/components/schemas/common/FSMATraceabilityLot.yml
@@ -38,14 +38,14 @@ properties:
     $ref: ./Place.yml
     $linkedData:
       term: lotCodeGeneratorLocation
-      '@id': https://www.gs1.org/voc/Place
+      '@id': https://schema.org/location
   lotCodeGeneratorPOC:
     title: Lot Code Generator Point of Contact
     description: The point of contact for the party responsible for generating this lot code.
     $ref: ./Entity.yml
     $linkedData:
       term: lotCodeGeneratorPOC
-      '@id': https://schema.org/Person
+      '@id': https://schema.org/contactPoint
   lotType:
     title: Lot Type
     description: Value should be one of "originated" (i.e. grown), "transformed", or "created" (i.e. created from multiple ingredients NOT on traceability list).

--- a/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
@@ -1,0 +1,202 @@
+$linkedData:
+  term: FSMATransformingCTE
+  '@id': https://w3id.org/traceability#FSMATransformingCTE
+title: FSMA Transforming CTE
+description: >-
+  "Information regarding an FSMA Transforming CTE (Critical Tracking Event), designed to meet
+  reporting requirements for the FDA Traceability Rule as specified here:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability"
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - FSMATransformingCTE
+      - type: string
+        const: FSMATransformingCTE
+  foodUsed:
+    title: Food Used
+    description: The food used in transformation.
+    $ref: ./FSMAProduct.yml
+    $linkedData:
+      term: foodUsed
+      '@id': https://w3id.org/traceability#FSMAProduct
+  foodProduced:
+    title: Product
+    description: The food produced by transformation.
+    $ref: ./FSMAProduct.yml
+    $linkedData:
+      term: foodProduced
+      '@id': https://w3id.org/traceability#FSMAProduct
+  locationTransformed:
+    title: Location Transformed
+    description: Where the food was transformed.
+    $ref: ./Place.yml
+    $linkedData:
+      term: locationTransformed
+      '@id': https://schema.org/Place
+  dateCompleted:
+    title: Date Completed
+    description: The date transformation was completed in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
+    type: string
+    $linkedData:
+      term: dateCompleted
+      '@id': https://schema.org/DateTime
+  additionalData:
+    title: Additional Data
+    description: Additional Key Data Elements (KDEs).
+    type: array
+    items:
+      $ref: ./FSMAAbstractKDE.yml
+    $linkedData:
+      term: additionalData
+      '@id': https://w3id.org/traceability#FSMAAbstractKDE
+additionalProperties: false
+example: |-
+  {
+    "type": "FSMATransformingCTE",
+    "foodUsed": {
+      "type": "FSMAProduct",
+      "traceabilityLot": {
+        "type": "FSMATraceabilityLot",
+        "lotCode": "CHE-MIG-TTF1-061321-H37J",
+        "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+        "lotCodeGeneratorLocation": {
+          "type": [
+            "Place"
+          ],
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "John's Produce",
+            "streetAddress": "4335 Walsh Underpass",
+            "addressLocality": "Port Mark",
+            "addressRegion": "LA",
+            "postalCode": "67391",
+            "addressCountry": "United States"
+          },
+          "locationName": "John's Tomato Farm #1"
+        },
+        "lotCodeGeneratorPOC": {
+          "type": "Entity",
+          "entityType" : "Person",
+          "name" : "John Davis",
+          "email": "jdavis@johnsproduce.com",
+          "phoneNumber": "129.697.0673"
+        },
+        "lotType": "originated"
+      },
+      "quantityUnitMeasure": {
+        "type": [
+          "QuantitativeValue"
+        ],
+        "unitCode": "Field Bins",
+        "value": "7"
+      },
+      "additionalData": [
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Category code",
+          "value": "659351253"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Category name",
+          "value": "Tomatoes"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Brand name",
+          "value": "John's Produce"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Commodity",
+          "value": "Cherry Tomatoes"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Variety",
+          "value": "Mighty Sweet Hybrid"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Product name",
+          "value": "N/A"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Packaging size",
+          "value": "Bulk"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Packaging style",
+          "value": "Field Bins"
+        }
+      ]
+    },
+    "foodProduced": {
+      "type": "FSMAProduct",
+      "traceabilityLot": {
+        "type": "FSMATraceabilityLot",
+        "lotCode": "638854954425-FP-PP16-061221-6H08",
+        "lotCodeAssignmentMethod": "Lot codes are assigned based on the product ID, location, process date and a randomly generated string.",
+        "lotType": "transformed"
+      },
+      "quantityUnitMeasure": {
+        "type": [
+          "QuantitativeValue"
+        ],
+        "unitCode": "Cartons",
+        "value": "19"
+      },
+      "additionalData": [
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Category code",
+          "value": "212271504"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Category name",
+          "value": "Fruits and Vegetables (Fresh-Cut)"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Brand name",
+          "value": "Fresh Promise"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Commodity",
+          "value": "N/A"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Variety",
+          "value": "N/A"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Product name",
+          "value": "Garden Salad Kit 10 X 12 OZ"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Packaging size",
+          "value": "8 LB"
+        },
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Packaging style",
+          "value": "Cartons"
+        }
+      ]
+    },
+    "dateCompleted": "2022-01-06T00:00Z"
+  }

--- a/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
@@ -85,18 +85,13 @@ example: |-
           "type": "Entity",
           "entityType" : "Person",
           "name" : "John Davis",
-          "email": "jdavis@johnsproduce.com",
-          "phoneNumber": "129.697.0673"
+          "email": "produce@example.com",
+          "phoneNumber": "129-697-0673"
         },
         "lotType": "originated"
       },
-      "quantityUnitMeasure": {
-        "type": [
-          "QuantitativeValue"
-        ],
-        "unitCode": "Field Bins",
-        "value": "7"
-      },
+      "quantity": 7,
+      "unit": "Field Bins",
       "additionalData": [
         {
           "type": "FSMAAbstractKDE",
@@ -148,13 +143,8 @@ example: |-
         "lotCodeAssignmentMethod": "Lot codes are assigned based on the product ID, location, process date and a randomly generated string.",
         "lotType": "transformed"
       },
-      "quantityUnitMeasure": {
-        "type": [
-          "QuantitativeValue"
-        ],
-        "unitCode": "Cartons",
-        "value": "19"
-      },
+      "quantity": 19,
+      "unit": "Cartons",
       "additionalData": [
         {
           "type": "FSMAAbstractKDE",

--- a/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
@@ -37,14 +37,14 @@ properties:
     $ref: ./Place.yml
     $linkedData:
       term: locationTransformed
-      '@id': https://schema.org/Place
+      '@id': https://schema.org/location
   dateCompleted:
     title: Date Completed
     description: The date transformation was completed in 24hr ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
     type: string
     $linkedData:
       term: dateCompleted
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/Place.yml
+++ b/docs/openapi/components/schemas/common/Place.yml
@@ -57,6 +57,13 @@ properties:
     $linkedData:
       term: iataAirportCode
       '@id': https://onerecord.iata.org/cargo/Location#code
+  locationName:
+    title: Location Name
+    description: Physical Location Name (if available).
+    type: string
+    $linkedData:
+      term: locationName
+      '@id': https://schema.org/name
 additionalProperties: false
 example: |-
   {
@@ -76,5 +83,6 @@ example: |-
       "postalCode": "65587",
       "addressCountry": "Cyprus"
     },
-    "unLocode": "DKCPH"
+    "unLocode": "DKCPH",
+    "locationName": "Northwest Office"
   }

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
@@ -1,0 +1,170 @@
+$linkedData:
+  term: FSMACreatingCTECertificate
+  '@id': https://w3id.org/traceability#FSMACreatingCTECertificate
+title: FSMA Creating CTE Certificate
+description: >-
+  This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
+  "creating" CTE (Critical Tracking Event), as created by the responsible entity to meet the
+  requirements of the FDA Traceability Rule.
+
+  Additional information about the Traceability Rule & reporting requirements:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability
+
+  Examples of supply chain KDE records for certain foods: https://www.fda.gov/media/145838/download
+type: object
+properties:
+  '@context':
+    type: array
+    items:
+      const:
+        - 'https://www.w3.org/2018/credentials/v1'
+        - 'https://w3id.org/traceability/v1'
+  type:
+    type: array
+    items:
+      const:
+        - VerifiableCredential
+        - FSMACreatingCTECertificate
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  issuer:
+    type: object
+  credentialSubject:
+    $ref: ../common/FSMACreatingCTE.yml
+  proof:
+    type: object
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ../common/LinkRole.yml
+additionalProperties: false
+required: []
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "https://example.com/credential/123",
+    "type": [
+      "VerifiableCredential",
+      "FSMACreatingCTECertificate"
+    ],
+    "name": "FSMA Creating CTE Certificate",
+    "relatedLink": [
+      {
+        "type": [
+          "LinkRole"
+        ],
+        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
+        "linkRelationship": "traceabilityRuleInformationLink"
+      }
+    ],
+    "issuanceDate": "2021-12-11T03:50:55Z",
+    "issuer": {
+      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "type": "Organization",
+      "name": "Delicious Dips",
+      "description": "Delicious dips & related foodstuffs",
+      "address": {
+        "type": "PostalAddress",
+        "organizationName": "Delicious Dips",
+        "streetAddress": "755 Stephanie Gardens",
+        "addressLocality": "Rasmussenborough",
+        "addressRegion": "KS",
+        "postalCode": "90819",
+        "addressCountry": "United States"
+      },
+      "email": "service@deliciousdips.com",
+      "phoneNumber": "712.472.6159"
+    },
+    "credentialSubject": {
+      "type": "FSMACreatingCTE",
+      "foodCreated": {
+        "type": "FSMAProduct",
+        "traceabilityLot": {
+          "type": "FSMATraceabilityLot",
+          "lotCode": "2b1ed51f-f1da-49f6-8130-ac81d1e5e61d",
+          "lotCodeAssignmentMethod": "Lot codes are generated as a random UUID.",
+          "lotType": "created"
+        },
+        "quantityUnitMeasure": {
+          "type": [
+            "QuantitativeValue"
+          ],
+          "unitCode": "Crates",
+          "value": "50"
+        },
+        "additionalData": [
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Category code",
+            "value": "659351253"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Category name",
+            "value": "Nut butter"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Brand name",
+            "value": "Peter's Pantry"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Commodity",
+            "value": "Peanut Butter"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Product name",
+            "value": "PP PB"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Packaging size",
+            "value": "24 LB"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Packaging style",
+            "value": "Crates"
+          }
+        ]
+      },
+      "locationCreated": {
+        "type": [
+          "Place"
+        ],
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Delicious Dips",
+          "streetAddress": "755 Stephanie Gardens",
+          "addressLocality": "Rasmussenborough",
+          "addressRegion": "KS",
+          "postalCode": "90819",
+          "addressCountry": "United States"
+        },
+        "locationName": "Delicious Dips Production Center"
+      },
+      "dateCompleted": "2022-02-01T00:00Z"
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2022-07-15T17:21:40Z",
+      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..7pcW_T9jzXpYfxCyb_pNSAKBIO8i8FbIslzBRg35f-mauMAIYU8onNNZXyrmbvvFM6JW7QCPrDEWwikfyjM5Dg"
+    }
+  }

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
@@ -5,7 +5,7 @@ title: FSMA Creating CTE Certificate
 description: >-
   This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
   "creating" CTE (Critical Tracking Event), as created by the responsible entity to meet the
-  requirements of the FDA Traceability Rule.
+  requirements of the FSMA (Food Safety Modernization Act) Traceability Rule.
 
   Additional information about the Traceability Rule & reporting requirements:
   https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
@@ -96,13 +96,8 @@ example: |-
           "lotCodeAssignmentMethod": "Lot codes are generated as a random UUID.",
           "lotType": "created"
         },
-        "quantityUnitMeasure": {
-          "type": [
-            "QuantitativeValue"
-          ],
-          "unitCode": "Crates",
-          "value": "50"
-        },
+        "quantity": 50,
+        "unit": "Crates",
         "additionalData": [
           {
             "type": "FSMAAbstractKDE",
@@ -117,7 +112,7 @@ example: |-
           {
             "type": "FSMAAbstractKDE",
             "name": "Brand name",
-            "value": "Peter's Pantry"
+            "value": "Delicious Dips"
           },
           {
             "type": "FSMAAbstractKDE",
@@ -127,7 +122,7 @@ example: |-
           {
             "type": "FSMAAbstractKDE",
             "name": "Product name",
-            "value": "PP PB"
+            "value": "DD PB"
           },
           {
             "type": "FSMAAbstractKDE",
@@ -162,9 +157,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-19T01:26:11Z",
+      "created": "2022-07-19T04:04:13Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ApfaQmo1F-utLl8T-5KjX0T0H7-UQH5n1grt2xYx-rh2wpey_TxcHPSOhbLqer0VKb8f4wkihBbFfK1WW3uRAQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..nhRo_DdBCM8H5aDHSM2SUK2oBPrygH4dpVkh17zWax_wRBClaqKFyUAurwqmicmeQ3RFQo1t4TNxprTiulPNAA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
@@ -88,7 +88,7 @@ example: |-
     },
     "credentialSubject": {
       "type": "FSMACreatingCTE",
-      "foodCreated": {
+      "food": {
         "type": "FSMAProduct",
         "traceabilityLot": {
           "type": "FSMATraceabilityLot",
@@ -141,7 +141,7 @@ example: |-
           }
         ]
       },
-      "locationCreated": {
+      "location": {
         "type": [
           "Place"
         ],
@@ -162,9 +162,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-15T17:21:40Z",
+      "created": "2022-07-19T01:26:11Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..7pcW_T9jzXpYfxCyb_pNSAKBIO8i8FbIslzBRg35f-mauMAIYU8onNNZXyrmbvvFM6JW7QCPrDEWwikfyjM5Dg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ApfaQmo1F-utLl8T-5KjX0T0H7-UQH5n1grt2xYx-rh2wpey_TxcHPSOhbLqer0VKb8f4wkihBbFfK1WW3uRAQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
@@ -112,8 +112,8 @@ example: |-
           "type": "Entity",
           "entityType": "Person",
           "name": "John Davis",
-          "email": "jdavis@johnsproduce.com",
-          "phoneNumber": "129.697.0673"
+          "email": "produce@example.com",
+          "phoneNumber": "129-697-0673"
         },
         "lotType": "originated"
       },
@@ -140,9 +140,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-15T17:21:40Z",
+      "created": "2022-07-19T03:54:51Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..9GRXnixj8DPJu-NrzFmba_2anzsvLwNXh3uQdT9jGfsLUs1HTd1BLW74TVSedMHt22lDtB0lwfXFgGEsUXIQCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..v67UEHjHK2gmeCNuU1l--_pHtbdqIRkMMuNRt2_K3NK2sBb3lbxqrNh6ShiNnIAIQ9PERj5l9oIlFLmLGe_TBA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
@@ -4,8 +4,8 @@ $linkedData:
 title: FSMA First Receiver Data Certificate
 description: >-
   This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
-  "first receiver" data, as created by the responsible entity to meet the requirements of the FDA
-  Traceability Rule.
+  "first receiver" data, as created by the responsible entity to meet the requirements of the FSMA
+  (Food Safety Modernization Act) Traceability Rule.
 
   Additional information about the Traceability Rule & reporting requirements:
   https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
@@ -1,0 +1,148 @@
+$linkedData:
+  term: FSMAFirstReceiverDataCertificate
+  '@id': https://w3id.org/traceability#FSMAFirstReceiverDataCertificate
+title: FSMA First Receiver Data Certificate
+description: >-
+  This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
+  "first receiver" data, as created by the responsible entity to meet the requirements of the FDA
+  Traceability Rule.
+
+  Additional information about the Traceability Rule & reporting requirements:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability
+
+  Examples of supply chain KDE records for certain foods: https://www.fda.gov/media/145838/download
+type: object
+properties:
+  '@context':
+    type: array
+    items:
+      const:
+        - 'https://www.w3.org/2018/credentials/v1'
+        - 'https://w3id.org/traceability/v1'
+  type:
+    type: array
+    items:
+      const:
+        - VerifiableCredential
+        - FSMAFirstReceiverDataCertificate
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  issuer:
+    type: object
+  credentialSubject:
+    $ref: ../common/FSMAFirstReceiverData.yml
+  proof:
+    type: object
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ../common/LinkRole.yml
+additionalProperties: false
+required: []
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "https://example.com/credential/123",
+    "type": [
+      "VerifiableCredential",
+      "FSMAFirstReceiverDataCertificate"
+    ],
+    "name": "FSMA First Receiver Data Certificate",
+    "relatedLink": [
+      {
+        "type": [
+          "LinkRole"
+        ],
+        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
+        "linkRelationship": "traceabilityRuleInformationLink"
+      }
+    ],
+    "issuanceDate": "2021-12-11T03:50:55Z",
+    "issuer": {
+      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "type": "Organization",
+      "name": "Fresh Promise",
+      "description": "The very freshest transformed goods",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "374 Fischer Dam Suite 435",
+        "addressLocality": "Port Mark",
+        "addressRegion": "LA",
+        "postalCode": "67391",
+        "addressCountry": "United States"
+      },
+      "email": "internal@freshpromise.com",
+      "phoneNumber": "175.353.7703"
+    },
+    "credentialSubject": {
+      "type": "FSMAFirstReceiverData",
+      "traceabilityLot": {
+        "type": "FSMATraceabilityLot",
+        "lotCode": "CHE-MIG-TTF1-061321-H37J",
+        "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+        "lotCodeGeneratorLocation": {
+          "type": [
+            "Place"
+          ],
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "John's Produce",
+            "streetAddress": "4335 Walsh Underpass",
+            "addressLocality": "Port Mark",
+            "addressRegion": "LA",
+            "postalCode": "67391",
+            "addressCountry": "United States"
+          },
+          "locationName": "John's Tomato Farm #1"
+        },
+        "lotCodeGeneratorPOC": {
+          "type": "Entity",
+          "entityType": "Person",
+          "name": "John Davis",
+          "email": "jdavis@johnsproduce.com",
+          "phoneNumber": "129.697.0673"
+        },
+        "lotType": "originated"
+      },
+      "originatorLocation": {
+        "type": [
+          "Place"
+        ],
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "John's Produce",
+          "streetAddress": "4335 Walsh Underpass",
+          "addressLocality": "Port Mark",
+          "addressRegion": "LA",
+          "postalCode": "67391",
+          "addressCountry": "United States"
+        },
+        "locationName": "John's Tomato Farm #1"
+      },
+      "harvestDate": "2022-01-03T00:00Z",
+      "coolingDate": "2022-01-07T00:00Z",
+      "packingDate": "2022-02-03T00:00Z"
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2022-07-15T17:21:40Z",
+      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..9GRXnixj8DPJu-NrzFmba_2anzsvLwNXh3uQdT9jGfsLUs1HTd1BLW74TVSedMHt22lDtB0lwfXFgGEsUXIQCw"
+    }
+  }

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
@@ -5,7 +5,7 @@ title: FSMA Growing CTE Certificate
 description: >-
   This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
   "growing" CTE (Critical Tracking Event), as created by the responsible entity to meet the
-  requirements of the FDA Traceability Rule.
+  requirements of the FSMA (Food Safety Modernization Act) Traceability Rule.
 
   Additional information about the Traceability Rule & reporting requirements:
   https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
@@ -1,0 +1,135 @@
+$linkedData:
+  term: FSMAGrowingCTECertificate
+  '@id': https://w3id.org/traceability#FSMAGrowingCTECertificate
+title: FSMA Growing CTE Certificate
+description: >-
+  This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
+  "growing" CTE (Critical Tracking Event), as created by the responsible entity to meet the
+  requirements of the FDA Traceability Rule.
+
+  Additional information about the Traceability Rule & reporting requirements:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability
+
+  Examples of supply chain KDE records for certain foods: https://www.fda.gov/media/145838/download
+type: object
+properties:
+  '@context':
+    type: array
+    items:
+      const:
+        - 'https://www.w3.org/2018/credentials/v1'
+        - 'https://w3id.org/traceability/v1'
+  type:
+    type: array
+    items:
+      const:
+        - VerifiableCredential
+        - FSMAGrowingCTECertificate
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  issuer:
+    type: object
+  credentialSubject:
+    $ref: ../common/FSMAGrowingCTE.yml
+  proof:
+    type: object
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ../common/LinkRole.yml
+additionalProperties: false
+required: []
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "https://example.com/credential/123",
+    "type": [
+      "VerifiableCredential",
+      "FSMAGrowingCTECertificate"
+    ],
+    "name": "FSMA Growing CTE Certificate",
+    "relatedLink": [
+      {
+        "type": [
+          "LinkRole"
+        ],
+        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
+        "linkRelationship": "traceabilityRuleInformationLink"
+      }
+    ],
+    "issuanceDate": "2021-12-11T03:50:55Z",
+    "issuer": {
+      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "type": "Organization",
+      "name": "John's Produce",
+      "description": "Producing top quality agricultural products since 1932",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "4335 Walsh Underpass",
+        "addressLocality": "Port Mark",
+        "addressRegion": "LA",
+        "postalCode": "67391",
+        "addressCountry": "United States"
+      },
+      "email": "john@johnsproduce.com",
+      "phoneNumber": "146.829.0249"
+    },
+    "credentialSubject": {
+      "type": "FSMAGrowingCTE",
+      "traceabilityLot": {
+        "type": "FSMATraceabilityLot",
+        "lotCode": "CHE-MIG-TTF1-061321-H37J",
+        "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+        "lotCodeGeneratorLocation": {
+          "type": [
+            "Place"
+          ],
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "John's Produce",
+            "streetAddress": "4335 Walsh Underpass",
+            "addressLocality": "Port Mark",
+            "addressRegion": "LA",
+            "postalCode": "67391",
+            "addressCountry": "United States"
+          },
+          "locationName": "John's Tomato Farm #1"
+        },
+        "lotCodeGeneratorPOC": {
+          "type": "Entity",
+          "entityType": "Person",
+          "name": "John Davis",
+          "email": "jdavis@johnsproduce.com",
+          "phoneNumber": "129.697.0673"
+        },
+        "lotType": "originated"
+      },
+      "growingAreaCoordinates": {
+        "type": [
+          "GeoCoordinates"
+        ],
+        "latitude": "44.859038",
+        "longitude": "70.916213"
+      }
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2022-07-15T17:21:40Z",
+      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..4wUzK7rBMIG927jbJmrcHNlf-890f_lCdGPB8TAhXfep6P0eESzKPt7gV9hCU-2o9kOHuaYng-CFyDQmgcllCQ"
+    }
+  }

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
@@ -112,8 +112,8 @@ example: |-
           "type": "Entity",
           "entityType": "Person",
           "name": "John Davis",
-          "email": "jdavis@johnsproduce.com",
-          "phoneNumber": "129.697.0673"
+          "email": "produce@example.com",
+          "phoneNumber": "129-697-0673"
         },
         "lotType": "originated"
       },
@@ -127,9 +127,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-15T17:21:40Z",
+      "created": "2022-07-19T03:54:51Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..4wUzK7rBMIG927jbJmrcHNlf-890f_lCdGPB8TAhXfep6P0eESzKPt7gV9hCU-2o9kOHuaYng-CFyDQmgcllCQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..4n0o_hhqPHkz4sDNMZvdan8ZrtMG1oobeaDMniyGc5pnnQ0QWpJuqO_hczrcDJ11QAcj4he4kF2FVS-mz7j7CQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
@@ -1,0 +1,245 @@
+$linkedData:
+  term: FSMAReceivingCTECertificate
+  '@id': https://w3id.org/traceability#FSMAReceivingCTECertificate
+title: FSMA Receiving CTE Certificate
+description: >-
+  This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
+  "receiving" CTE (Critical Tracking Event), as created by the responsible entity to meet the
+  requirements of the FDA Traceability Rule.
+
+  Additional information about the Traceability Rule & reporting requirements:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability
+
+  Examples of supply chain KDE records for certain foods: https://www.fda.gov/media/145838/download
+type: object
+properties:
+  '@context':
+    type: array
+    items:
+      const:
+        - 'https://www.w3.org/2018/credentials/v1'
+        - 'https://w3id.org/traceability/v1'
+  type:
+    type: array
+    items:
+      const:
+        - VerifiableCredential
+        - FSMAReceivingCTECertificate
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  issuer:
+    type: object
+  credentialSubject:
+    $ref: ../common/FSMAReceivingCTE.yml
+  proof:
+    type: object
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ../common/LinkRole.yml
+additionalProperties: false
+required: []
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "https://example.com/credential/123",
+    "type": [
+      "VerifiableCredential",
+      "FSMAReceivingCTECertificate"
+    ],
+    "name": "FSMA Receiving CTE Certificate",
+    "relatedLink": [
+      {
+        "type": [
+          "LinkRole"
+        ],
+        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
+        "linkRelationship": "traceabilityRuleInformationLink"
+      }
+    ],
+    "issuanceDate": "2021-12-11T03:50:55Z",
+    "issuer": {
+      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "type": "Organization",
+      "name": "Fresh Promise",
+      "description": "The very freshest transformed goods",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "374 Fischer Dam Suite 435",
+        "addressLocality": "Port Mark",
+        "addressRegion": "LA",
+        "postalCode": "67391",
+        "addressCountry": "United States"
+      },
+      "email": "internal@freshpromise.com",
+      "phoneNumber": "175.353.7703"
+    },
+    "credentialSubject": {
+      "type": "FSMAReceivingCTE",
+      "shipment": {
+        "type": "FSMAShipment",
+        "product": {
+          "type": "FSMAProduct",
+          "traceabilityLot": {
+            "type": "FSMATraceabilityLot",
+            "lotCode": "CHE-MIG-TTF1-061321-H37J",
+            "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+            "lotCodeGeneratorLocation": {
+              "type": [
+                "Place"
+              ],
+              "address": {
+                "type": [
+                  "PostalAddress"
+                ],
+                "organizationName": "John's Produce",
+                "streetAddress": "4335 Walsh Underpass",
+                "addressLocality": "Port Mark",
+                "addressRegion": "LA",
+                "postalCode": "67391",
+                "addressCountry": "United States"
+              },
+              "locationName": "John's Tomato Farm #1"
+            },
+            "lotCodeGeneratorPOC": {
+              "type": "Entity",
+              "entityType": "Person",
+              "name": "John Davis",
+              "email": "jdavis@johnsproduce.com",
+              "phoneNumber": "129.697.0673"
+            },
+            "lotType": "originated"
+          },
+          "quantityUnitMeasure": {
+            "type": [
+              "QuantitativeValue"
+            ],
+            "unitCode": "Field Bins",
+            "value": "103"
+          },
+          "additionalData": [
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Category code",
+              "value": "659351253"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Category name",
+              "value": "Tomatoes"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Brand name",
+              "value": "John's Produce"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Commodity",
+              "value": "Cherry Tomatoes"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Variety",
+              "value": "Mighty Sweet Hybrid"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Product name",
+              "value": "N/A"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Packaging size",
+              "value": "Bulk"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Packaging style",
+              "value": "Field Bins"
+            }
+          ]
+        },
+        "from": {
+          "type": [
+            "Place"
+          ],
+          "geo": {
+            "type": "GeoCoordinates",
+            "latitude": "44.859038",
+            "longitude": "70.916213"
+          },
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "John's Produce",
+            "streetAddress": "4335 Walsh Underpass",
+            "addressLocality": "Port Mark",
+            "addressRegion": "LA",
+            "postalCode": "67391",
+            "addressCountry": "United States"
+          },
+          "locationName": "John's Tomato Farm #1"
+        },
+        "to": {
+          "type": [
+            "Place"
+          ],
+          "geo": {
+            "type": "GeoCoordinates",
+            "latitude": "31.319706",
+            "longitude": "-92.117524"
+          },
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "Pattie's Packers",
+            "streetAddress": "8974 Bolton Drive",
+            "addressLocality": "Port Mark",
+            "addressRegion": "LA",
+            "postalCode": "67391",
+            "addressCountry": "United States"
+          },
+          "locationName": "PP Packing Shed"
+        },
+        "additionalData": [
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Reference record type and number",
+            "value": "BOL 24884"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Import entry number",
+            "value": "N/A"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Transporter name",
+            "value": "Local Trucking Co."
+          }
+        ]
+      },
+      "dateShipped": "2022-01-03T00:00Z"
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2022-07-15T17:21:41Z",
+      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..9ml1OsbOX-B9y3Ozysa8CkLRKiOfInTQlCIBrM8kSsyASCY-ppTTHpB-NDboJOGQzqY5pB4Mys0BrCrnhNoQBg"
+    }
+  }

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
@@ -116,18 +116,13 @@ example: |-
               "type": "Entity",
               "entityType": "Person",
               "name": "John Davis",
-              "email": "jdavis@johnsproduce.com",
-              "phoneNumber": "129.697.0673"
+              "email": "produce@example.com",
+              "phoneNumber": "129-697-0673"
             },
             "lotType": "originated"
           },
-          "quantityUnitMeasure": {
-            "type": [
-              "QuantitativeValue"
-            ],
-            "unitCode": "Field Bins",
-            "value": "103"
-          },
+          "quantity": 103,
+          "unit": "Field Bins",
           "additionalData": [
             {
               "type": "FSMAAbstractKDE",
@@ -237,9 +232,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-15T17:21:41Z",
+      "created": "2022-07-19T04:04:13Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..9ml1OsbOX-B9y3Ozysa8CkLRKiOfInTQlCIBrM8kSsyASCY-ppTTHpB-NDboJOGQzqY5pB4Mys0BrCrnhNoQBg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wib7IrWfSELBuhULLjJhnKbCjdM5a4TfcJKzowW7OGe_3mPQXcw87p-b70GM38HwxDUXRDkSNFZxPhVy1k1lCw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
@@ -5,7 +5,7 @@ title: FSMA Receiving CTE Certificate
 description: >-
   This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
   "receiving" CTE (Critical Tracking Event), as created by the responsible entity to meet the
-  requirements of the FDA Traceability Rule.
+  requirements of the FSMA (Food Safety Modernization Act) Traceability Rule.
 
   Additional information about the Traceability Rule & reporting requirements:
   https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
@@ -1,0 +1,252 @@
+$linkedData:
+  term: FSMAShippingCTECertificate
+  '@id': https://w3id.org/traceability#FSMAShippingCTECertificate
+title: FSMA Shipping CTE Certificate
+description: >-
+  This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
+  "shipping" CTE (Critical Tracking Event), as created by the responsible entity to meet the
+  requirements of the FDA Traceability Rule.
+
+  Additional information about the Traceability Rule & reporting requirements:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability
+
+  Examples of supply chain KDE records for certain foods: https://www.fda.gov/media/145838/download
+type: object
+properties:
+  '@context':
+    type: array
+    items:
+      const:
+        - 'https://www.w3.org/2018/credentials/v1'
+        - 'https://w3id.org/traceability/v1'
+  type:
+    type: array
+    items:
+      const:
+        - VerifiableCredential
+        - FSMAShippingCTECertificate
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  issuer:
+    type: object
+  credentialSubject:
+    $ref: ../common/FSMAShippingCTE.yml
+  proof:
+    type: object
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ../common/LinkRole.yml
+additionalProperties: false
+required: []
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "https://example.com/credential/123",
+    "type": [
+      "VerifiableCredential",
+      "FSMAShippingCTECertificate"
+    ],
+    "name": "FSMA Shipping CTE Certificate",
+    "relatedLink": [
+      {
+        "type": [
+          "LinkRole"
+        ],
+        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
+        "linkRelationship": "traceabilityRuleInformationLink"
+      }
+    ],
+    "issuanceDate": "2021-12-11T03:50:55Z",
+    "issuer": {
+      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "type": "Organization",
+      "name": "John's Produce",
+      "description": "Producing top quality agricultural products since 1932",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "4335 Walsh Underpass",
+        "addressLocality": "Port Mark",
+        "addressRegion": "LA",
+        "postalCode": "67391",
+        "addressCountry": "United States"
+      },
+      "email": "john@johnsproduce.com",
+      "phoneNumber": "146.829.0249"
+    },
+    "credentialSubject": {
+      "type": "FSMAShippingCTE",
+      "shipment": {
+        "type": "FSMAShipment",
+        "product": {
+          "type": "FSMAProduct",
+          "traceabilityLot": {
+            "type": "FSMATraceabilityLot",
+            "lotCode": "CHE-MIG-TTF1-061321-H37J",
+            "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+            "lotCodeGeneratorLocation": {
+              "type": [
+                "Place"
+              ],
+              "address": {
+                "type": [
+                  "PostalAddress"
+                ],
+                "organizationName": "John's Produce",
+                "streetAddress": "4335 Walsh Underpass",
+                "addressLocality": "Port Mark",
+                "addressRegion": "LA",
+                "postalCode": "67391",
+                "addressCountry": "United States"
+              },
+              "locationName": "John's Tomato Farm #1"
+            },
+            "lotCodeGeneratorPOC": {
+              "type": "Entity",
+              "entityType": "Person",
+              "name": "John Davis",
+              "email": "jdavis@johnsproduce.com",
+              "phoneNumber": "129.697.0673"
+            },
+            "lotType": "originated"
+          },
+          "quantityUnitMeasure": {
+            "type": [
+              "QuantitativeValue"
+            ],
+            "unitCode": "Field Bins",
+            "value": "103"
+          },
+          "additionalData": [
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Category code",
+              "value": "659351253"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Category name",
+              "value": "Tomatoes"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Brand name",
+              "value": "John's Produce"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Commodity",
+              "value": "Cherry Tomatoes"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Variety",
+              "value": "Mighty Sweet Hybrid"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Product name",
+              "value": "N/A"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Packaging size",
+              "value": "Bulk"
+            },
+            {
+              "type": "FSMAAbstractKDE",
+              "name": "Packaging style",
+              "value": "Field Bins"
+            }
+          ]
+        },
+        "from": {
+          "type": [
+            "Place"
+          ],
+          "geo": {
+            "type": "GeoCoordinates",
+            "latitude": "44.859038",
+            "longitude": "70.916213"
+          },
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "John's Produce",
+            "streetAddress": "4335 Walsh Underpass",
+            "addressLocality": "Port Mark",
+            "addressRegion": "LA",
+            "postalCode": "67391",
+            "addressCountry": "United States"
+          },
+          "locationName": "John's Tomato Farm #1"
+        },
+        "to": {
+          "type": [
+            "Place"
+          ],
+          "geo": {
+            "type": "GeoCoordinates",
+            "latitude": "31.319706",
+            "longitude": "-92.117524"
+          },
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "organizationName": "Pattie's Packers",
+            "streetAddress": "8974 Bolton Drive",
+            "addressLocality": "Port Mark",
+            "addressRegion": "LA",
+            "postalCode": "67391",
+            "addressCountry": "United States"
+          },
+          "locationName": "PP Packing Shed"
+        },
+        "additionalData": [
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Reference record type and number",
+            "value": "BOL 24884"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Import entry number",
+            "value": "N/A"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Transporter name",
+            "value": "Local Trucking Co."
+          }
+        ]
+      },
+      "dateShipped": "2022-01-01T00:00Z",
+      "additionalData": [
+        {
+          "type": "FSMAAbstractKDE",
+          "name": "Statement if the shipper is a farm",
+          "value": "TRUE"
+        }
+      ]
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2022-07-15T17:21:41Z",
+      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..z6ec_qlviORjrxZ5FAXcoWsyrg1LN7LcE0ZGJ7gMFOWy4lPEAAsWSRwglyTE9wRo2eBDePNcGZjQ4H3a9aFWCw"
+    }
+  }

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
@@ -5,7 +5,7 @@ title: FSMA Shipping CTE Certificate
 description: >-
   This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
   "shipping" CTE (Critical Tracking Event), as created by the responsible entity to meet the
-  requirements of the FDA Traceability Rule.
+  requirements of the FSMA (Food Safety Modernization Act) Traceability Rule.
 
   Additional information about the Traceability Rule & reporting requirements:
   https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
@@ -116,18 +116,13 @@ example: |-
               "type": "Entity",
               "entityType": "Person",
               "name": "John Davis",
-              "email": "jdavis@johnsproduce.com",
-              "phoneNumber": "129.697.0673"
+              "email": "produce@example.com",
+              "phoneNumber": "129-697-0673"
             },
             "lotType": "originated"
           },
-          "quantityUnitMeasure": {
-            "type": [
-              "QuantitativeValue"
-            ],
-            "unitCode": "Field Bins",
-            "value": "103"
-          },
+          "quantity": 103,
+          "unit": "Field Bins",
           "additionalData": [
             {
               "type": "FSMAAbstractKDE",
@@ -244,9 +239,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-15T17:21:41Z",
+      "created": "2022-07-19T04:04:13Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..z6ec_qlviORjrxZ5FAXcoWsyrg1LN7LcE0ZGJ7gMFOWy4lPEAAsWSRwglyTE9wRo2eBDePNcGZjQ4H3a9aFWCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..kad-9d1qxqgFIeDF-vCRsyGLToEY1egr_18LPCN-F6Op-sTAfax7MCMy1gR4iYmJhtvFhcMT2pYMVJsdu79VCg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
@@ -1,0 +1,239 @@
+$linkedData:
+  term: FSMATransformingCTECertificate
+  '@id': https://w3id.org/traceability#FSMATransformingCTECertificate
+title: FSMA Transforming CTE Certificate
+description: >-
+  This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
+  "transforming" CTE (Critical Tracking Event), as created by the responsible entity to meet the
+  requirements of the FDA Traceability Rule.
+
+  Additional information about the Traceability Rule & reporting requirements:
+  https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability
+
+  Examples of supply chain KDE records for certain foods: https://www.fda.gov/media/145838/download
+type: object
+properties:
+  '@context':
+    type: array
+    items:
+      const:
+        - 'https://www.w3.org/2018/credentials/v1'
+        - 'https://w3id.org/traceability/v1'
+  type:
+    type: array
+    items:
+      const:
+        - VerifiableCredential
+        - FSMATransformingCTECertificate
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  issuer:
+    type: object
+  credentialSubject:
+    $ref: ../common/FSMATransformingCTE.yml
+  proof:
+    type: object
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ../common/LinkRole.yml
+additionalProperties: false
+required: []
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "https://example.com/credential/123",
+    "type": [
+      "VerifiableCredential",
+      "FSMATransformingCTECertificate"
+    ],
+    "name": "FSMA Transforming CTE Certificate",
+    "relatedLink": [
+      {
+        "type": [
+          "LinkRole"
+        ],
+        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
+        "linkRelationship": "traceabilityRuleInformationLink"
+      }
+    ],
+    "issuanceDate": "2021-12-11T03:50:55Z",
+    "issuer": {
+      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "type": "Organization",
+      "name": "Fresh Promise",
+      "description": "The very freshest transformed goods",
+      "address": {
+        "type": "PostalAddress",
+        "streetAddress": "374 Fischer Dam Suite 435",
+        "addressLocality": "Port Mark",
+        "addressRegion": "LA",
+        "postalCode": "67391",
+        "addressCountry": "United States"
+      },
+      "email": "internal@freshpromise.com",
+      "phoneNumber": "175.353.7703"
+    },
+    "credentialSubject": {
+      "type": "FSMATransformingCTE",
+      "foodUsed": {
+        "type": "FSMAProduct",
+        "traceabilityLot": {
+          "type": "FSMATraceabilityLot",
+          "lotCode": "CHE-MIG-TTF1-061321-H37J",
+          "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
+          "lotCodeGeneratorLocation": {
+            "type": [
+              "Place"
+            ],
+            "address": {
+              "type": [
+                "PostalAddress"
+              ],
+              "organizationName": "John's Produce",
+              "streetAddress": "4335 Walsh Underpass",
+              "addressLocality": "Port Mark",
+              "addressRegion": "LA",
+              "postalCode": "67391",
+              "addressCountry": "United States"
+            },
+            "locationName": "John's Tomato Farm #1"
+          },
+          "lotCodeGeneratorPOC": {
+            "type": "Entity",
+            "entityType": "Person",
+            "name": "John Davis",
+            "email": "jdavis@johnsproduce.com",
+            "phoneNumber": "129.697.0673"
+          },
+          "lotType": "originated"
+        },
+        "quantityUnitMeasure": {
+          "type": [
+            "QuantitativeValue"
+          ],
+          "unitCode": "Field Bins",
+          "value": "7"
+        },
+        "additionalData": [
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Category code",
+            "value": "659351253"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Category name",
+            "value": "Tomatoes"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Brand name",
+            "value": "John's Produce"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Commodity",
+            "value": "Cherry Tomatoes"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Variety",
+            "value": "Mighty Sweet Hybrid"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Product name",
+            "value": "N/A"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Packaging size",
+            "value": "Bulk"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Packaging style",
+            "value": "Field Bins"
+          }
+        ]
+      },
+      "foodProduced": {
+        "type": "FSMAProduct",
+        "traceabilityLot": {
+          "type": "FSMATraceabilityLot",
+          "lotCode": "638854954425-FP-PP16-061221-6H08",
+          "lotCodeAssignmentMethod": "Lot codes are assigned based on the product ID, location, process date and a randomly generated string.",
+          "lotType": "transformed"
+        },
+        "quantityUnitMeasure": {
+          "type": [
+            "QuantitativeValue"
+          ],
+          "unitCode": "Cartons",
+          "value": "19"
+        },
+        "additionalData": [
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Category code",
+            "value": "212271504"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Category name",
+            "value": "Fruits and Vegetables (Fresh-Cut)"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Brand name",
+            "value": "Fresh Promise"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Commodity",
+            "value": "N/A"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Variety",
+            "value": "N/A"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Product name",
+            "value": "Garden Salad Kit 10 X 12 OZ"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Packaging size",
+            "value": "8 LB"
+          },
+          {
+            "type": "FSMAAbstractKDE",
+            "name": "Packaging style",
+            "value": "Cartons"
+          }
+        ]
+      },
+      "dateCompleted": "2022-01-06T00:00Z"
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2022-07-15T17:21:41Z",
+      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..9wIBaPkLYC2QXI7UW32ZvjcAuxw7CMt06bHTUe_Uu0tCs5I_k7w9L73pk4eVc9_pQdHKdvSfhmRHME1nyUfjBw"
+    }
+  }

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
@@ -114,18 +114,13 @@ example: |-
             "type": "Entity",
             "entityType": "Person",
             "name": "John Davis",
-            "email": "jdavis@johnsproduce.com",
-            "phoneNumber": "129.697.0673"
+            "email": "produce@example.com",
+            "phoneNumber": "129-697-0673"
           },
           "lotType": "originated"
         },
-        "quantityUnitMeasure": {
-          "type": [
-            "QuantitativeValue"
-          ],
-          "unitCode": "Field Bins",
-          "value": "7"
-        },
+        "quantity": 7,
+        "unit": "Field Bins",
         "additionalData": [
           {
             "type": "FSMAAbstractKDE",
@@ -177,13 +172,8 @@ example: |-
           "lotCodeAssignmentMethod": "Lot codes are assigned based on the product ID, location, process date and a randomly generated string.",
           "lotType": "transformed"
         },
-        "quantityUnitMeasure": {
-          "type": [
-            "QuantitativeValue"
-          ],
-          "unitCode": "Cartons",
-          "value": "19"
-        },
+        "quantity": 19,
+        "unit": "Cartons",
         "additionalData": [
           {
             "type": "FSMAAbstractKDE",
@@ -231,9 +221,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-15T17:21:41Z",
+      "created": "2022-07-19T04:04:13Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..9wIBaPkLYC2QXI7UW32ZvjcAuxw7CMt06bHTUe_Uu0tCs5I_k7w9L73pk4eVc9_pQdHKdvSfhmRHME1nyUfjBw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..UB0JLwHI2MIgXX3DQRzkLozxt4ePsT_rOAmNUKaFj2qeJ1ClFXtwpgxYb3OCmJ91bjEdA6V-1DsVae8WMHQ7Ag"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
@@ -5,7 +5,7 @@ title: FSMA Transforming CTE Certificate
 description: >-
   This certificate represents a secure digital record of the KDEs (Key Data Elements) for the
   "transforming" CTE (Critical Tracking Event), as created by the responsible entity to meet the
-  requirements of the FDA Traceability Rule.
+  requirements of the FSMA (Food Safety Modernization Act) Traceability Rule.
 
   Additional information about the Traceability Rule & reporting requirements:
   https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -332,6 +332,126 @@ paths:
                 $ref: './components/schemas/common/Event.yml'
     
 
+  /schemas/common/FSMAAbstractKDE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAAbstractKDE.yml'
+    
+
+  /schemas/common/FSMACreatingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMACreatingCTE.yml'
+    
+
+  /schemas/common/FSMAFirstReceiverData.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAFirstReceiverData.yml'
+    
+
+  /schemas/common/FSMAGrowingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAGrowingCTE.yml'
+    
+
+  /schemas/common/FSMAProduct.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAProduct.yml'
+    
+
+  /schemas/common/FSMAReceivingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAReceivingCTE.yml'
+    
+
+  /schemas/common/FSMAShipment.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAShipment.yml'
+    
+
+  /schemas/common/FSMAShippingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAShippingCTE.yml'
+    
+
+  /schemas/common/FSMATraceabilityLot.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMATraceabilityLot.yml'
+    
+
+  /schemas/common/FSMATransformingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMATransformingCTE.yml'
+    
+
   /schemas/common/FoodGradeInspection.yml:
     get:
       tags:
@@ -1518,6 +1638,78 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/EntrySummaryCertificate.yml'
+    
+
+  /schemas/credentials/FSMACreatingCTECertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FSMACreatingCTECertificate.yml'
+    
+
+  /schemas/credentials/FSMAFirstReceiverDataCertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml'
+    
+
+  /schemas/credentials/FSMAGrowingCTECertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FSMAGrowingCTECertificate.yml'
+    
+
+  /schemas/credentials/FSMAReceivingCTECertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FSMAReceivingCTECertificate.yml'
+    
+
+  /schemas/credentials/FSMAShippingCTECertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FSMAShippingCTECertificate.yml'
+    
+
+  /schemas/credentials/FSMATransformingCTECertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FSMATransformingCTECertificate.yml'
     
 
   /schemas/credentials/FoodGradeInspectionCertificate.yml:


### PR DESCRIPTION
This PR creates several schemas & corresponding certificates representing the Critical Tracking Events (CTEs) & Key Data Elements (KDEs) which ag supply chain organizations will be required to report once the upcoming FSMA Traceability Rule takes effect.

Outline of the FSMA Proposed Rule for Food Traceability: https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability

Details about KDEs required for reporting on the various CTEs: https://www.fda.gov/food/food-safety-modernization-act-fsma/which-key-data-elements-would-apply-me

Mock data for reporting on an example product: https://www.fda.gov/media/145838/download