### PR TITLE
Referencing VC

### DIFF
--- a/docs/openapi/components/schemas/common/CommissionEvent.yml
+++ b/docs/openapi/components/schemas/common/CommissionEvent.yml
@@ -40,14 +40,13 @@ properties:
       '@id': https://w3id.org/traceability#Organization
   products:
     title: Products
-    description: >-
-      List of product details as outlined in the Product schema
+    description: The products referenced by the event in hashlinks.
     type: array
     items:
-      $ref: ./Product.yml
+      type: string
     $linkedData:
-      term: product
-      '@id': https://schema.org/Product
+      term: products
+      '@id': https://w3c-ccg.github.io/hashlink/#hl-url-params
 additionalProperties: false
 example: |-
   {
@@ -90,39 +89,6 @@ example: |-
       }
     ],
     "products":[
-      {
-        "id":"752f9fef-a028-415c-b17b-33a7aafda835",
-        "name":"Carbon and alloy long product",
-        "type":[
-          "Product"
-        ],
-        "width":{
-          "type":[
-            "MeasuredValue"
-          ],
-          "value":"1220",
-          "unitCode":"CM"
-        },
-        "length":{
-          "type":[
-            "MeasuredValue"
-          ],
-          "value":"654460",
-          "unitCode":"CM"
-        },
-        "weight":{
-          "type":[
-            "MeasuredValue"
-          ],
-          "value":"11013",
-          "unitCode":"KG"
-        },
-        "manufacturer":{
-          "name":"Steel Co.",
-          "type":[
-            "Organization"
-          ]
-        }
-      }
+      "http://example.org/products/05b6867b-2211-4c8f-ae7a-2a770b9510af?hl=ZfqLwiBj3yidP7p344d71z8ybyjb2+YVfhckGGHHEzk="
     ]
   }

--- a/docs/openapi/components/schemas/common/Event.yml
+++ b/docs/openapi/components/schemas/common/Event.yml
@@ -55,13 +55,13 @@ properties:
       '@id': https://schema.org/DateTime
   products:
     title: Products
-    description: The products referenced by the event.
+    description: The products referenced by the event in hashlinks.
     type: array
     items:
-      $ref: ./Product.yml
+      type: string
     $linkedData:
       term: products
-      '@id': https://schema.org/Product
+      '@id': https://w3c-ccg.github.io/hashlink/#hl-url-params
 additionalProperties: false
 example: |-
   {
@@ -125,69 +125,6 @@ example: |-
     },
     "eventTime": "2019-12-11T03:50:55Z",
     "products": [
-      {
-        "type": "Product",
-        "manufacturer": {
-          "type": "Organization",
-          "name": "Ferry, Von and Boehm",
-          "description": "Object-based real-time project",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "485 Bayer Drives",
-            "addressLocality": "New Tabithaside",
-            "addressRegion": "Indiana",
-            "postalCode": "80982",
-            "addressCountry": "Barbados"
-          },
-          "email": "Bridget.Yundt96@example.com",
-          "phoneNumber": "555-338-4723",
-          "faxNumber": "555-696-7109"
-        },
-        "name": "Sleek Wooden Bike",
-        "description": "The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality",
-        "sizeOrAmount": {
-          "type": "QuantitativeValue",
-          "unitCode": "hg/ha",
-          "value": "1645"
-        },
-        "weight": {
-          "type": "QuantitativeValue",
-          "unitCode": "hg/ha",
-          "value": "3001"
-        },
-        "sku": "781731172154"
-      },
-      {
-        "type": "Product",
-        "manufacturer": {
-          "type": "Organization",
-          "name": "Schaefer - Ward",
-          "description": "Ergonomic hybrid encryption",
-          "address": {
-            "type": "PostalAddress",
-            "streetAddress": "03394 Hattie Plaza",
-            "addressLocality": "Cassieside",
-            "addressRegion": "Wyoming",
-            "postalCode": "80200",
-            "addressCountry": "Cambodia"
-          },
-          "email": "Jaylon70@example.net",
-          "phoneNumber": "555-150-6921",
-          "faxNumber": "555-208-7547"
-        },
-        "name": "Fantastic Plastic Cheese",
-        "description": "Carbonite web goalkeeper gloves are ergonomically designed to give easy fit",
-        "sizeOrAmount": {
-          "type": "QuantitativeValue",
-          "unitCode": "hg/ha",
-          "value": "7322"
-        },
-        "weight": {
-          "type": "QuantitativeValue",
-          "unitCode": "hg/ha",
-          "value": "1748"
-        },
-        "sku": "500038921455"
-      }
+      "http://example.org/products/05b6867b-2211-4c8f-ae7a-2a770b9510af?hl=ZfqLwiBj3yidP7p344d71z8ybyjb2+YVfhckGGHHEzk="
     ]
   }

