### PR TITLE
CBP JSON Schema errors

### DIFF
--- a/docs/openapi/components/schemas/common/EntrySummary.yml
+++ b/docs/openapi/components/schemas/common/EntrySummary.yml
@@ -226,11 +226,19 @@ properties:
   descriptionOfMerchandise: 
     title: Description of Merchandise
     description: A description of the articles in sufficient detail to permit the classification thereof under the proper statistical reporting number in the HTS should be reported at the top of column 28. The standard definitions from the CBP HTS database are acceptable for this requirement. 
-    $ref: ./EntrySummaryLineItem.yml
+    array: 
+      items: 
+      $ref: ./EntrySummaryLineItem.yml
+    $linkedData:
+      term: descriptionOfMerchandise
+      '@id': https://w3id.org/traceability#descriptionOfMerchandise
   otherFeeSummary:
     title: Other Fee Summary
     description: For entries subject to payment of AD/CVD and/or any of the various fees, each applicable fee must be indicated in this area, and the individual amount of each fee must be shown on the corresponding line. AD/CVD amounts are to be included in the summary only when they are actually deposited. Bonded amounts should not be included.
     type: string
+    $linkedData:
+      term: otherFeeSummary
+      '@id': https://w3id.org/traceability#otherFeeSummary
   totalEnteredValue:
     title: Total Entered Value
     description: Report the total entered value for all line items. This information is required on all entry summaries
@@ -277,13 +285,16 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "EntrySummary",
-    "entryNumber": 73461882610,
+    "type": ["EntrySummary"],
+    "entryNumber": "73461882610",
     "entryType": "01",
     "summaryDate": "2022-03-01T12:54Z",
     "suretyNumber": "228",
     "bondType": "Single Transaction Bond",
-    "portCode": "USLBC",
+    "portCode": {
+      "type": ["Place"], 
+      "unLocode": "USLBC"
+    },
     "entryDate": "2022-03-01T12:54Z",
     "importingCarrier": "NISC",
     "transportMode": "Ocean",
