### PR TITLE
chore: rename ag to agriculture for clarity

### DIFF
--- a/docs/openapi/components/schemas/common/AgricultureActivity.yml
+++ b/docs/openapi/components/schemas/common/AgricultureActivity.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: AgActivity
-  '@id': https://w3id.org/traceability#AgActivity
-title: Agricultural Activity
+  term: AgricultureActivity
+  '@id': https://w3id.org/traceability#AgricultureActivity
+title: Agriculture Activity
 description: >-
   An activity that takes place on the farm that needs to be recorded, such as
   planting, harvesting, applying fertilizer, etc.
@@ -13,9 +13,9 @@ properties:
         items:
           type: string
           enum:
-            - AgActivity
+            - AgricultureActivity
       - type: string
-        const: AgActivity
+        const: AgricultureActivity
   business:
     title: Business
     description: The business entity performing the activity.
@@ -54,14 +54,14 @@ properties:
     $linkedData:
       term: activityType
       '@id': https://www.schema.org/value
-  agProduct:
+  agricultureProduct:
     title: Product List
     description: Agricultural Product the Activity was performed on if known
     type: array
     items:
-      $ref: ./AgProduct.yml
+      $ref: ./AgricultureProduct.yml
     $linkedData:
-      term: agProduct
+      term: agricultureProduct
       '@id': https://schema.org/ItemList
       '@type': https://schema.org/ItemList
   observation:
@@ -79,7 +79,7 @@ properties:
 additionalProperties: true
 example: |-
   {
-    "type": "AgActivity",
+    "type": "AgricultureActivity",
     "farm": {
       "type": [
         "Person"
@@ -125,10 +125,10 @@ example: |-
     },
     "activityDate": "2020-02-15",
     "activityType": "spray",
-    "agProduct": [
+    "agricultureProduct": [
       {
         "type": [
-          "AgProduct"
+          "AgricultureProduct"
         ],
         "upc": "033383401508",
         "plu": "94225",
@@ -171,7 +171,7 @@ example: |-
       },
       {
         "type": [
-          "AgProduct"
+          "AgricultureProduct"
         ],
         "upc": "033383401508",
         "plu": "94225",

--- a/docs/openapi/components/schemas/common/AgricultureInspectionReport.yml
+++ b/docs/openapi/components/schemas/common/AgricultureInspectionReport.yml
@@ -1,6 +1,6 @@
 $linkedData:
-  term: AgInspectionReport
-  '@id': https://w3id.org/traceability#AgInspectionReport
+  term: AgricultureInspectionReport
+  '@id': https://w3id.org/traceability#AgricultureInspectionReport
 title: Agriculture Inspection Report
 description: Information on the Inspection and the observations made
 type: object
@@ -11,10 +11,10 @@ properties:
         items:
           type: string
           enum:
-            - AgInspectionReport
+            - AgricultureInspectionReport
       - type: string
         const:
-          - AgInspectionReport 
+          - AgricultureInspectionReport 
   facility:
     title: Facility
     description: Information on the inspection facility.
@@ -35,7 +35,7 @@ properties:
   shipment:
     title: Shipment
     description: Details for a shipment of goods.
-    $ref: ./AgParcelDelivery.yml
+    $ref: ./AgricultureParcelDelivery.yml
     $linkedData:
       term: shipment
       '@id': https://schema.org/ParcelDelivery
@@ -102,7 +102,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "AgInspectionReport",
+    "type": "AgricultureInspectionReport",
     "facility": {
       "type": [
         "Place"
@@ -172,7 +172,7 @@ example: |-
     },
     "shipment": {
       "type": [
-        "AgParcelDelivery"
+        "AgricultureParcelDelivery"
       ],
       "deliveryAddress": {
         "type": [
@@ -260,10 +260,10 @@ example: |-
         "phoneNumber": "555-895-1661",
         "faxNumber": "555-497-2527"
       },
-      "AgPackage": [
+      "agriculturePackage": [
         {
           "type": [
-            "AgPackage"
+            "AgriculturePackage"
           ]
         }
       ],

--- a/docs/openapi/components/schemas/common/AgriculturePackage.yml
+++ b/docs/openapi/components/schemas/common/AgriculturePackage.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: AgPackage
-  '@id': https://w3id.org/traceability#AgPackage
-title: AgPackage
+  term: AgriculturePackage
+  '@id': https://w3id.org/traceability#AgriculturePackage
+title: Agriculture Package
 description: >-
   A package (container, crate, etc.) which holds agricultural products. The
   contents or the package itself should meet the requirements as specified here:
@@ -14,10 +14,10 @@ properties:
         items:
           type: string
           enum:
-            - AgPackage
+            - AgriculturePackage
       - type: string
         const:
-          - AgPackage 
+          - AgriculturePackage 
   packageName:
     title: Package Name
     description: Name of the items within the package.
@@ -76,27 +76,27 @@ properties:
     $linkedData:
       term: labelImageHash
       '@id': https://w3id.org/traceability#labelImageHash
-  agProduct:
+  agricultureProduct:
     title: Product List
     description: List of agricultural products contained within this package.
     type: array
     items:
-      $ref: ./AgProduct.yml
+      $ref: ./AgricultureProduct.yml
     $linkedData:
-      term: agProduct
+      term: agricultureProduct
       '@id': https://schema.org/ItemList
       '@type': https://schema.org/ItemList
   harvest:
     title: Harvest
     description: Product harvest.
-    $ref: ./AgActivity.yml
+    $ref: ./AgricultureActivity.yml
     $linkedData:
       term: harvest
-      '@id': https://w3id.org/traceability#AgActivity
+      '@id': https://w3id.org/traceability#AgricultureActivity
 additionalProperties: true
 example: |-
   {
-    "type": "AgPackage",
+    "type": "AgriculturePackage",
     "packageName": "Avocados, Bulk",
     "grade": "AA",
     "responsibleParty": {
@@ -110,10 +110,10 @@ example: |-
     "date": "2021-03-14",
     "labelImageUrl": "https://img.example.org/640/480/",
     "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "agProduct": [
+    "agricultureProduct": [
       {
         "type": [
-          "AgProduct"
+          "AgricultureProduct"
         ],
         "upc": "033383401508",
         "plu": "94225",
@@ -156,7 +156,7 @@ example: |-
       },
       {
         "type": [
-          "AgProduct"
+          "AgricultureProduct"
         ],
         "upc": "033383401508",
         "plu": "94225",

--- a/docs/openapi/components/schemas/common/AgricultureParcelDelivery.yml
+++ b/docs/openapi/components/schemas/common/AgricultureParcelDelivery.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: AgParcelDelivery
-  '@id': https://w3id.org/traceability#AgParcelDelivery
-title: Ag Parcel Delivery
+  term: AgricultureParcelDelivery
+  '@id': https://w3id.org/traceability#AgricultureParcelDelivery
+title: Agriculture Parcel Delivery
 description: Details on a shipment or delivery.
 type: object
 properties:
@@ -11,10 +11,10 @@ properties:
         items:
           type: string
           enum:
-            - AgParcelDelivery
+            - AgricultureParcelDelivery
       - type: string
         const:
-          - AgParcelDelivery 
+          - AgricultureParcelDelivery 
   deliveryAddress:
     title: Delivery Address
     description: Final destination address to which the shipment is being sent.
@@ -80,15 +80,15 @@ properties:
     $linkedData:
       term: consignee
       '@id': https://schema.org/Organization
-  AgPackage:
+  agriculturePackage:
     title: Packages of items being shipped
     description: Item(s) being shipped.
     type: array
     items:
-      $ref: ./AgPackage.yml
+      $ref: ./AgriculturePackage.yml
     $linkedData:
-      term: AgPackage
-      '@id': https://w3id.org/traceability#AgPackage
+      term: agriculturePackage
+      '@id': https://w3id.org/traceability#AgriculturePackage
   movementPoints:
     title: Shipping Stops
     description: Coordinates and time of each stop, with additional metadata if provided.
@@ -129,7 +129,7 @@ properties:
 additionalProperties: true
 example: |-
   {
-    "type": "AgParcelDelivery",
+    "type": "AgricultureParcelDelivery",
     "deliveryAddress": {
       "type": [
         "PostalAddress"
@@ -216,10 +216,10 @@ example: |-
       "phoneNumber": "555-895-1661",
       "faxNumber": "555-497-2527"
     },
-    "AgPackage": [
+    "agriculturePackage": [
       {
         "type": [
-          "AgPackage"
+          "AgriculturePackage"
         ],
         "packageName": "Avocados, Bulk",
         "grade": "AA",
@@ -234,10 +234,10 @@ example: |-
         "date": "2021-03-14",
         "labelImageUrl": "https://img.example.org/640/480/",
         "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "agProduct": [
+        "agricultureProduct": [
           {
             "type": [
-              "AgProduct"
+              "AgricultureProduct"
             ],
             "upc": "033383401508",
             "plu": "94225",

--- a/docs/openapi/components/schemas/common/AgricultureProduct.yml
+++ b/docs/openapi/components/schemas/common/AgricultureProduct.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: AgProduct
-  '@id': https://w3id.org/traceability#AgProduct
-title: AgProduct
+  term: AgricultureProduct
+  '@id': https://w3id.org/traceability#AgricultureProduct
+title: Agriculture Product
 description: >-
   An agricultural product, extending the Product schema.  This schema
   accounts for the FDA lebeling data requirements at the crate level as
@@ -15,10 +15,10 @@ properties:
         items:
           type: string
           enum:
-            - AgProduct
+            - AgricultureProduct
       - type: string
         const:
-          - AgProduct 
+          - AgricultureProduct 
   upc:
     title: UPC Number
     description: >-
@@ -108,7 +108,7 @@ properties:
 additionalProperties: true
 example: |-
   {
-    "type": "AgProduct",
+    "type": "AgricultureProduct",
     "upc": "033383401508",
     "plu": "94225",
     "gtin": "033383401508",

--- a/docs/openapi/components/schemas/common/FoodGradeInspection.yml
+++ b/docs/openapi/components/schemas/common/FoodGradeInspection.yml
@@ -69,7 +69,7 @@ properties:
   shipment:
     title: Shipment
     description: Details for a shipment of goods.
-    $ref: ./AgParcelDelivery.yml
+    $ref: ./AgricultureParcelDelivery.yml
     $linkedData:
       term: shipment
       '@id': https://schema.org/ParcelDelivery
@@ -214,7 +214,7 @@ example: |-
     },
     "shipment": {
       "type": [
-        "AgParcelDelivery"
+        "AgricultureParcelDelivery"
       ],
       "deliveryAddress": {
         "type": [
@@ -252,10 +252,10 @@ example: |-
         "phoneNumber": "555-895-1661",
         "faxNumber": "555-497-2527"
       },
-      "AgPackage": [
+      "agriculturePackage": [
         {
           "type": [
-            "AgPackage"
+            "AgriculturePackage"
           ],
           "packageName": "Avocados, Bulk",
           "grade": "AA",
@@ -270,10 +270,10 @@ example: |-
           "date": "2021-03-14",
           "labelImageUrl": "https://img.example.org/640/480/",
           "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-          "agProduct": [
+          "agricultureProduct": [
             {
               "type": [
-                "AgProduct"
+                "AgricultureProduct"
               ],
               "upc": "033383401508",
               "plu": "94225",
@@ -361,9 +361,9 @@ example: |-
     "lots": [
       {
         "type": "FoodGradeInspectionLot",
-        "agProduct": {
+        "agricultureProduct": {
           "type": [
-            "AgProduct"
+            "AgricultureProduct"
           ],
           "upc": "033383401508",
           "plu": "94225",

--- a/docs/openapi/components/schemas/common/FoodGradeInspectionLot.yml
+++ b/docs/openapi/components/schemas/common/FoodGradeInspectionLot.yml
@@ -14,13 +14,13 @@ properties:
             - FoodGradeInspectionLot
       - type: string
         const: FoodGradeInspectionLot
-  agProduct:
+  agricultureProduct:
     title: Product
     description: The product inspected.
-    $ref: ./AgProduct.yml
+    $ref: ./AgricultureProduct.yml
     $linkedData:
-      term: agProduct
-      '@id': https://w3id.org/traceability#AgProduct
+      term: agricultureProduct
+      '@id': https://w3id.org/traceability#AgricultureProduct
   lotIdentifier:
     title: Lot Identifier
     description: Use to further add to identification of the lot inspected, or to distinguish between lots / sublots for certification purposes (e.g. "Loaded", "Main Lot", "U.S. Fancy", "Film Wrapped").
@@ -99,9 +99,9 @@ additionalProperties: false
 example: |-
   {
     "type": "FoodGradeInspectionLot",
-    "agProduct": {
+    "agricultureProduct": {
       "type": [
-        "AgProduct"
+        "agricultureProduct"
       ],
       "upc": "033383401508",
       "plu": "94225",

--- a/docs/openapi/components/schemas/common/Phytosanitary.yml
+++ b/docs/openapi/components/schemas/common/Phytosanitary.yml
@@ -134,19 +134,19 @@ properties:
   shipment:
     title: Shipment
     description: Details for a shipment of goods.
-    $ref: ./AgParcelDelivery.yml
+    $ref: ./AgricultureParcelDelivery.yml
     $linkedData:
       term: shipment
-      '@id': https://schema.org/AgParcelDelivery
-  agPackage:
+      '@id': https://schema.org/AgricultureParcelDelivery
+  agriculturePackage:
     title: Agriculture Package
     description: >-
       Package, crate, or other container holding an agricultural product or
       products for inspection.
-    $ref: ./AgPackage.yml
+    $ref: ./AgriculturePackage.yml
     $linkedData:
-      term: agPackage
-      '@id': https://w3id.org/traceability#AgPackage
+      term: agriculturePackage
+      '@id': https://w3id.org/traceability#AgriculturePackage
   applicant:
     title: Applicant
     description: Entity that is applying for the inspection.
@@ -255,7 +255,7 @@ example: |-
     },
     "shipment": {
       "type": [
-        "AgParcelDelivery"
+        "AgricultureParcelDelivery"
       ],
       "deliveryAddress": {
         "type": [
@@ -343,10 +343,10 @@ example: |-
         "phoneNumber": "555-895-1661",
         "faxNumber": "555-497-2527"
       },
-      "AgPackage": [
+      "agriculturePackage": [
         {
           "type": [
-            "AgPackage"
+            "AgriculturePackage"
           ]
         }
       ],

--- a/docs/openapi/components/schemas/common/UsdaSc6.yml
+++ b/docs/openapi/components/schemas/common/UsdaSc6.yml
@@ -92,10 +92,10 @@ properties:
   shipment:
     title: Shipment
     description: Details for a shipment of goods.
-    $ref: ./AgParcelDelivery.yml
+    $ref: ./AgricultureParcelDelivery.yml
     $linkedData:
       term: shipment
-      '@id': https://w3id.org/traceability#AgParcelDelivery
+      '@id': https://w3id.org/traceability#AgricultureParcelDelivery
   applicant:
     title: Applicant
     description: Entity that is applying for the inspection.
@@ -210,7 +210,7 @@ example: |-
     },
     "shipment": {
       "type": [
-        "AgParcelDelivery"
+        "AgricultureParcelDelivery"
       ],
       "deliveryAddress": {
         "type": [
@@ -298,10 +298,10 @@ example: |-
         "phoneNumber": "555-895-1661",
         "faxNumber": "555-497-2527"
       },
-      "AgPackage": [
+      "agriculturePackage": [
         {
           "type": [
-            "AgPackage"
+            "agriculturePackage"
           ]
         }
       ],

--- a/docs/openapi/components/schemas/common/ppq587.yml
+++ b/docs/openapi/components/schemas/common/ppq587.yml
@@ -35,10 +35,10 @@ properties:
   shipment:
     title: Shipment
     description: Details for a shipment of agricultural goods.
-    $ref: ./AgParcelDelivery.yml
+    $ref: ./AgricultureParcelDelivery.yml
     $linkedData:
       term: shipment
-      '@id': https://schema.org/AgParcelDelivery
+      '@id': https://schema.org/AgricultureParcelDelivery
   applicant:
     title: Applicant
     description: Entity that is applying for the inspection.
@@ -87,7 +87,7 @@ example: |-
     },
     "shipment": {
       "type": [
-        "AgParcelDelivery"
+        "AgricultureParcelDelivery"
       ],
       "deliveryAddress": {
         "type": [
@@ -175,10 +175,10 @@ example: |-
         "phoneNumber": "555-895-1661",
         "faxNumber": "555-497-2527"
       },
-      "AgPackage": [
+      "agriculturePackage": [
         {
           "type": [
-            "AgPackage"
+            "AgriculturePackage"
           ]
         }
       ],

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
@@ -178,7 +178,7 @@ example: |-
       },
       "shipment": {
         "type": [
-          "AgParcelDelivery"
+          "AgricultureParcelDelivery"
         ],
         "deliveryAddress": {
           "type": [
@@ -216,10 +216,10 @@ example: |-
           "phoneNumber": "555-895-1661",
           "faxNumber": "555-497-2527"
         },
-        "AgPackage": [
+        "agriculturePackage": [
           {
             "type": [
-              "AgPackage"
+              "AgriculturePackage"
             ],
             "packageName": "Avocados, Bulk",
             "grade": "AA",
@@ -234,10 +234,10 @@ example: |-
             "date": "2021-03-14",
             "labelImageUrl": "https://img.example.org/640/480/",
             "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-            "agProduct": [
+            "agricultureProduct": [
               {
                 "type": [
-                  "AgProduct"
+                  "AgricultureProduct"
                 ],
                 "upc": "033383401508",
                 "plu": "94225",
@@ -325,9 +325,9 @@ example: |-
       "lots": [
         {
           "type": "FoodGradeInspectionLot",
-          "agProduct": {
+          "agricultureProduct": {
             "type": [
-              "AgProduct"
+              "AgricultureProduct"
             ],
             "upc": "033383401508",
             "plu": "94225",
@@ -476,9 +476,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-06-22T08:47:27Z",
+      "created": "2022-07-19T05:24:24Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..WedDJJ5T7kRJeQUSUL9mDJqP2Y148lVayFFegoGklUOrieqh0Q-wIH0o6ftsaSyZ8QqA_rCbqe0E53v4F43oDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..8HUMrMo9QaWxmrKCpeSxwQodDETbOVk0L7uzrrjxOM4nzPB5YquKeISEuaHlbmphNO9imfu0TTpCt3m6nF_mDw"
     }
   }

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -20,7 +20,7 @@ paths:
                 $ref: './components/schemas/common/AdditionalProductCodeRegistrationCredential.yml'
     
 
-  /schemas/common/AgActivity.yml:
+  /schemas/common/AgricultureActivity.yml:
     get:
       tags:
       - common
@@ -29,10 +29,10 @@ paths:
           content:
             application/yml:
               schema:
-                $ref: './components/schemas/common/AgActivity.yml'
+                $ref: './components/schemas/common/AgricultureActivity.yml'
     
 
-  /schemas/common/AgInspectionReport.yml:
+  /schemas/common/AgricultureInspectionReport.yml:
     get:
       tags:
       - common
@@ -41,10 +41,10 @@ paths:
           content:
             application/yml:
               schema:
-                $ref: './components/schemas/common/AgInspectionReport.yml'
+                $ref: './components/schemas/common/AgricultureInspectionReport.yml'
     
 
-  /schemas/common/AgPackage.yml:
+  /schemas/common/AgriculturePackage.yml:
     get:
       tags:
       - common
@@ -53,10 +53,10 @@ paths:
           content:
             application/yml:
               schema:
-                $ref: './components/schemas/common/AgPackage.yml'
+                $ref: './components/schemas/common/AgriculturePackage.yml'
     
 
-  /schemas/common/AgParcelDelivery.yml:
+  /schemas/common/AgricultureParcelDelivery.yml:
     get:
       tags:
       - common
@@ -65,10 +65,10 @@ paths:
           content:
             application/yml:
               schema:
-                $ref: './components/schemas/common/AgParcelDelivery.yml'
+                $ref: './components/schemas/common/AgricultureParcelDelivery.yml'
     
 
-  /schemas/common/AgProduct.yml:
+  /schemas/common/AgricultureProduct.yml:
     get:
       tags:
       - common
@@ -77,7 +77,7 @@ paths:
           content:
             application/yml:
               schema:
-                $ref: './components/schemas/common/AgProduct.yml'
+                $ref: './components/schemas/common/AgricultureProduct.yml'
     
 
   /schemas/common/BillOfLading.yml:


### PR DESCRIPTION
This PR changes all "Ag" abbreviations to "Agriculture" to improve clarity & better adhere to conventions.