--- a/docs/openapi/components/schemas/common/Event.yml
+++ b/docs/openapi/components/schemas/common/Event.yml
@@ -1,7 +1,7 @@
 $linkedData:
   term: Event
   '@id': https://schema.org/Event
-title: Organization
+title: Event
 description: An event such as a transformation, aggregation, commission, etc.
 type: object
 properties:

--- a/docs/openapi/components/schemas/common/TransferEvent.yml
+++ b/docs/openapi/components/schemas/common/TransferEvent.yml
@@ -38,14 +38,13 @@ properties:
       '@id': https://schema.org/price
   products:
     title: Products
-    description: >-
-      List of product details as outlined in the Product schema
+    description: The products referenced by the event in hashlinks.
     type: array
     items:
-      $ref: ./Product.yml
+      type: string
     $linkedData:
-      term: product
-      '@id': https://schema.org/Product
+      term: products
+      '@id': https://w3c-ccg.github.io/hashlink/#hl-url-params
   actor:
     title: Event Actors
     description: >-
@@ -132,47 +131,7 @@ example: |-
     },
     "price": 1200,
     "products": [
-      {
-        "productID": "9d237753-b377-492a-a8c8-a28fe9f3457b",
-        "type": "Product",
-        "manufacturer": {
-          "type": "Person",
-          "firstName": "Lawson",
-          "lastName": "Weber",
-          "email": "Hollie.Lindgren@example.org",
-          "phoneNumber": "555-547-4441",
-          "worksFor": {
-            "type": "Organization",
-            "name": "Zemlak - Wyman",
-            "description": "Progressive fault-tolerant task-force",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "964 Mikayla Viaduct",
-              "addressLocality": "Runolfsdottirburgh",
-              "addressRegion": "Florida",
-              "postalCode": "48442-9522",
-              "addressCountry": "Barbados"
-            },
-            "email": "Reyna_Hamill56@example.com",
-            "phoneNumber": "555-718-9023",
-            "faxNumber": "555-523-8629"
-          },
-          "jobTitle": "District Mobility Planner"
-        },
-        "name": "Handmade Fresh Hat",
-        "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
-        "sizeOrAmount": {
-          "type": "QuantitativeValue",
-          "unitCode": "sqm",
-          "value": "47"
-        },
-        "weight": {
-          "type": "QuantitativeValue",
-          "unitCode": "kg",
-          "value": "4890"
-        },
-        "sku": "712120934258"
-      }
+      "http://example.org/products/05b6867b-2211-4c8f-ae7a-2a770b9510af?hl=ZfqLwiBj3yidP7p344d71z8ybyjb2+YVfhckGGHHEzk="
     ],
     "actor": [
       {

--- a/docs/openapi/components/schemas/common/TransformEvent.yml
+++ b/docs/openapi/components/schemas/common/TransformEvent.yml
@@ -36,33 +36,23 @@ properties:
       term: organization
       '@id': https://w3id.org/traceability#Organization
   products:
-    title: Products
-    description: >-
-      List of product details as outlined in the Product schema
-    type: array
-    items:
-      $ref: ./Product.yml
-    $linkedData:
-      term: product
-      '@id': https://schema.org/Product
-  newProducts:
     title: New products created from the transformation event
-    description: Identifiers for the new products.
+    description: The created products referenced by the event in hashlinks.
     type: array
     items:
       type: string
     $linkedData:
-      term: identifier
-      '@id': https://schema.org/identifier
+      term: products
+      '@id': https://w3c-ccg.github.io/hashlink/#hl-url-params
   consumedProducts:
-    title: New products created from the transformation event
-    description: Identifiers for the new products.
+    title: Old products consumed from the transformation event
+    description: The consumed products referenced by the event in hashlinks.
     type: array
     items:
       type: string
     $linkedData:
-      term: identifier
-      '@id': https://schema.org/identifier
+      term: products
+      '@id': https://w3c-ccg.github.io/hashlink/#hl-url-params
 additionalProperties: false
 example: |-
   {
@@ -103,178 +93,12 @@ example: |-
         ]
       }
     ],