@@ -297,25 +308,25 @@ example: |-
     "immediateTransportationDate": "2022-03-01T12:54Z",
     "missingDocuments": [],
     "portOfLoading": {
-      "type": "Place",
-      "UNLocode": "SGSIN"
+      "type": ["Place"],
+      "unLocode": "SGSIN"
     },
     "portOfUnlading": {
-      "type": "Place",
-      "UNLocode": "USLBC"
+      "type": ["Place"],
+      "unLocode": "USLBC"
     },
     "locationOfGoods": {
-      "type": "Place",
-      "UNLocode": "USLBC"
+      "type": ["Place"],
+      "unLocode": "USLBC"
     },
     "consigneeNumber": "9982312",
     "importerNumber": "9900127",
     "referenceNumber": "ref199812841",
     "ultimateConsignee": {
-      "type": "Entity",
+      "type": ["Entity"],
       "name": "Future Mobility, Inc.",
       "address": {
-        "type": "PostalAddress",
+        "type": ["PostalAddress"],
         "streetAddress": "2016 W Farmington Rd",
         "addressLocality": "West Peoria",
         "postalCode": "61604",
@@ -324,10 +335,10 @@ example: |-
       "entityType": "Organization"
     },
     "importerOfRecord": {
-      "type": "Entity",
+      "type": ["Entity"],
       "name": "Future Mobility, Inc.",
       "address": {
-        "type": "PostalAddress",
+        "type": ["PostalAddress"],
         "streetAddress": "2016 W Farmington Rd",
         "addressLocality": "West Peoria",
         "postalCode": "61604",
@@ -337,9 +348,9 @@ example: |-
     },
     "descriptionOfMerchandise": [
       {
-        "type": "EntrySummaryLineItem",
+        "type": ["EntrySummaryLineItem"],
         "commodity": {
-          "type": "Commodity",
+          "type": ["Commodity"],
           "commodityCode": "2204.21.60 00",
           "commodityCodeType": "HS",
           "description": "Wine of fresh grapes"
@@ -347,23 +358,23 @@ example: |-
         "adCvdNumber": "A123-234-345",
         "categoryNumber": "CAT ABC",
         "grossWeight": {
-          "type": "QuantitativeValue",
+          "type": ["QuantitativeValue"],
           "value": "7420",
           "unitCode": "kg"
         },
         "manifestQuantity": 3500,
         "netQuantity": {
-          "type": "QuantitativeValue",
+          "type": ["QuantitativeValue"],
           "value": "6620",
           "unitCode": "kg"
         },
         "enteredValue": {
-          "type": "PriceSpecification",
+          "type": ["PriceSpecification"],
           "price": 12000,
           "priceCurrency": "USD"
         },
         "charges": {
-          "type": "PriceSpecification",
+          "type": ["PriceSpecification"],
           "price": 1500,
           "priceCurrency": "USD"
         },
@@ -371,7 +382,7 @@ example: |-
         "htsRate": "ad valorem",
         "visaNumber": "V10000345",
         "dutyAndIRTax": {
-          "type": "PriceSpecification",
+          "type": ["PriceSpecification"],
           "price": 8230,
           "priceCurrency": "USD"
         }
@@ -379,23 +390,23 @@ example: |-
     ],
     "otherFeeSummary": "AD",
     "totalEnteredValue": {
-      "type": "PriceSpecification",
+      "type": ["PriceSpecification"],
       "price": 8230,
       "priceCurrency": "USD"
     },
     "declarationOfImporter": "Importer of Record",
     "duty": {
-      "type": "PriceSpecification",
+      "type": ["PriceSpecification"],
       "price": 20,
       "priceCurrency": "USD"
     },
     "tax": {
-      "type": "PriceSpecification",
+      "type": ["PriceSpecification"],
       "price": 282,
       "priceCurrency": "USD"
     },
     "total": {
-      "type": "PriceSpecification",
+      "type": ["PriceSpecification"],
       "price": 8532,
       "priceCurrency": "USD"
     }

--- a/docs/openapi/components/schemas/common/EntrySummaryLineItem.yml
+++ b/docs/openapi/components/schemas/common/EntrySummaryLineItem.yml
@@ -6,15 +6,11 @@ description: A description of the articles in sufficient detail to permit the cl
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - EntrySummaryLineItem
-      - type: string
-        const:
-          - EntrySummaryLineItem 
+    type: array
+    items:
+      type: string
+      enum:
+        - EntrySummaryLineItem
   commodity:
     title: Commodity
     description: Product commodity code, codification system and description
@@ -150,9 +146,9 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "EntrySummaryLineItem",
+    "type": ["EntrySummaryLineItem"],
     "commodity": {
-      "type": "Commodity",
+      "type": ["Commodity"],
       "commodityCode": "2204.21.60 00",
       "commodityCodeType": "HS",
       "description": "Wine of fresh grapes"
@@ -160,23 +156,23 @@ example: |-
     "adCvdNumber": "A123-234-345",
     "categoryNumber": "CAT ABC",
     "grossWeight": {
-      "type": "QuantitativeValue",
+      "type": ["QuantitativeValue"],
       "value": "7420",
       "unitCode": "kg"
     },
     "manifestQuantity": 3500,
     "netQuantity": {
-      "type": "QuantitativeValue",
+      "type": ["QuantitativeValue"],
       "value": "6620",
       "unitCode": "kg"
     },
     "enteredValue": {
-      "type": "PriceSpecification",
+      "type": ["PriceSpecification"],
       "price": 12000,
       "priceCurrency": "USD"
     },
     "charges": {
-      "type": "PriceSpecification",
+      "type": ["PriceSpecification"],
       "price": 1500,
       "priceCurrency": "USD"
     },
@@ -184,7 +180,7 @@ example: |-
     "htsRate": "ad valorem",
     "visaNumber": "V10000345",
     "dutyAndIRTax": {
-      "type": "PriceSpecification",
+      "type": ["PriceSpecification"],
       "price": 8230,
       "priceCurrency": "USD"
     }

--- a/docs/openapi/components/schemas/common/ImmediateDelivery.yml
+++ b/docs/openapi/components/schemas/common/ImmediateDelivery.yml
@@ -6,14 +6,11 @@ description: CBP Form 3461 for Immediate Delivery (https://www.cbp.gov/sites/def
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ImmediateDelivery
-      - type: string
-        const: ImmediateDelivery 
+    type: array
+    items:
+      type: string
+      enum:
+        - ImmediateDelivery
   portOfEntry:
     title: Port Of Entry
     $ref: ./Place.yml
@@ -198,7 +195,7 @@ properties:
   splitBill:
     title: Split Bill
     description: Indicates if the bill is a split bill.
-    type: string
+    type: boolean
     $linkedData:
       term: splitBill
       '@id': https://w3id.org/traceability#splitBill
@@ -260,17 +257,17 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "ImmediateDelivery",
+    "type": ["ImmediateDelivery"],
     "portOfEntry": {
-      "type": "Place",
+      "type": ["Place"],
       "unLocode": "USLBC"
     },
     "bondType": "Single Transaction Bond",
     "importer": {
-      "type": "Entity",
+      "type": ["Entity"],
       "name": "Onwards A/S",
       "address": {
-        "type": "PostalAddress",
+        "type": ["PostalAddress"],
         "streetAddress": "Sludevej 63",
         "addressLocality": "Kgs. Lyngby",
         "postalCode": "2800",
@@ -288,12 +285,12 @@ example: |-
     "originatingWarehouseEntryNumber": "38819",
     "suretyCode": "511",
     "portOfUnlading": {
-      "type": "Place",
+      "type": ["Place"],
       "unLocode": "USBBK"
     },
     "transportMode": "Ocean",
     "locationOfGoods": {
-      "type": "Place",
+      "type": ["Place"],
       "unLocode": "USMRE"
     },
     "generalOrderNumber": "O1000212",
@@ -302,9 +299,9 @@ example: |-
     "referenceIDNumber": "EX123456",
     "lineItems": [
       {
-        "type": "ImmediateDeliveryLineItem",
+        "type": ["ImmediateDeliveryLineItem"],
         "commodity": {
-          "type": "Commodity",
+          "type": ["Commodity"],
           "commodityCode": "9403 7000 00",
           "commodityCodeType": "HTS"
         },
@@ -312,10 +309,10 @@ example: |-
         "itemCount": 400,
         "itemParty": {
           "consignee": {
-            "type": "Entity",
+            "type": ["Entity"],
             "name": "Future Mobility, Inc.",
             "address": {
-              "type": "PostalAddress",
+              "type": ["PostalAddress"],
               "streetAddress": "2016 W Farmington Rd",
               "addressLocality": "West Peoria",
               "postalCode": "61604",

--- a/docs/openapi/components/schemas/common/ImmediateDeliveryEntity.yml
+++ b/docs/openapi/components/schemas/common/ImmediateDeliveryEntity.yml
@@ -6,15 +6,11 @@ description: Entity identifier used on CBP 3461 Immediate Delivery Form.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ImmediateDeliveryEntity
-      - type: string
-        const:
-          - ImmediateDeliveryEntity 
+    type: array
+    items:
+      type: string
+      enum:
+        - ImmediateDeliveryEntity
   manufacturer:
     title: Manufacturer
     description: A manufacturer party.

--- a/docs/openapi/components/schemas/common/ImmediateDeliveryLineItem.yml
+++ b/docs/openapi/components/schemas/common/ImmediateDeliveryLineItem.yml
@@ -6,14 +6,11 @@ description: Line Item identifier used on CBP 3461 Immediate Delivery Form.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ImmediateDeliveryEntity
-      - type: string
-        const: ImmediateDeliveryEntity 
+    type: array
+    items:
+      type: string
+      enum:
+        - ImmediateDeliveryLineItem
   commodity: 
     title: Commodity
     description: Commodity classification based on either WCO HS or USITS HTS codification.

--- a/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCertificate.yml
@@ -1,5 +1,5 @@
 $linkedData:
-  term: ImmediateDeliveryCertificate
+  term: CBP3461ImmediateDeliveryCertificate
   '@id': https://w3id.org/traceability#ImmediateDeliveryCertificate
 title: CBP Form 3461 - Immediate Delivery Certificate
 tags:
@@ -11,14 +11,14 @@ properties:
     type: array
     items:
       type: string
-      const:
+      enum:
         - 'https://www.w3.org/2018/credentials/v1'
         - 'https://w3id.org/traceability/v1'
   type:
     type: array
     items:
       type: string
-      const:
+      enum:
         - VerifiableCredential
         - ImmediateDeliveryCertificate
   id:
@@ -57,10 +57,14 @@ example: |-
     "issuanceDate": "2022-02-25T14:34:00Z",
     "issuer": {
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "type": "Organization",
+      "type": [
+        "Organization"
+      ],
       "name": "Onwards A/S",
       "address": {
-        "type": "PostalAddress",
+        "type": [
+          "PostalAddress"
+        ],
         "streetAddress": "Sludevej 63",
         "addressLocality": "Kgs. Lyngby",
         "postalCode": "2800",
@@ -68,17 +72,25 @@ example: |-
       }
     },
     "credentialSubject": {
-      "type": "ImmediateDelivery",
+      "type": [
+        "ImmediateDelivery"
+      ],
       "portOfEntry": {
-        "type": "Place",
+        "type": [
+          "Place"
+        ],
         "unLocode": "USLBC"
       },
       "bondType": "Single Transaction Bond",
       "importer": {
-        "type": "Entity",
+        "type": [
+          "Entity"
+        ],
         "name": "Onwards A/S",
         "address": {
-          "type": "PostalAddress",
+          "type": [
+            "PostalAddress"
+          ],
           "streetAddress": "Sludevej 63",
           "addressLocality": "Kgs. Lyngby",
           "postalCode": "2800",
@@ -96,12 +108,16 @@ example: |-
       "originatingWarehouseEntryNumber": "38819",
       "suretyCode": "511",
       "portOfUnlading": {
-        "type": "Place",
+        "type": [
+          "Place"
+        ],
         "unLocode": "USBBK"
       },
       "transportMode": "Ocean",
       "locationOfGoods": {
-        "type": "Place",
+        "type": [
+          "Place"
+        ],
         "unLocode": "USMRE"
       },
       "generalOrderNumber": "O1000212",
@@ -110,9 +126,13 @@ example: |-
       "referenceIDNumber": "EX123456",
       "lineItems": [
         {
-          "type": "ImmediateDeliveryLineItem",
+          "type": [
+            "ImmediateDeliveryLineItem"
+          ],
           "commodity": {
-            "type": "Commodity",
+            "type": [
+              "Commodity"
+            ],
             "commodityCode": "9403 7000 00",
             "commodityCodeType": "HTS"
           },
@@ -120,10 +140,14 @@ example: |-
           "itemCount": 400,
           "itemParty": {
             "consignee": {
-              "type": "Entity",
+              "type": [
+                "Entity"
+              ],
               "name": "Future Mobility, Inc.",
               "address": {
-                "type": "PostalAddress",
+                "type": [
+                  "PostalAddress"
+                ],
                 "streetAddress": "2016 W Farmington Rd",
                 "addressLocality": "West Peoria",
                 "postalCode": "61604",
@@ -153,9 +177,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-06-22T08:47:24Z",
+      "created": "2022-07-29T14:45:21Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..R283GCuOZl2Xim6TOjRa6MvcdInFqN-SlA9Uce4lNs6MtmP5HgGln_gjKfI1p_xh9ZozB5kbybVPdgzL1Zf6Bg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..0Z5EPOLq-GePQM0d0_RjIZDHdiVkEOHvaeWM_Te4bh7LJa86TqBLrcS7Ss1DelZHliNOPnbvObqMDosH0l_ZCQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCertificate.yml
@@ -1,5 +1,5 @@
 $linkedData:
-  term: EntrySummaryCertificate
+  term: CBP7501EntrySummaryCertificate
   '@id': https://w3id.org/traceability#EntrySummaryCertificate
 title: CBP Form 7501 - Entry Summary Certificate
 tags:
@@ -11,14 +11,14 @@ properties:
     type: array
     items:
       type: string
-      const:
+      enum:
         - https://www.w3.org/2018/credentials/v1
         - https://w3id.org/traceability/v1
   type:
     type: array
     items:
       type: string
-      const:
+      enum:
         - VerifiableCredential
         - EntrySummaryCertificate
   id:
@@ -55,11 +55,15 @@ example: |-
       "EntrySummaryCertificate"
     ],
     "issuer": {
-      "type": "Organization",
+      "type": [
+        "Organization"
+      ],
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "name": "Future Mobility, Inc.",
       "address": {
-        "type": "PostalAddress",
+        "type": [
+          "PostalAddress"
+        ],
         "streetAddress": "2016 W Farmington Rd",
         "addressLocality": "West Peoria",
         "postalCode": "61604",
@@ -68,13 +72,20 @@ example: |-
     },
     "issuanceDate": "2022-03-03T15:20:00Z",
     "credentialSubject": {
-      "type": "EntrySummary",
-      "entryNumber": 73461882610,
+      "type": [
+        "EntrySummary"
+      ],
+      "entryNumber": "73461882610",
       "entryType": "01",
       "summaryDate": "2022-03-01T12:54Z",
       "suretyNumber": "228",
       "bondType": "Single Transaction Bond",
-      "portCode": "USLBC",
+      "portCode": {
+        "type": [
+          "Place"
+        ],
+        "unLocode": "USLBC"
+      },
       "entryDate": "2022-03-01T12:54Z",
       "importingCarrier": "NISC",
       "transportMode": "Ocean",
@@ -88,25 +99,35 @@ example: |-
       "immediateTransportationDate": "2022-03-01T12:54Z",
       "missingDocuments": [],
       "portOfLoading": {
-        "type": "Place",
-        "UNLocode": "SGSIN"
+        "type": [
+          "Place"
+        ],
+        "unLocode": "SGSIN"
       },
       "portOfUnlading": {
-        "type": "Place",
-        "UNLocode": "USLBC"
+        "type": [
+          "Place"
+        ],
+        "unLocode": "USLBC"
       },
       "locationOfGoods": {
-        "type": "Place",
-        "UNLocode": "USLBC"
+        "type": [
+          "Place"
+        ],
+        "unLocode": "USLBC"
       },
       "consigneeNumber": "9982312",
       "importerNumber": "9900127",
       "referenceNumber": "ref199812841",
       "ultimateConsignee": {
-        "type": "Entity",
+        "type": [
+          "Entity"
+        ],
         "name": "Future Mobility, Inc.",
         "address": {
-          "type": "PostalAddress",
+          "type": [
+            "PostalAddress"
+          ],
           "streetAddress": "2016 W Farmington Rd",
           "addressLocality": "West Peoria",
           "postalCode": "61604",
@@ -115,10 +136,14 @@ example: |-
         "entityType": "Organization"
       },
       "importerOfRecord": {
-        "type": "Entity",
+        "type": [
+          "Entity"
+        ],
         "name": "Future Mobility, Inc.",
         "address": {
-          "type": "PostalAddress",
+          "type": [
+            "PostalAddress"
+          ],
           "streetAddress": "2016 W Farmington Rd",
           "addressLocality": "West Peoria",
           "postalCode": "61604",
@@ -128,9 +153,13 @@ example: |-
       },
       "descriptionOfMerchandise": [
         {
-          "type": "EntrySummaryLineItem",
+          "type": [
+            "EntrySummaryLineItem"
+          ],
           "commodity": {
-            "type": "Commodity",
+            "type": [
+              "Commodity"
+            ],
             "commodityCode": "2204.21.60 00",
             "commodityCodeType": "HS",
             "description": "Wine of fresh grapes"
@@ -138,23 +167,31 @@ example: |-
           "adCvdNumber": "A123-234-345",
           "categoryNumber": "CAT ABC",
           "grossWeight": {
-            "type": "QuantitativeValue",
+            "type": [
+              "QuantitativeValue"
+            ],
             "value": "7420",
             "unitCode": "kg"
           },
           "manifestQuantity": 3500,
           "netQuantity": {
-            "type": "QuantitativeValue",
+            "type": [
+              "QuantitativeValue"
+            ],
             "value": "6620",
             "unitCode": "kg"
           },
           "enteredValue": {
-            "type": "PriceSpecification",
+            "type": [
+              "PriceSpecification"
+            ],
             "price": 12000,
             "priceCurrency": "USD"
           },
           "charges": {
-            "type": "PriceSpecification",
+            "type": [
+              "PriceSpecification"
+            ],
             "price": 1500,
             "priceCurrency": "USD"
           },
@@ -162,7 +199,9 @@ example: |-
           "htsRate": "ad valorem",
           "visaNumber": "V10000345",
           "dutyAndIRTax": {
-            "type": "PriceSpecification",
+            "type": [
+              "PriceSpecification"
+            ],
             "price": 8230,
             "priceCurrency": "USD"
           }
@@ -170,32 +209,40 @@ example: |-
       ],
       "otherFeeSummary": "AD",
       "totalEnteredValue": {
-        "type": "PriceSpecification",
+        "type": [
+          "PriceSpecification"
+        ],
         "price": 8230,
         "priceCurrency": "USD"
       },
       "declarationOfImporter": "Importer of Record",
       "duty": {
-        "type": "PriceSpecification",
+        "type": [
+          "PriceSpecification"
+        ],
         "price": 20,
         "priceCurrency": "USD"
       },
       "tax": {
-        "type": "PriceSpecification",
+        "type": [
+          "PriceSpecification"
+        ],
         "price": 282,
         "priceCurrency": "USD"
       },
       "total": {
-        "type": "PriceSpecification",
+        "type": [
+          "PriceSpecification"
+        ],
         "price": 8532,
         "priceCurrency": "USD"
       }
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-06-14T11:24:27Z",
+      "created": "2022-07-29T14:45:21Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Hmb4V2eDWW8rkSEDylTdxidT_1O6BtD1FodmrGFqUctd6OeQ3acsEe-cDWC7h-wHJy0NLmyl--w5hHMsBplpBA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..IkrQzD5WmUBYQoRE5fvqXiEh0p9MfcDeWYXhSoiFioa3BYnf6WyFVOloN2iqcdZ5ZruK27va-S0lR8x-40zrBg"
     }
   }


### PR DESCRIPTION
This fixes JSON Schema errors on certificates for CBP forms. These are the ones which are normally hidden, but emerge on the console when other errors exist.

There are three main category of bugs fixed:

- Array const instead of enum, which has been copy-pasted many times
- Changes to Org and Entity propagating to where referenced
- "Normal", one-off JSON Schema bugs (mostly mine)