### PR TITLE
Introduction to the credentials section

### DIFF
--- a/packages/traceability-schemas/scripts/schemas-to-vocab.js
+++ b/packages/traceability-schemas/scripts/schemas-to-vocab.js
@@ -126,7 +126,7 @@ const separateSchemas = (schemaList) => {
     <section>
       <h2>Credentials</h2>
       <p>
-        This section lists Verifiable Credential schemas, targeting specific business use cases. These are issued, presented and verified in order to execute business workflows. 
+        This section lists Verifiable Credential schemas, targeting specific business use cases. These are issued, presented, and verified to execute business workflows. 
         Technically, these are all of <code>"type": "VerifiableCredential"</code>. 
       </p>      
       ${credentials}

--- a/packages/traceability-schemas/scripts/schemas-to-vocab.js
+++ b/packages/traceability-schemas/scripts/schemas-to-vocab.js
@@ -127,7 +127,7 @@ const separateSchemas = (schemaList) => {
       <h2>Credentials</h2>
       <p>
         This section lists Verifiable Credential schemas, targeting specific business use cases. These are issued, presented and verified in order to execute business workflows. 
-        Technically, these are all of \"type\": \"VerifiableCredential\". 
+        Technically, these are all of <code>"type": "VerifiableCredential"</code>. 
       </p>      
       ${credentials}
     </section>

--- a/packages/traceability-schemas/scripts/schemas-to-vocab.js
+++ b/packages/traceability-schemas/scripts/schemas-to-vocab.js
@@ -125,6 +125,10 @@ const separateSchemas = (schemaList) => {
   const credentialSection = `
     <section>
       <h2>Credentials</h2>
+      <p>
+        This section lists Verifiable Credential schemas, targeting specific business use cases. These are issued, presented and verified in order to execute business workflows. 
+        Technically, these are all of \"type\": \"VerifiableCredential\". 
+      </p>      
       ${credentials}
     </section>
   `;


### PR DESCRIPTION
This adds a basic introduction to the [Credentials section](https://w3c-ccg.github.io/traceability-vocab/#credentials). Not least to avoid the "floating header" without any text.
![image](https://user-images.githubusercontent.com/34443212/180428802-c03e71b2-3406-40c6-b3fe-29272b2d2792.png)