-    "products":[
-      {
-        "productID":"5c93de07-5d94-4357-85cf-aefc9ccbff97",
-        "type": "Product",
-        "manufacturer": {
-          "type": "Person",
-          "firstName": "Lawson",
-          "lastName": "Weber",
-          "email": "Hollie.Lindgren@example.org",
-          "phoneNumber": "555-547-4441",
-          "worksFor": {
-            "type": "Organization",
-            "name": "Zemlak - Wyman",
-            "description": "Progressive fault-tolerant task-force",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "964 Mikayla Viaduct",
-              "addressLocality": "Runolfsdottirburgh",
-              "addressRegion": "Florida",
-              "postalCode": "48442-9522",
-              "addressCountry": "Barbados"
-            },
-            "email": "Reyna_Hamill56@example.com",
-            "phoneNumber": "555-718-9023",
-            "faxNumber": "555-523-8629"
-          },
-          "jobTitle": "District Mobility Planner"
-        },
-        "name": "Handmade Fresh Hat",
-        "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
-        "sizeOrAmount": {
-          "type": "QuantitativeValue",
-          "unitCode": "sqm",
-          "value": "47"
-        },
-        "weight": {
-          "type": "QuantitativeValue",
-          "unitCode": "kg",
-          "value": "4890"
-        },
-        "sku": "712120934258"
-      },
-      {
-        "productID":"9d237753-b377-492a-a8c8-a28fe9f3457b",
-        "type": "Product",
-        "manufacturer": {
-          "type": "Person",
-          "firstName": "Lawson",
-          "lastName": "Weber",
-          "email": "Hollie.Lindgren@example.org",
-          "phoneNumber": "555-547-4441",
-          "worksFor": {
-            "type": "Organization",
-            "name": "Zemlak - Wyman",
-            "description": "Progressive fault-tolerant task-force",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "964 Mikayla Viaduct",
-              "addressLocality": "Runolfsdottirburgh",
-              "addressRegion": "Florida",
-              "postalCode": "48442-9522",
-              "addressCountry": "Barbados"
-            },
-            "email": "Reyna_Hamill56@example.com",
-            "phoneNumber": "555-718-9023",
-            "faxNumber": "555-523-8629"
-          },
-          "jobTitle": "District Mobility Planner"
-        },
-        "name": "Handmade Fresh Hat",
-        "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
-        "sizeOrAmount": {
-          "type": "QuantitativeValue",
-          "unitCode": "sqm",
-          "value": "47"
-        },
-        "weight": {
-          "type": "QuantitativeValue",
-          "unitCode": "kg",
-          "value": "4890"
-        },
-        "sku": "712120934258"
-      },
-      {
-        "productID":"adf9a0fe-a117-4728-a323-b941b5bcf011",
-        "type": "Product",
-        "manufacturer": {
-          "type": "Person",
-          "firstName": "Lawson",
-          "lastName": "Weber",
-          "email": "Hollie.Lindgren@example.org",
-          "phoneNumber": "555-547-4441",
-          "worksFor": {
-            "type": "Organization",
-            "name": "Zemlak - Wyman",
-            "description": "Progressive fault-tolerant task-force",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "964 Mikayla Viaduct",
-              "addressLocality": "Runolfsdottirburgh",
-              "addressRegion": "Florida",
-              "postalCode": "48442-9522",
-              "addressCountry": "Barbados"
-            },
-            "email": "Reyna_Hamill56@example.com",
-            "phoneNumber": "555-718-9023",
-            "faxNumber": "555-523-8629"
-          },
-          "jobTitle": "District Mobility Planner"
-        },
-        "name": "Handmade Fresh Hat",
-        "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
-        "sizeOrAmount": {
-          "type": "QuantitativeValue",
-          "unitCode": "sqm",
-          "value": "47"
-        },
-        "weight": {
-          "type": "QuantitativeValue",
-          "unitCode": "kg",
-          "value": "4890"
-        },
-        "sku": "712120934258"
-      },
-      {
-        "productID":"c72a3cb7-3d2f-4d42-b398-2deb6e6ace66",
-        "type": "Product",
-        "manufacturer": {
-          "type": "Person",
-          "firstName": "Lawson",
-          "lastName": "Weber",
-          "email": "Hollie.Lindgren@example.org",
-          "phoneNumber": "555-547-4441",
-          "worksFor": {
-            "type": "Organization",
-            "name": "Zemlak - Wyman",
-            "description": "Progressive fault-tolerant task-force",
-            "address": {
-              "type": "PostalAddress",
-              "streetAddress": "964 Mikayla Viaduct",
-              "addressLocality": "Runolfsdottirburgh",
-              "addressRegion": "Florida",
-              "postalCode": "48442-9522",
-              "addressCountry": "Barbados"
-            },
-            "email": "Reyna_Hamill56@example.com",
-            "phoneNumber": "555-718-9023",
-            "faxNumber": "555-523-8629"
-          },
-          "jobTitle": "District Mobility Planner"
-        },
-        "name": "Handmade Fresh Hat",
-        "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
-        "sizeOrAmount": {
-          "type": "QuantitativeValue",
-          "unitCode": "sqm",
-          "value": "47"
-        },
-        "weight": {
-          "type": "QuantitativeValue",
-          "unitCode": "kg",
-          "value": "4890"
-        },
-        "sku": "712120934258"
-      }
-    ],
     "newProducts":[
-      "https://example.com/5c93de07-5d94-4357-85cf-aefc9ccbff97"
+      "http://example.org/products/429d2c3b-73d3-429d-9bd0-91db17c1e2ec?hl=t10H2RwsspADWwmbwR2xCISYwBEJ49MoTi3heucZrKs="
     ],
     "consumedProducts":[
-      "https://example.com/9d237753-b377-492a-a8c8-a28fe9f3457b",
-      "https://example.com/adf9a0fe-a117-4728-a323-b941b5bcf011",
-      "https://example.com/c72a3cb7-3d2f-4d42-b398-2deb6e6ace66"
+      "http://example.org/products/05b6867b-2211-4c8f-ae7a-2a770b9510af?hl=ZfqLwiBj3yidP7p344d71z8ybyjb2+YVfhckGGHHEzk=",
+      "http://example.org/products/0f67ab5c-1a78-4744-8392-19c21ad0f6c7?hl=EK1bNv2VcnbjBlHe1v+JnZ1cBgI8jfVuS6jh1+hTH1A=",
+      "http://example.org/products/2c748483-cdde-49ec-826b-8b7c00584568?hl=yibnswLb+ROwnWWq0MJd5StoFe97iihzGpusGgwIex0="
     ]
   }

--- a/docs/openapi/components/schemas/common/TransportEvent.yml
+++ b/docs/openapi/components/schemas/common/TransportEvent.yml
@@ -40,14 +40,13 @@ properties:
       '@id': https://w3id.org/traceability#Organization
   products:
     title: Products
-    description: >-
-      List of product details as outlined in the Product schema
+    description: The products referenced by the event in hashlinks.
     type: array
     items:
-      $ref: ./Product.yml
+      type: string
     $linkedData:
-      term: product
-      '@id': https://schema.org/Product
+      term: products
+      '@id': https://w3c-ccg.github.io/hashlink/#hl-url-params
   deliveryMethod:
     title: Delivery Method
     description: The means of transportation used in delivering the shipment.
@@ -103,40 +102,8 @@ example: |-
       }
     ],
     "products":[
-      {
-        "id":"752f9fef-a028-415c-b17b-33a7aafda835",
-        "name":"Carbon and alloy long product",
-        "type":[
-          "Product"
-        ],
-        "width":{
-          "type":[
-            "MeasuredValue"
-          ],
-          "value":"1220",
-          "unitCode":"CM"
-        },
-        "length":{
-          "type":[
-            "MeasuredValue"
-          ],
-          "value":"654460",
-          "unitCode":"CM"
-        },
-        "weight":{
-          "type":[
-            "MeasuredValue"
-          ],
-          "value":"11013",
-          "unitCode":"KG"
-        },
-        "manufacturer":{
-          "name":"Steel Co.",
-          "type":[
-            "Organization"
-          ]
-        }
-      }
+      "http://example.org/products/05b6867b-2211-4c8f-ae7a-2a770b9510af?hl=ZfqLwiBj3yidP7p344d71z8ybyjb2+YVfhckGGHHEzk="
+
     ],
     "deliveryMethod":"Truck",
     "trackingNumber":"1258"


### PR DESCRIPTION
Related issue: https://github.com/w3c-ccg/traceability-vocab/issues/374

Replacing directly embed credential with a hashlink which points to the hosted VCs

`Hashlink` is prefered over `Evidence` and `Related Link` because:
1. it makes sure the data being referenced is the same
    - in the case of `Events`, `Products` should stay the same (ie, size, amount, manufactuer, etc.)
    - `Hashlink` makes sure the content returned by the link is the same as when it's generated, otherwise the hash would change
    - `Evidence` and `Related Link` can only meet this requirement if `reference`/`target` is `Hashlink`

2. it describes the relationship between `Products` and `Events` in a dry way
    - in the case of `Transform Events`, there are 2 types of `Products` - newly created & consumed/used products
    - `Hashlink` is replacing the directly embed credential in the structure, which already describes the type of `Products`
    - `Evidence` does not describe the type of credential being referenced
    - `Related Link` has a field `LinkRelationship` to meet this requirement, but the solution is more complicated and harder to read
