### PR TITLE
Update organizationName to name in PostalAddress

### DIFF
--- a/docs/openapi/components/schemas/common/AgricultureInspectionReport.yml
+++ b/docs/openapi/components/schemas/common/AgricultureInspectionReport.yml
@@ -119,7 +119,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Bednar - Kiehn",
+        "name": "Bednar - Kiehn",
         "streetAddress": "853 Wisozk River",
         "addressLocality": "New Noemyfort",
         "addressRegion": "New Mexico",
@@ -178,7 +178,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Bartell - Doyle",
+        "name": "Bartell - Doyle",
         "streetAddress": "84189 Roberts Route",
         "addressLocality": "Kautzerstad",
         "addressRegion": "Louisiana",
@@ -189,7 +189,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Marks, Runte and Bartell",
+        "name": "Marks, Runte and Bartell",
         "streetAddress": "97696 Weissnat Pines",
         "addressLocality": "Reynabury",
         "addressRegion": "North Dakota",
@@ -212,7 +212,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Moen - Swift",
+          "name": "Moen - Swift",
           "streetAddress": "9746 Laron Gardens",
           "addressLocality": "Port Flossie",
           "addressRegion": "Hawaii",
@@ -237,7 +237,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Mills, Daugherty and Nader",
+          "name": "Mills, Daugherty and Nader",
           "streetAddress": "39514 Kulas Terrace",
           "addressLocality": "East Avis",
           "addressRegion": "Utah",

--- a/docs/openapi/components/schemas/common/AgricultureParcelDelivery.yml
+++ b/docs/openapi/components/schemas/common/AgricultureParcelDelivery.yml
@@ -134,7 +134,7 @@ example: |-
       "type": [
         "PostalAddress"
       ],
-      "organizationName": "Bartell - Doyle",
+      "name": "Bartell - Doyle",
       "streetAddress": "84189 Roberts Route",
       "addressLocality": "Kautzerstad",
       "addressRegion": "Louisiana",
@@ -145,7 +145,7 @@ example: |-
       "type": [
         "PostalAddress"
       ],
-      "organizationName": "Marks, Runte and Bartell",
+      "name": "Marks, Runte and Bartell",
       "streetAddress": "97696 Weissnat Pines",
       "addressLocality": "Reynabury",
       "addressRegion": "North Dakota",
@@ -168,7 +168,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Moen - Swift",
+        "name": "Moen - Swift",
         "streetAddress": "9746 Laron Gardens",
         "addressLocality": "Port Flossie",
         "addressRegion": "Hawaii",
@@ -193,7 +193,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Mills, Daugherty and Nader",
+        "name": "Mills, Daugherty and Nader",
         "streetAddress": "39514 Kulas Terrace",
         "addressLocality": "East Avis",
         "addressRegion": "Utah",

--- a/docs/openapi/components/schemas/common/BillOfLading.yml
+++ b/docs/openapi/components/schemas/common/BillOfLading.yml
@@ -190,7 +190,7 @@ example: |-
         },
         "address": {
           "type": ["PostalAddress"],
-          "organizationName": "Hahn LLC",
+          "name": "Hahn LLC",
           "streetAddress": "786 Pfeffer Plains",
           "addressLocality": "West Ottilie",
           "addressRegion": "Nebraska",
@@ -207,7 +207,7 @@ example: |-
         },
         "address": {
           "type": ["PostalAddress"],
-          "organizationName": "Rosenbaum, Hills and Pagac",
+          "name": "Rosenbaum, Hills and Pagac",
           "streetAddress": "71834 Zelma Trail",
           "addressLocality": "West Gerhardview",
           "addressRegion": "North Carolina",

--- a/docs/openapi/components/schemas/common/BindingDataRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/common/BindingDataRegistrationCredential.yml
@@ -80,7 +80,7 @@ example: |-
       "type": "ShippingStop",
       "shippingStopAddress": {
         "type": "PostalAddress",
-        "organizationName": "Metz - Kemmer",
+        "name": "Metz - Kemmer",
         "streetAddress": "7885 Nils Mountains",
         "addressLocality": "West Jarenbury",
         "addressRegion": "Oklahoma",

--- a/docs/openapi/components/schemas/common/CrudeOilProduct.yml
+++ b/docs/openapi/components/schemas/common/CrudeOilProduct.yml
@@ -85,7 +85,7 @@ example: |-
          "type":[
             "PostalAddress"
          ],
-         "organizationName":"Nienow Group",
+         "name":"Nienow Group",
          "streetAddress":"9479 Keven Wall",
          "addressLocality":"East Jadonview",
          "addressRegion":"Virginia",

--- a/docs/openapi/components/schemas/common/DCSATransportDocument.yml
+++ b/docs/openapi/components/schemas/common/DCSATransportDocument.yml
@@ -323,7 +323,7 @@ example: |-
         "name": "MULTI CONTAINER LINE",
         "address": {
           "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
+          "name": "MCL Multi Container Line LTD.",
           "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
           "addressLocality": "Kowloon Bay",
           "addressRegion": "Hong Kong",

--- a/docs/openapi/components/schemas/common/Event.yml
+++ b/docs/openapi/components/schemas/common/Event.yml
@@ -114,7 +114,7 @@ example: |-
       },
       "address": {
         "type": "PostalAddress",
-        "organizationName": "Krajcik Inc",
+        "name": "Krajcik Inc",
         "streetAddress": "229 Carroll Alley",
         "addressLocality": "Fayeberg",
         "addressRegion": "Kansas",

--- a/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
@@ -107,7 +107,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Delicious Dips",
+        "name": "Delicious Dips",
         "streetAddress": "755 Stephanie Gardens",
         "addressLocality": "Rasmussenborough",
         "addressRegion": "KS",

--- a/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
+++ b/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
@@ -92,7 +92,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "John's Produce",
+          "name": "John's Produce",
           "streetAddress": "4335 Walsh Underpass",
           "addressLocality": "Port Mark",
           "addressRegion": "LA",
@@ -118,7 +118,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "John's Produce",
+        "name": "John's Produce",
         "streetAddress": "4335 Walsh Underpass",
         "addressLocality": "Port Mark",
         "addressRegion": "LA",

--- a/docs/openapi/components/schemas/common/FSMAGrowingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAGrowingCTE.yml
@@ -56,7 +56,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "John's Produce",
+          "name": "John's Produce",
           "streetAddress": "4335 Walsh Underpass",
           "addressLocality": "Port Mark",
           "addressRegion": "LA",

--- a/docs/openapi/components/schemas/common/FSMAProduct.yml
+++ b/docs/openapi/components/schemas/common/FSMAProduct.yml
@@ -64,7 +64,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "John's Produce",
+          "name": "John's Produce",
           "streetAddress": "4335 Walsh Underpass",
           "addressLocality": "Port Mark",
           "addressRegion": "LA",

--- a/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
@@ -60,7 +60,7 @@ example: |-
               "type": [
                 "PostalAddress"
               ],
-              "organizationName": "John's Produce",
+              "name": "John's Produce",
               "streetAddress": "4335 Walsh Underpass",
               "addressLocality": "Port Mark",
               "addressRegion": "LA",
@@ -136,7 +136,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "John's Produce",
+          "name": "John's Produce",
           "streetAddress": "4335 Walsh Underpass",
           "addressLocality": "Port Mark",
           "addressRegion": "LA",
@@ -158,7 +158,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Pattie's Packers",
+          "name": "Pattie's Packers",
           "streetAddress": "8974 Bolton Drive",
           "addressLocality": "Port Mark",
           "addressRegion": "LA",

--- a/docs/openapi/components/schemas/common/FSMAShipment.yml
+++ b/docs/openapi/components/schemas/common/FSMAShipment.yml
@@ -66,7 +66,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "John's Produce",
+            "name": "John's Produce",
             "streetAddress": "4335 Walsh Underpass",
             "addressLocality": "Port Mark",
             "addressRegion": "LA",
@@ -142,7 +142,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "John's Produce",
+        "name": "John's Produce",
         "streetAddress": "4335 Walsh Underpass",
         "addressLocality": "Port Mark",
         "addressRegion": "LA",
@@ -164,7 +164,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Pattie's Packers",
+        "name": "Pattie's Packers",
         "streetAddress": "8974 Bolton Drive",
         "addressLocality": "Port Mark",
         "addressRegion": "LA",

--- a/docs/openapi/components/schemas/common/FSMAShippingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAShippingCTE.yml
@@ -60,7 +60,7 @@ example: |-
               "type": [
                 "PostalAddress"
               ],
-              "organizationName": "John's Produce",
+              "name": "John's Produce",
               "streetAddress": "4335 Walsh Underpass",
               "addressLocality": "Port Mark",
               "addressRegion": "LA",
@@ -136,7 +136,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "John's Produce",
+          "name": "John's Produce",
           "streetAddress": "4335 Walsh Underpass",
           "addressLocality": "Port Mark",
           "addressRegion": "LA",
@@ -158,7 +158,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Pattie's Packers",
+          "name": "Pattie's Packers",
           "streetAddress": "8974 Bolton Drive",
           "addressLocality": "Port Mark",
           "addressRegion": "LA",

--- a/docs/openapi/components/schemas/common/FSMATraceabilityLot.yml
+++ b/docs/openapi/components/schemas/common/FSMATraceabilityLot.yml
@@ -76,7 +76,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "John's Produce",
+        "name": "John's Produce",
         "streetAddress": "4335 Walsh Underpass",
         "addressLocality": "Port Mark",
         "addressRegion": "LA",

--- a/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
@@ -72,7 +72,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "John's Produce",
+            "name": "John's Produce",
             "streetAddress": "4335 Walsh Underpass",
             "addressLocality": "Port Mark",
             "addressRegion": "LA",

--- a/docs/openapi/components/schemas/common/FoodGradeInspection.yml
+++ b/docs/openapi/components/schemas/common/FoodGradeInspection.yml
@@ -144,7 +144,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Ace Foodstuffs",
+        "name": "Ace Foodstuffs",
         "streetAddress": "853 Wisozk River",
         "addressLocality": "New Noemyfort",
         "addressRegion": "New Mexico",
@@ -220,7 +220,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Industrial Distributions",
+        "name": "Industrial Distributions",
         "streetAddress": "853 Wisozk River",
         "addressLocality": "New Noemyfort",
         "addressRegion": "New Mexico",
@@ -231,7 +231,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Green Fields",
+        "name": "Green Fields",
         "streetAddress": "97696 Weissnat Pines",
         "addressLocality": "Reynabury",
         "addressRegion": "North Dakota",

--- a/docs/openapi/components/schemas/common/FreightManifest.yml
+++ b/docs/openapi/components/schemas/common/FreightManifest.yml
@@ -74,7 +74,7 @@ example: |-
       "name": "MULTI CONTAINER LINE",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
+        "name": "MCL Multi Container Line LTD.",
         "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
         "addressLocality": "Kowloon Bay",
         "addressRegion": "Hong Kong",

--- a/docs/openapi/components/schemas/common/HouseBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/HouseBillOfLading.yml
@@ -256,7 +256,7 @@ example: |-
       "name": "World Forward, Inc.",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
+        "name": "MCL Multi Container Line LTD.",
         "streetAddress": "Well Fung Ind Centre",
         "addressLocality": "Kwai Chung",
         "addressRegion": "Hong Kong",

--- a/docs/openapi/components/schemas/common/Inbond.yml
+++ b/docs/openapi/components/schemas/common/Inbond.yml
@@ -162,7 +162,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Will Group",
+        "name": "Will Group",
         "streetAddress": "73355 Abel Meadows",
         "addressLocality": "Jevonville",
         "addressRegion": "Maryland",
@@ -201,7 +201,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Mraz Group",
+        "name": "Mraz Group",
         "streetAddress": "6892 Kozey Trail",
         "addressLocality": "Leannonland",
         "addressRegion": "Georgia",
@@ -226,7 +226,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Waelchi - Emard",
+        "name": "Waelchi - Emard",
         "streetAddress": "25775 Moen Shores",
         "addressLocality": "East Cielofort",
         "addressRegion": "Alabama",
@@ -241,7 +241,7 @@ example: |-
         "type": "Place",
         "address": {
           "type": "PostalAddress",
-          "organizationName": "Walker and Sons",
+          "name": "Walker and Sons",
           "streetAddress": "27382 Kirlin Center",
           "addressLocality": "East Wyatt",
           "addressRegion": "New Hampshire",
@@ -253,7 +253,7 @@ example: |-
         "type": "Place",
         "address": {
           "type": "PostalAddress",
-          "organizationName": "Becker and Sons",
+          "name": "Becker and Sons",
           "streetAddress": "158 MacGyver Mountain",
           "addressLocality": "Dachmouth",
           "addressRegion": "Georgia",

--- a/docs/openapi/components/schemas/common/InspectionReport.yml
+++ b/docs/openapi/components/schemas/common/InspectionReport.yml
@@ -102,7 +102,7 @@ example: |-
       "globalLocationNumber": "3177794693200",
       "address": {
           "@type": "PostalAddress",
-          "organizationName": "Canada Border Services Agency",
+          "name": "Canada Border Services Agency",
           "streetAddress": "Highway 12",
           "addressLocality": "Sprague",
           "addressRegion": "Manitoba",

--- a/docs/openapi/components/schemas/common/IntentToImport.yml
+++ b/docs/openapi/components/schemas/common/IntentToImport.yml
@@ -81,7 +81,7 @@ example: |-
         "type": "Place",
           "address": {
           "type": "PostalAddress",
-          "organizationName": "Generic Motors of America",
+          "name": "Generic Motors of America",
           "streetAddress": "12 Generic Motors Dr",
           "addressLocality": "Detroit",
           "addressRegion": "Michigan",

--- a/docs/openapi/components/schemas/common/Invoice.yml
+++ b/docs/openapi/components/schemas/common/Invoice.yml
@@ -287,7 +287,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Generic Motors of America",
+        "name": "Generic Motors of America",
         "streetAddress": "12 Generic Motors Dr",
         "addressLocality": "Detroit",
         "addressRegion": "Michigain",

--- a/docs/openapi/components/schemas/common/MasterBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MasterBillOfLading.yml
@@ -273,7 +273,7 @@ example: |-
       "name": "MULTI CONTAINER LINE",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
+        "name": "MCL Multi Container Line LTD.",
         "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
         "addressLocality": "Kowloon Bay",
         "addressRegion": "Hong Kong",

--- a/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
@@ -273,7 +273,7 @@ example: |-
       "name": "MULTI CONTAINER LINE",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
+        "name": "MCL Multi Container Line LTD.",
         "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
         "addressLocality": "Kowloon Bay",
         "addressRegion": "Hong Kong",

--- a/docs/openapi/components/schemas/common/NaturalGasProduct.yml
+++ b/docs/openapi/components/schemas/common/NaturalGasProduct.yml
@@ -77,7 +77,7 @@ example: |-
       },
       "address": {
         "type": "PostalAddress",
-        "organizationName": "Schneider - Bernier",
+        "name": "Schneider - Bernier",
         "streetAddress": "012 Cecil Keys",
         "addressLocality": "Gaylordhaven",
         "addressRegion": "Indiana",

--- a/docs/openapi/components/schemas/common/OGBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/OGBillOfLading.yml
@@ -155,7 +155,7 @@ example: |-
           },
           "address": {
             "type": "PostalAddress",  
-            "organizationName": "Waters, Yost and Franecki",
+            "name": "Waters, Yost and Franecki",
             "streetAddress": "5223 Abshire Stream",
             "addressLocality": "Mannmouth",
             "addressRegion": "Kentucky",
@@ -172,7 +172,7 @@ example: |-
           },
           "address": {
             "type": "PostalAddress",
-            "organizationName": "Leannon LLC",
+            "name": "Leannon LLC",
             "streetAddress": "6095 Queen Springs",
             "addressLocality": "Justuschester",
             "addressRegion": "Georgia",

--- a/docs/openapi/components/schemas/common/ParcelDelivery.yml
+++ b/docs/openapi/components/schemas/common/ParcelDelivery.yml
@@ -84,7 +84,7 @@ example: |-
       },
       "address" : {
         "type": "PostalAddress",
-        "organizationName": "Reichel, Feil and Botsford",
+        "name": "Reichel, Feil and Botsford",
         "streetAddress": "632 Adelbert Avenue",
         "addressLocality": "Jaidenland",
         "addressRegion": "Missouri",
@@ -101,7 +101,7 @@ example: |-
       },
       "address": {
         "type": "PostalAddress",
-        "organizationName": "Jaskolski Inc",
+        "name": "Jaskolski Inc",
         "streetAddress": "25015 Crona Mission",
         "addressLocality": "Marcoston",
         "addressRegion": "Pennsylvania",

--- a/docs/openapi/components/schemas/common/Phytosanitary.yml
+++ b/docs/openapi/components/schemas/common/Phytosanitary.yml
@@ -207,7 +207,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Von LLC",
+        "name": "Von LLC",
         "streetAddress": "825 Strosin Knoll",
         "addressLocality": "West Alivia",
         "addressRegion": "New Mexico",
@@ -261,7 +261,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Bartell - Doyle",
+        "name": "Bartell - Doyle",
         "streetAddress": "84189 Roberts Route",
         "addressLocality": "Kautzerstad",
         "addressRegion": "Louisiana",
@@ -272,7 +272,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Marks, Runte and Bartell",
+        "name": "Marks, Runte and Bartell",
         "streetAddress": "97696 Weissnat Pines",
         "addressLocality": "Reynabury",
         "addressRegion": "North Dakota",
@@ -295,7 +295,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Moen - Swift",
+          "name": "Moen - Swift",
           "streetAddress": "9746 Laron Gardens",
           "addressLocality": "Port Flossie",
           "addressRegion": "Hawaii",
@@ -320,7 +320,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Mills, Daugherty and Nader",
+          "name": "Mills, Daugherty and Nader",
           "streetAddress": "39514 Kulas Terrace",
           "addressLocality": "East Avis",
           "addressRegion": "Utah",

--- a/docs/openapi/components/schemas/common/Place.yml
+++ b/docs/openapi/components/schemas/common/Place.yml
@@ -76,7 +76,7 @@ example: |-
     },
     "address": {
       "type": "PostalAddress",
-      "organizationName": "Ratke - Bergstrom",
+      "name": "Ratke - Bergstrom",
       "streetAddress": "21851 Ima Heights",
       "addressLocality": "O'Connellborough",
       "addressRegion": "Missouri",

--- a/docs/openapi/components/schemas/common/PostalAddress.yml
+++ b/docs/openapi/components/schemas/common/PostalAddress.yml
@@ -17,13 +17,13 @@ properties:
       - type: string
         const:
           - PostalAddress   
-  organizationName:
-    title: Organization Name
-    description: The name of the organization expressed in text.
+  name:
+    title: Name
+    description: The name of the entity in text.
     type: string
     $linkedData:
-      term: organizationName
-      '@id': https://gs1.org/voc/organizationName
+      term: name
+      '@id': https://schema.org/name
   streetAddress:
     title: Street Address
     description: >-
@@ -98,7 +98,7 @@ additionalProperties: false
 example: |-
   {
     "type": "PostalAddress",
-    "organizationName": "Lebsack Inc",
+    "name": "Lebsack Inc",
     "streetAddress": "758 Huel Neck",
     "addressLocality": "Hagenesstad",
     "addressRegion": "Illinois",

--- a/docs/openapi/components/schemas/common/PurchaseOrder.yml
+++ b/docs/openapi/components/schemas/common/PurchaseOrder.yml
@@ -221,7 +221,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+        "name": "Aishi Metal Shinzo Co., Ltd.",
         "streetAddress": "1651, Shimonakano, Yoshida",
         "addressLocality": "Tsubame-shi",
         "addressRegion": "Niigata-ken",
@@ -237,7 +237,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Generic Motors of America",
+        "name": "Generic Motors of America",
         "streetAddress": "12 Generic Motors Dr",
         "addressLocality": "Detroit",
         "addressRegion": "Michigain",
@@ -255,7 +255,7 @@ example: |-
             "name": "Aishi Metal Shinzo Co., Ltd.",
             "address": {
               "type": ["PostalAddress"],
-              "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+              "name": "Aishi Metal Shinzo Co., Ltd.",
               "streetAddress": "1651, Shimonakano, Yoshida",
               "addressLocality": "Tsubame-shi",
               "addressRegion": "Niigata-ken",
@@ -291,7 +291,7 @@ example: |-
             "name": "Aishi Metal Shinzo Co., Ltd.",
             "address": {
               "type": ["PostalAddress"],
-              "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+              "name": "Aishi Metal Shinzo Co., Ltd.",
               "streetAddress": "1651, Shimonakano, Yoshida",
               "addressLocality": "Tsubame-shi",
               "addressRegion": "Niigata-ken",

--- a/docs/openapi/components/schemas/common/SeaCargoManifest.yml
+++ b/docs/openapi/components/schemas/common/SeaCargoManifest.yml
@@ -199,7 +199,7 @@ example: |-
           "name": "MULTI CONTAINER LINE",
           "address": {
             "type": "PostalAddress",
-            "organizationName": "MCL Multi Container Line LTD.",
+            "name": "MCL Multi Container Line LTD.",
             "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
             "addressLocality": "Kowloon Bay",
             "addressRegion": "Hong Kong",
@@ -435,7 +435,7 @@ example: |-
             "name": "MULTI CONTAINER LINE",
             "address": {
               "type": "PostalAddress",
-              "organizationName": "MCL Multi Container Line LTD.",
+              "name": "MCL Multi Container Line LTD.",
               "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
               "addressLocality": "Kowloon Bay",
               "addressRegion": "Hong Kong",

--- a/docs/openapi/components/schemas/common/ShippingStop.yml
+++ b/docs/openapi/components/schemas/common/ShippingStop.yml
@@ -58,7 +58,7 @@ example: |-
     "type": "ShippingStop",
     "shippingStopAddress": {
       "type": "PostalAddress",
-      "organizationName": "Tremblay, Prosacco and Beatty",
+      "name": "Tremblay, Prosacco and Beatty",
       "streetAddress": "69047 Mann Lodge",
       "addressLocality": "Cormierview",
       "addressRegion": "Mississippi",

--- a/docs/openapi/components/schemas/common/Template.yml
+++ b/docs/openapi/components/schemas/common/Template.yml
@@ -192,7 +192,7 @@ example: |-
                     "type": "Place",
                     "address": {
                         "type": "PostalAddress",
-                        "organizationName": "Goyette Inc",
+                        "name": "Goyette Inc",
                         "streetAddress": "3685 Hessel Field",
                         "addressLocality": "North Alexannemouth",
                         "addressRegion": "Kansas",
@@ -204,7 +204,7 @@ example: |-
                     "type": "Place",
                     "address" : {
                         "type": "PostalAddress",
-                        "organizationName": "Schaefer, Beer and O'Reilly",
+                        "name": "Schaefer, Beer and O'Reilly",
                         "streetAddress": "269 Aaliyah Trafficway",
                         "addressLocality": "Caylaland",
                         "addressRegion": "Maryland",

--- a/docs/openapi/components/schemas/common/UsdaSc6.yml
+++ b/docs/openapi/components/schemas/common/UsdaSc6.yml
@@ -157,7 +157,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Friesen Inc",
+        "name": "Friesen Inc",
         "streetAddress": "0644 Grant Viaduct",
         "addressLocality": "West Gretaton",
         "addressRegion": "Rhode Island",
@@ -216,7 +216,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Bartell - Doyle",
+        "name": "Bartell - Doyle",
         "streetAddress": "84189 Roberts Route",
         "addressLocality": "Kautzerstad",
         "addressRegion": "Louisiana",
@@ -227,7 +227,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Marks, Runte and Bartell",
+        "name": "Marks, Runte and Bartell",
         "streetAddress": "97696 Weissnat Pines",
         "addressLocality": "Reynabury",
         "addressRegion": "North Dakota",
@@ -250,7 +250,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Moen - Swift",
+          "name": "Moen - Swift",
           "streetAddress": "9746 Laron Gardens",
           "addressLocality": "Port Flossie",
           "addressRegion": "Hawaii",
@@ -275,7 +275,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Mills, Daugherty and Nader",
+          "name": "Mills, Daugherty and Nader",
           "streetAddress": "39514 Kulas Terrace",
           "addressLocality": "East Avis",
           "addressRegion": "Utah",

--- a/docs/openapi/components/schemas/common/WayBillRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/common/WayBillRegistrationCredential.yml
@@ -85,7 +85,7 @@ example: |-
       "type": "ShippingStop",
       "shippingStopAddress": {
         "type": "PostalAddress",
-        "organizationName": "Oberbrunner, Feeney and Langosh",
+        "name": "Oberbrunner, Feeney and Langosh",
         "streetAddress": "13308 Abigayle Drives",
         "addressLocality": "South Vanessaton",
         "addressRegion": "Kentucky",

--- a/docs/openapi/components/schemas/common/ppq587.yml
+++ b/docs/openapi/components/schemas/common/ppq587.yml
@@ -76,7 +76,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Schuster - Macejkovic",
+        "name": "Schuster - Macejkovic",
         "streetAddress": "83995 Roberts Dale",
         "addressLocality": "West Abigalestad",
         "addressRegion": "Montana",
@@ -93,7 +93,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Bartell - Doyle",
+        "name": "Bartell - Doyle",
         "streetAddress": "84189 Roberts Route",
         "addressLocality": "Kautzerstad",
         "addressRegion": "Louisiana",
@@ -104,7 +104,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Marks, Runte and Bartell",
+        "name": "Marks, Runte and Bartell",
         "streetAddress": "97696 Weissnat Pines",
         "addressLocality": "Reynabury",
         "addressRegion": "North Dakota",
@@ -127,7 +127,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Moen - Swift",
+          "name": "Moen - Swift",
           "streetAddress": "9746 Laron Gardens",
           "addressLocality": "Port Flossie",
           "addressRegion": "Hawaii",
@@ -152,7 +152,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Mills, Daugherty and Nader",
+          "name": "Mills, Daugherty and Nader",
           "streetAddress": "39514 Kulas Terrace",
           "addressLocality": "East Avis",
           "addressRegion": "Utah",

--- a/docs/openapi/components/schemas/credentials/BillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCertificate.yml
@@ -156,7 +156,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "Hahn LLC",
+            "name": "Hahn LLC",
             "streetAddress": "786 Pfeffer Plains",
             "addressLocality": "West Ottilie",
             "addressRegion": "Nebraska",
@@ -179,7 +179,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "Rosenbaum, Hills and Pagac",
+            "name": "Rosenbaum, Hills and Pagac",
             "streetAddress": "71834 Zelma Trail",
             "addressLocality": "West Gerhardview",
             "addressRegion": "North Carolina",
@@ -205,9 +205,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-03T11:36:37Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HJCBJbQK_u_Dku5C22nfEZFDQEypt_5esaQDNK09MNyKfwVPSxrkP6weJ9LPmt1yFoZOfSeZuYrVIlrnW_7aCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..3__h3a9maluzWNPwBMdGQdjxGE87S5lIrdPlQ1U8RKiweYPR5m50iJ_N6khAgK_Kx4MQJzMea_TXY90erelACA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCertificate.yml
@@ -177,9 +177,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-29T14:45:21Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..0Z5EPOLq-GePQM0d0_RjIZDHdiVkEOHvaeWM_Te4bh7LJa86TqBLrcS7Ss1DelZHliNOPnbvObqMDosH0l_ZCQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..KNTSBuLx_du0sO6n4W_ErsB--Z4BCzOozhlNXBggSclllMHoZvZmq3JS3WYzeY1d-G9P1HU0nUUXh0F2BqXwCg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCertificate.yml
@@ -240,9 +240,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-29T14:45:21Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..IkrQzD5WmUBYQoRE5fvqXiEh0p9MfcDeWYXhSoiFioa3BYnf6WyFVOloN2iqcdZ5ZruK27va-S0lR8x-40zrBg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Gicd_GvgBPaSHYfkE_xO-Pxla1hokrS0qhMEhN2GatyC_BSEqFpQv26dshpspGkT0X8X6cLYVb2hTdu_I1ZYAA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -132,7 +132,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Trans-Atlantic Shipping Co. Ltd.",
+        "name": "Trans-Atlantic Shipping Co. Ltd.",
         "streetAddress": "82 Whitchurch Road",
         "addressLocality": "Elsworth",
         "postalCode": "CB3 8NW",
@@ -146,9 +146,9 @@ example: |-
     "issuingCountry": "US",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-01T15:05:08Z",
+      "created": "2022-08-17T14:41:36Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ssF9IW3w2ebfuIcbNeSsXCBoiY4hD1W-jxA4L8HGNZ6QGLFWKrleFauUeJXDo5fzqbNuR7pd6qSjJ7R4e_NiAg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..dg5QvGx7EL2W63zAgnH5TRnlsNrIs0vxoVVmPLZ9Tdto0A5FDsie7PNq3QIy0m9tNlpCQs9qwQzoLSNV17wCAg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -94,9 +94,9 @@ example: |-
     "dateOfExport": "2022-02-02T09:30:00Z",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-26T19:02:38Z",
+      "created": "2022-08-17T14:41:36Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..j70A3OJDj_2ZTj0pEtmEQPvw19tmCndBFLE7QFQr6PXWuXG_UMLDVWDwpsXSyj9Kc9XeecKPv2CKGKl4QsmdDw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..0Fm8_o1-QVk3QAfhDPqfRZQ4MHRSs_aAHXIflO9zDH4CCjH-47dg37PH3HZnipSj3T0VjvqaufrqbW9NQhtjDQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CommercialInvoiceCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CommercialInvoiceCertificate.yml
@@ -143,7 +143,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Generic Motors of America",
+          "name": "Generic Motors of America",
           "streetAddress": "12 Generic Motors Dr",
           "addressLocality": "Detroit",
           "addressRegion": "Michigain",
@@ -296,9 +296,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-03T11:57:23Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ua_8myK5LnkJHA_Me41Tma7O8xnTfrRYmQRQRd_vn4yetQpktNSMkU34bE2U572Qz3htWe5xOA9KsQlhJMGoBw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HPHrfxZGeAVEV0nmTXVZiCGu1bFUJJLB095RkfBw-qGdNG1uc8D7TAPTpQjRGJGX_e7ojQvhKoPmkR_avKMdBQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CrudeOilProductCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CrudeOilProductCertificate.yml
@@ -72,7 +72,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Nienow Group",
+          "name": "Nienow Group",
           "streetAddress": "9479 Keven Wall",
           "addressLocality": "East Jadonview",
           "addressRegion": "Virginia",
@@ -178,9 +178,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-06-22T08:47:24Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..NGRNSaeytuE9O2IR2sg7mEbi3uLghkr4-oRUEsAgFecYPVVsmys9f3Foxiqkz0bCbc4dN7ct2UUlWecs5U0NAQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ryv3T4b0C2lCjuUmHi8O0gCUa4ndhZBSL6ySBJiSVKVxv3Aeqnta4CeR2ar7ianlfC9W86Ay888_796h8Ea0Dg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCertificate.yml
@@ -228,9 +228,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-29T13:27:56Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..qt2BOWxh754s6m4_nx4juHmdTJBomQ5MQh5m2sGr_PGay1VpyXnGlN54ZCEdhx-pkuKNrQVKfdjAFIT-TJ85AA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..aTTXe6L9BddiReu4GrbAjvZebdxIZGErSV956xCxsDtYaNBRmh5jcI11N2lF-0yiRz5_CXG9ZLqzuAu9px59Dw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/DCSATransportDocumentCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/DCSATransportDocumentCertificate.yml
@@ -74,7 +74,7 @@ example: |-
       "name": "MULTI CONTAINER LINE",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
+        "name": "MCL Multi Container Line LTD.",
         "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
         "addressLocality": "Kowloon Bay",
         "addressRegion": "Hong Kong",
@@ -269,7 +269,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "MCL Multi Container Line LTD.",
+            "name": "MCL Multi Container Line LTD.",
             "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
             "addressLocality": "Kowloon Bay",
             "addressRegion": "Hong Kong",
@@ -282,9 +282,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-29T13:27:56Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..CzdeWnFejlxwnSZ8twxNNXg2sFcuLuPZC2NGoQYsrqTtOluudhLQk6gd3bMeEwmYH8fOi8xKLFIPPDze_i4_DA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..94FuEPcJeTmktHr5qgHzKpfTahPdkJI-cEa7Mud3-UIc0F0a65I1igBA3AsgExVz4qy8z5nkGSdRylL5gK4ZDQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/DeMinimisShipmentCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/DeMinimisShipmentCertificate.yml
@@ -290,9 +290,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-18T11:32:12Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..uvEj7UY_vCWe8pZkB8E_9OTa6BogxPD66k7vSKlHwgkvK1-FdJC9YpFKUd2DTy6_8kefHVe0Nwk2jCDPqqsXCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yrVcf8ZotJDXqS20D2L2NgklzlidjiY5fedeVcdZXwdnoSmCRLCVSyND5IoZopWGZUiU9L6a6VD2pPzk_qGrAQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
@@ -76,7 +76,7 @@ example: |-
       "description": "Delicious dips & related foodstuffs",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "Delicious Dips",
+        "name": "Delicious Dips",
         "streetAddress": "755 Stephanie Gardens",
         "addressLocality": "Rasmussenborough",
         "addressRegion": "KS",
@@ -144,7 +144,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Delicious Dips",
+          "name": "Delicious Dips",
           "streetAddress": "755 Stephanie Gardens",
           "addressLocality": "Rasmussenborough",
           "addressRegion": "KS",
@@ -157,9 +157,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-19T04:04:13Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..nhRo_DdBCM8H5aDHSM2SUK2oBPrygH4dpVkh17zWax_wRBClaqKFyUAurwqmicmeQ3RFQo1t4TNxprTiulPNAA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..efmu_xmJK2QOCatJYsxeiUdHniKHyKOGY9Er64JgpEEiv1RN5yJ7BXu7x4JkEVaKIdw1N5M-ifhyq4OnRZt0Aw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
@@ -99,7 +99,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "John's Produce",
+            "name": "John's Produce",
             "streetAddress": "4335 Walsh Underpass",
             "addressLocality": "Port Mark",
             "addressRegion": "LA",
@@ -125,7 +125,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "John's Produce",
+          "name": "John's Produce",
           "streetAddress": "4335 Walsh Underpass",
           "addressLocality": "Port Mark",
           "addressRegion": "LA",
@@ -140,9 +140,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-27T04:23:25Z",
+      "created": "2022-08-17T14:41:36Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YuaFMhqjZXHqElLTqVoVR1wUns_BkPf5GfzwdEVmG9-Po9k2buR1Th1g0hXqJh1k7SD8vtpnEDdCEWQNQe5BDw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..CE_kaDDCpBISoWXUkkF5JMaHaPm0UAQh14b9mt7wMv-3gjCgbBPYTlcpb4hMovWuP68iH9I8bMxkWxUI5GM6AQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
@@ -99,7 +99,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "John's Produce",
+            "name": "John's Produce",
             "streetAddress": "4335 Walsh Underpass",
             "addressLocality": "Port Mark",
             "addressRegion": "LA",
@@ -127,9 +127,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-19T03:54:51Z",
+      "created": "2022-08-17T14:41:36Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..4n0o_hhqPHkz4sDNMZvdan8ZrtMG1oobeaDMniyGc5pnnQ0QWpJuqO_hczrcDJ11QAcj4he4kF2FVS-mz7j7CQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..KNkU5j4rnqd62y48YUOq_WD4OTRE7pgZON-tYD4GTgI6-yp3Nl1IB7IhcLhE5UNaAwZ4zsjgU9oP5aoBVKnNCA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
@@ -103,7 +103,7 @@ example: |-
                 "type": [
                   "PostalAddress"
                 ],
-                "organizationName": "John's Produce",
+                "name": "John's Produce",
                 "streetAddress": "4335 Walsh Underpass",
                 "addressLocality": "Port Mark",
                 "addressRegion": "LA",
@@ -179,7 +179,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "John's Produce",
+            "name": "John's Produce",
             "streetAddress": "4335 Walsh Underpass",
             "addressLocality": "Port Mark",
             "addressRegion": "LA",
@@ -201,7 +201,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "Pattie's Packers",
+            "name": "Pattie's Packers",
             "streetAddress": "8974 Bolton Drive",
             "addressLocality": "Port Mark",
             "addressRegion": "LA",
@@ -232,9 +232,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-27T04:52:31Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..JBF0wQuxEfV8pYegZH2uuuE5kJZvsSAgAlr4Njw9G4IF0kA0jyUgz-_0QTxx9Pk-gpiHjESM6__ToWuGIAHJCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.._Kbk4vCrwCxDVfGK7JJMaDoaSEaW8w6yY3SbekM-WZcAEEQZMMAzE0gHzbqWLPU9D4EDGmIl65bHowhdX7oBAQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
@@ -103,7 +103,7 @@ example: |-
                 "type": [
                   "PostalAddress"
                 ],
-                "organizationName": "John's Produce",
+                "name": "John's Produce",
                 "streetAddress": "4335 Walsh Underpass",
                 "addressLocality": "Port Mark",
                 "addressRegion": "LA",
@@ -179,7 +179,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "John's Produce",
+            "name": "John's Produce",
             "streetAddress": "4335 Walsh Underpass",
             "addressLocality": "Port Mark",
             "addressRegion": "LA",
@@ -201,7 +201,7 @@ example: |-
             "type": [
               "PostalAddress"
             ],
-            "organizationName": "Pattie's Packers",
+            "name": "Pattie's Packers",
             "streetAddress": "8974 Bolton Drive",
             "addressLocality": "Port Mark",
             "addressRegion": "LA",
@@ -239,9 +239,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-27T05:00:20Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..A3JMqjPQgElsxFmkix9UvsvwPOR1WKQ7okgNMwyBTPQl9xfBi6WoG4a0Xhs9GCIXxiukDNYtC04WJhYNNWAHBw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..n5OKNK7QPFatfStsilGiYg38DURTI0gc8FVd6qk6uHHJF-6AHTQ_YbAK64wqz9qG05diRe2Nbq7vvlVn3unXAg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
@@ -101,7 +101,7 @@ example: |-
               "type": [
                 "PostalAddress"
               ],
-              "organizationName": "John's Produce",
+              "name": "John's Produce",
               "streetAddress": "4335 Walsh Underpass",
               "addressLocality": "Port Mark",
               "addressRegion": "LA",
@@ -221,9 +221,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-19T04:04:13Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..UB0JLwHI2MIgXX3DQRzkLozxt4ePsT_rOAmNUKaFj2qeJ1ClFXtwpgxYb3OCmJ91bjEdA6V-1DsVae8WMHQ7Ag"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..60F5ONpk4a0iK0_WHWJFvitqmvp5byrkjJVYdgGfjHlX1doqzd98i_GKb9N20qkGqPFfQtsa23MvKTM_e2JzDQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
@@ -110,7 +110,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Ace Foodstuffs",
+          "name": "Ace Foodstuffs",
           "streetAddress": "853 Wisozk River",
           "addressLocality": "New Noemyfort",
           "addressRegion": "New Mexico",
@@ -186,7 +186,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Industrial Distributions",
+          "name": "Industrial Distributions",
           "streetAddress": "853 Wisozk River",
           "addressLocality": "New Noemyfort",
           "addressRegion": "New Mexico",
@@ -197,7 +197,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Green Fields",
+          "name": "Green Fields",
           "streetAddress": "97696 Weissnat Pines",
           "addressLocality": "Reynabury",
           "addressRegion": "North Dakota",
@@ -478,9 +478,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-26T19:02:43Z",
+      "created": "2022-08-17T14:41:38Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..QusThqa6XnMCHYY7Mmeto664o2W38UfLDsJnT1lT9SkapuF8rglcQ97virwJikmXbiaDSl8-dpTjQLSzst5bDg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HslJRQuvML_Iq-ZLLHkAEuj1X_k0u1sPZiPe2Av5PlEwIIFy5--VBTw-6hQgD0Ffg2yLPTQzwwdr6V9wsaN0Bw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FreightManifestCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FreightManifestCertificate.yml
@@ -59,7 +59,7 @@ example: |-
       "name": "MULTI CONTAINER LINE",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
+        "name": "MCL Multi Container Line LTD.",
         "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
         "addressLocality": "Kowloon Bay",
         "addressRegion": "Hong Kong",
@@ -73,7 +73,7 @@ example: |-
         "name": "MULTI CONTAINER LINE",
         "address": {
           "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
+          "name": "MCL Multi Container Line LTD.",
           "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
           "addressLocality": "Kowloon Bay",
           "addressRegion": "Hong Kong",
@@ -250,9 +250,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-29T13:39:31Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..3ksCLG-UqwdyHPATVtgWQ7DWqZdEojMHkSh9jFauhbEJ44_LfteUFZncFpUos5M62mcd2pfJc_4RHpif9hNRDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ehEA4DqzlMx9m0JJLWgBZTwyd1s9AndSdxXIohvo2LHCblyoArdIC4kRgJ8j5ZHibZqXNbWftYQ0Cj-Dx-D4Ag"
     }
   }

--- a/docs/openapi/components/schemas/credentials/HouseBillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/HouseBillOfLadingCertificate.yml
@@ -63,7 +63,7 @@ example: |-
       "name": "World Forward, Inc.",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
+        "name": "MCL Multi Container Line LTD.",
         "streetAddress": "Well Fung Ind Centre",
         "addressLocality": "Kwai Chung",
         "addressRegion": "Hong Kong",
@@ -128,7 +128,7 @@ example: |-
         "name": "World Forward, Inc.",
         "address": {
           "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
+          "name": "MCL Multi Container Line LTD.",
           "streetAddress": "Well Fung Ind Centre",
           "addressLocality": "Kwai Chung",
           "addressRegion": "Hong Kong",
@@ -204,9 +204,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-18T12:53:06Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..qk0jIhuu_m327En6VrUaLNaaYSWcrowPi20i--1BC7NBAzxGqzOcMD-tlnJrNI-_FDQsW4JGAz3Y04gySgCbDQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..c4b46cRt97AtPznH4Uvs9Yx_lBQ4UbHdiFV1P_xWRoRJ5EgCVYsmOByDvNH7SbJTg20aqONjA-PoOWr63StJBQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/IATAAirWaybillCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/IATAAirWaybillCertificate.yml
@@ -218,9 +218,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-01T13:58:52Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..U5Tvlypfv_p2LrgwFjXWZbkCL9g9dW5TBWfZrDSVkKWu1IlXX-tG1ao9SV_ZYAl57vZPoLX2NLr9g-Dn8ScUDw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Ls7EZPQrBhBicu1HPZeWhuQyZsNYXtytAtKuYsaH5sopIMnxKxVXO7noVaGls77xrCSkO6kn8CyzTicHJQD-Cg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCertificate.yml
@@ -222,9 +222,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-29T15:57:05Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BJC43hNZ77n6tjKsAmQU0L1AvYJu47U2N-hvzsbhq8PEqBimL9sHk9iKWSLAxrhioVAXFYSB8Hnky_wg1rsgCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pjNumdr-52kUC8fODASyIQc_TVTz7IcXMDsYf_9PZGMFDcNQiy0lisVauvTmkJhU1X6uCUHEW6e5cNXcDW9GCA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/IntentToImportCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCertificate.yml
@@ -68,7 +68,7 @@ example: |-
         "type": "Place",
         "address": {
           "type": "PostalAddress",
-          "organizationName": "Generic Motors of America",
+          "name": "Generic Motors of America",
           "streetAddress": "12 Generic Motors Dr",
           "addressLocality": "Detroit",
           "addressRegion": "Michigan",
@@ -105,7 +105,7 @@ example: |-
           "type": "Place",
           "address": {
             "type": "PostalAddress",
-            "organizationName": "Generic Motors of America",
+            "name": "Generic Motors of America",
             "streetAddress": "12 Generic Motors Dr",
             "addressLocality": "Detroit",
             "addressRegion": "Michigan",
@@ -145,9 +145,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-26T19:02:39Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..A0g9MqnFKP3zXctcSp7bK8GJkDf52gwDqQJksDpYXnBmpDeHZtUcOZIkau83YV2Z99jJ-FoDuRfFYF4Ga04qCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..tjFtQyPSUVZqDCfOGaRkKXkYJg3aikm8DJZXNCOAdA9hkYtIWAXzQhqCVmyGkeXKDgCAZ3_GRHK88T5Di7hMAw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/MasterBillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/MasterBillOfLadingCertificate.yml
@@ -58,7 +58,7 @@ example: |-
       "name": "MULTI CONTAINER LINE",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
+        "name": "MCL Multi Container Line LTD.",
         "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
         "addressLocality": "Kowloon Bay",
         "addressRegion": "Hong Kong",
@@ -123,7 +123,7 @@ example: |-
         "name": "MULTI CONTAINER LINE",
         "address": {
           "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
+          "name": "MCL Multi Container Line LTD.",
           "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
           "addressLocality": "Kowloon Bay",
           "addressRegion": "Hong Kong",
@@ -224,9 +224,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-18T12:53:06Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..FhA8IH3biUgDOOVhPhmRQr-rTpepOGyhzNMby56_oz8I3qe0YRXj3B87rYmTnlIajMaDRM4IE1YT0uIXvsUYDw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..waNHTjZipfeGXJRZVP4TvAbWCYhGNgtPiTnIPBalRPAKOzJsdrrQPMQbiOiNz5ahm2x_fh4JwB7V5U_sWmlHBw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/MillTestReportCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCertificate.yml
@@ -527,9 +527,9 @@ example: |-
     "issuanceDate": "2022-06-06T08:10:00+00:00",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-01T12:29:23Z",
+      "created": "2022-08-17T14:41:38Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..RFGP-66E0ve1D9wgBXQfYC5W5uXNh2gCuXNQFh7xDlhNxaAksWBdEmUPqEHSUL040q0xj84aIwFb7LFmsdUFDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..-T1eefjQRw-Y4jOd95Rnvvtoj_twznoOGznuHehuozv0Xbcv1aeNkUiblfv86Jc74xI9iZhYwpbPDmkGA3IHDg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCertificate.yml
@@ -56,7 +56,7 @@ example: |-
       "name": "MULTI CONTAINER LINE",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
+        "name": "MCL Multi Container Line LTD.",
         "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
         "addressLocality": "Kowloon Bay",
         "addressRegion": "Hong Kong",
@@ -121,7 +121,7 @@ example: |-
         "name": "MULTI CONTAINER LINE",
         "address": {
           "type": "PostalAddress",
-          "organizationName": "MCL Multi Container Line LTD.",
+          "name": "MCL Multi Container Line LTD.",
           "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
           "addressLocality": "Kowloon Bay",
           "addressRegion": "Hong Kong",
@@ -222,9 +222,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-18T12:53:06Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..e2w8sQwQNf6FHByftFl-77fr97GqYdtg-3jaCvUsMd3i32e8MYdPUS9ihQymgQ3ppctRH64nV9oGUnvGwZBNCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..4q8NgVJfXD31WmMBK1HOqu02g-09p-zMR9eRd7JXmrXPgGZFxZMYPce4lCsh6t5nIg8kxLtD8qhTNANxCIDwDw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/NaturalGasProductCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/NaturalGasProductCertificate.yml
@@ -58,7 +58,7 @@ example: |-
         },
         "address": {
           "type": "PostalAddress",
-          "organizationName": "Schneider - Bernier",
+          "name": "Schneider - Bernier",
           "streetAddress": "012 Cecil Keys",
           "addressLocality": "Gaylordhaven",
           "addressRegion": "Indiana",
@@ -126,9 +126,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-06-22T08:47:24Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..8tUgbnb5plcS5JvYSjrpEIHLFlyU2fp0UL8gPbK-zecdVttxVP9RXvPbg8E1FigRjXhjuP6YOijoFyfMVC0fCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..M-B_VElRSEpF3MR2TANurWD5thQzYLVX-gPAOUT837Z3JEY2MUvt_zvJ7WO6qTUOSgxVcBI04jFaP4no0f9NBg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/PGAShipmentStatusCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/PGAShipmentStatusCertificate.yml
@@ -120,9 +120,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-29T15:01:49Z",
+      "created": "2022-08-17T14:41:36Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..mBlPbmbTwfM_c3Aq_DOCwGiNB_VO5TpznyOKqP1M0wfaI4yH45ZFEEzC5QwoQGvqA7m1Hv7BZ_6wPogF3MSEBQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..QaSKiaDzlN2Dil4lFoJIqlIeLXGtQ_hTQTr1rQdyTM7lr3-_0ESaPIP2h267KJB1qAGuumcx097nuBoFG_4CCQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/PackingListCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/PackingListCertificate.yml
@@ -305,9 +305,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-03T11:57:23Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..RAl9MiUkVh_fRKrpADRDgv4spnLotIQ5qABKNDl1IFKUDTY7Pp1Rn2XPUKGf2MIgrL8q_cjiwwg1YhYYuFXhCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..iV07PE-pjOoioznYDV7QBlsJwJNVJbm_0jquZT10dJM8tbWJjBl4n7s8_sOM3W7VEj4img0sOgHV761b3YgMAQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/ProformaInvoiceCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/ProformaInvoiceCertificate.yml
@@ -67,7 +67,7 @@ example: |-
         "type": [
           "PostalAddress"
         ],
-        "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+        "name": "Aishi Metal Shinzo Co., Ltd.",
         "streetAddress": "1651, Shimonakano, Yoshida",
         "addressLocality": "Tsubame-shi",
         "addressRegion": "Niigata-ken",
@@ -96,7 +96,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+          "name": "Aishi Metal Shinzo Co., Ltd.",
           "streetAddress": "1651, Shimonakano, Yoshida",
           "addressLocality": "Tsubame-shi",
           "addressRegion": "Niigata-ken",
@@ -112,7 +112,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Generic Motors of America",
+          "name": "Generic Motors of America",
           "streetAddress": "12 Generic Motors Dr",
           "addressLocality": "Detroit",
           "addressRegion": "Michigain",
@@ -128,7 +128,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Generic Motors of America",
+          "name": "Generic Motors of America",
           "streetAddress": "12 Generic Motors Dr",
           "addressLocality": "Detroit",
           "addressRegion": "Michigain",
@@ -156,7 +156,7 @@ example: |-
                 ],
                 "address": {
                   "type": "PostalAddress",
-                  "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+                  "name": "Aishi Metal Shinzo Co., Ltd.",
                   "streetAddress": "1651, Shimonakano, Yoshida",
                   "addressLocality": "Tsubame-shi",
                   "addressRegion": "Niigata-ken",
@@ -210,7 +210,7 @@ example: |-
                   "type": [
                     "PostalAddress"
                   ],
-                  "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+                  "name": "Aishi Metal Shinzo Co., Ltd.",
                   "streetAddress": "1651, Shimonakano, Yoshida",
                   "addressLocality": "Tsubame-shi",
                   "addressRegion": "Niigata-ken",
@@ -263,9 +263,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-29T13:49:05Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xJvlfl-f0i5LNpJ8S8GLg1W5YIljGg2JNm-LhtjO_-MbBxYmUANMH7qv4aEdbI01uxErFvAd_TpsV_y93kriCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..eNUeyvVOSVVaQML_0hoQGjkGtBTSAQIt0N-DZ1JKbgGqutsab27ue7lYwbP5jRtXDLY9T3ixaUJF-vbO2pQSAA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/PurchaseOrderCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/PurchaseOrderCertificate.yml
@@ -109,7 +109,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+          "name": "Aishi Metal Shinzo Co., Ltd.",
           "streetAddress": "1651, Shimonakano, Yoshida",
           "addressLocality": "Tsubame-shi",
           "addressRegion": "Niigata-ken",
@@ -125,7 +125,7 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "organizationName": "Generic Motors of America",
+          "name": "Generic Motors of America",
           "streetAddress": "12 Generic Motors Dr",
           "addressLocality": "Detroit",
           "addressRegion": "Michigain",
@@ -151,7 +151,7 @@ example: |-
                 "type": [
                   "PostalAddress"
                 ],
-                "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+                "name": "Aishi Metal Shinzo Co., Ltd.",
                 "streetAddress": "1651, Shimonakano, Yoshida",
                 "addressLocality": "Tsubame-shi",
                 "addressRegion": "Niigata-ken",
@@ -201,7 +201,7 @@ example: |-
                 "type": [
                   "PostalAddress"
                 ],
-                "organizationName": "Aishi Metal Shinzo Co., Ltd.",
+                "name": "Aishi Metal Shinzo Co., Ltd.",
                 "streetAddress": "1651, Shimonakano, Yoshida",
                 "addressLocality": "Tsubame-shi",
                 "addressRegion": "Niigata-ken",
@@ -252,9 +252,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-03T12:00:26Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..hW6p4iAJpElTsA2b6WO47VRpeaXTyP6EkKv7LMZLxsoTib7mRuX9g-ODZEiXeJKLsDQWbqRYnhL_EdxG7eg4Dg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wvlDLtE9BGbDX9vJ8qE_ZZbGxeVMioZ1VEysMsndcqIm0ndojd55YbmJ5b_74ZAr6jpe5drbqEaIpsS8e7rZDg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCertificate.yml
@@ -55,12 +55,16 @@ example: |-
       "SIMASteelImportLicenseApplicationCertificate"
     ],
     "issuer": {
-      "type": ["Organization"],
+      "type": [
+        "Organization"
+      ],
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "name": "Maxi Acero Mexicano",
       "description": "Fusión y fabricación de acero sólido",
       "address": {
-        "type": ["PostalAddress"],
+        "type": [
+          "PostalAddress"
+        ],
         "streetAddress": "Avenida Carlos 100",
         "addressLocality": "Hernádez de Mara",
         "addressRegion": "Nuevo Leon",
@@ -72,13 +76,19 @@ example: |-
     },
     "issuanceDate": "2022-02-28T11:23:00Z",
     "credentialSubject": {
-      "type": ["SIMASteelImportLicense"],
+      "type": [
+        "SIMASteelImportLicense"
+      ],
       "applicantCompany": {
-        "type": ["Organization"],
+        "type": [
+          "Organization"
+        ],
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
         "address": {
-          "type": ["PostalAddress"],
+          "type": [
+            "PostalAddress"
+          ],
           "streetAddress": "Avenida Carlos 100",
           "addressLocality": "Hernádez de Mara",
           "addressRegion": "Nuevo Leon",
@@ -90,11 +100,15 @@ example: |-
       },
       "customsEntryNumber": 34001239,
       "importer": {
-        "type": ["Organization"],
+        "type": [
+          "Organization"
+        ],
         "name": "American Prime Steel Inc.",
         "description": "Quality Steel since 1952",
         "address": {
-          "type": ["PostalAddress"],
+          "type": [
+            "PostalAddress"
+          ],
           "streetAddress": "1551 Keebler Knoll",
           "addressLocality": "Vivianeburgh",
           "addressRegion": "Oregon",
@@ -105,11 +119,15 @@ example: |-
         "phoneNumber": "555-716-2400"
       },
       "exporter": {
-        "type": ["Organization"],
+        "type": [
+          "Organization"
+        ],
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
         "address": {
-          "type": ["PostalAddress"],
+          "type": [
+            "PostalAddress"
+          ],
           "streetAddress": "Avenida Carlos 100",
           "addressLocality": "Hernádez de Mara",
           "addressRegion": "Nuevo Leon",
@@ -120,11 +138,15 @@ example: |-
         "phoneNumber": "555-127-7813"
       },
       "manufacturer": {
-        "type": ["Organization"],
+        "type": [
+          "Organization"
+        ],
         "name": "Maxi Acero Mexicano",
         "description": "Fusión y fabricación de acero sólido",
         "address": {
-          "type": ["PostalAddress"],
+          "type": [
+            "PostalAddress"
+          ],
           "streetAddress": "Avenida Carlos 100",
           "addressLocality": "Hernádez de Mara",
           "addressRegion": "Nuevo Leon",
@@ -146,15 +168,21 @@ example: |-
             "SIMASteelImportProductSpecifier"
           ],
           "steelProduct": {
-            "type": ["SteelProduct"],
+            "type": [
+              "SteelProduct"
+            ],
             "heatNumber": "841",
             "specification": "ASTM-66272",
-            "grade": ["95913"],
+            "grade": [
+              "95913"
+            ],
             "originalCountryOfMeltAndPour": "MX",
             "weight": 3200,
             "weightUnit": "https://service.unece.org/trade/uncefact/vocabulary/rec20/#kilogram",
             "commodity": {
-              "type": ["Commodity"],
+              "type": [
+                "Commodity"
+              ],
               "commodityCode": "721320",
               "commodityCodeType": "HS",
               "description": "Steel Coils"
@@ -166,9 +194,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-06-22T08:47:24Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..w5AiWoXWcP4r5Y_3fGzpOTe9abCxmxURsvbxy-W6Eo--P89r2uYnfMqo2XWOo9kBTR9P-m3i37uZHV7Tuk46BQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..odb7sC-bJ5qyX9-W3rNOFV_nJw0Fv1--zDW2hNHN27KEPEj3m2E-uLvxFM-6vXzApmvi0v2jLj8u0Gw6KtBfDQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCertificate.yml
@@ -212,9 +212,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-28T15:31:06Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..LAETw7_VXF33S8C_UR1WeXdbUhGMY3yGYiqVWtR97vFGGFOvuVzbL4_Tp9B5wqGg0Utsfgx9qHAvcJIQMYMWDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fsbZ8pZITslWB09uo6hiUN4A2h7UEpoa_54tiWQkodvWXnW_VZfepek0r-JWzroUTNF1Un3-a8HOp687FvMJDg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/SeaCargoManifestCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/SeaCargoManifestCertificate.yml
@@ -55,7 +55,7 @@ example: |-
       "name": "MULTI CONTAINER LINE",
       "address": {
         "type": "PostalAddress",
-        "organizationName": "MCL Multi Container Line LTD.",
+        "name": "MCL Multi Container Line LTD.",
         "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
         "addressLocality": "Kowloon Bay",
         "addressRegion": "Hong Kong",
@@ -146,7 +146,7 @@ example: |-
             "name": "MULTI CONTAINER LINE",
             "address": {
               "type": "PostalAddress",
-              "organizationName": "MCL Multi Container Line LTD.",
+              "name": "MCL Multi Container Line LTD.",
               "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
               "addressLocality": "Kowloon Bay",
               "addressRegion": "Hong Kong",
@@ -382,7 +382,7 @@ example: |-
               "name": "MULTI CONTAINER LINE",
               "address": {
                 "type": "PostalAddress",
-                "organizationName": "MCL Multi Container Line LTD.",
+                "name": "MCL Multi Container Line LTD.",
                 "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
                 "addressLocality": "Kowloon Bay",
                 "addressRegion": "Hong Kong",
@@ -397,9 +397,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-18T12:53:07Z",
+      "created": "2022-08-17T14:41:38Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..S2-MWcMyotijnPAXtjHPhWNsrK-irNjQ5FwZ8q6UIw2ISUHsEf8gh35_G-FgssWzaLD6d3t7SNcqOR3p4UE5Dw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..meBp68meqRPkwj9CoW4DaHkcZ4urDT_hrcSy988TBcFnOG3tAkfK6ptDbp-tks-aNZgPB-rzHYhdPl4S7zZXBg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/ShippingInstructionsCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/ShippingInstructionsCertificate.yml
@@ -239,9 +239,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-03T12:06:18Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..UWM5gmIY1lZo1r4RxJfmVDaNq4-Se4UWD1-aeaSlNqCJhrtMvkzUS5OHDh1AGsFmUGbY2jdK4yj0selPu5toAQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..mAfr3PzmbPuHDQjxIk1Dl53MnazNarPvIVXX5cUgavY2T0Eb8SRZkrJMygHEsTReMuwWOkQjBF3n1b0LGXWtDQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/SoftwareBillOfMaterialsCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/SoftwareBillOfMaterialsCertificate.yml
@@ -166,9 +166,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-05-05T08:59:26Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..c9KCS0Ln0lWya862dZgkah4_C7lVmogiD5dv2CNA315_1_V65_mIt3FJfFh5iy37n0Mao_hnvBXml3aewbknDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..vUj1FhKMjuCCMbMQl0plrdr5z3XzquetAY8yoUsYGPZLk01uhCSeQyVRCEdxU2a1fSJ_Qmx6zaexXIleVZM_Bw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
@@ -285,9 +285,9 @@ example: |-
     "blanketPeriodTo": "2022-06-21",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-07-29T13:06:47Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..N9kc7zn89SPtzXKSVsj2mZ9VXKMQymhqn1Njlbw1R58rYAnPeGYIsWa-fl5Y0Ek1spBth3ERyvfbbeHUjuFhCA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..QWwwd30t3q-S1HbRlPYDzWDBDgdbH4cAJzPIeL2gAcxf2KasIWdmtkPApW0q63-4DSGwwA9q31QFOy6ptGeHBg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
@@ -117,9 +117,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-01T11:46:12Z",
+      "created": "2022-08-17T14:41:36Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BZWtXtKTTItbmpJsuEvg3qUDSpy9GvPWLld2x6rRvMkiwaPHrWPFqwK_OJET_ytx1cRJFLEi9kMTj56S4egyCw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..TkW5G-pBiYZqjVPlseLTZ5dUuXKsTwAOh05AMoxrgDFAPSNQekSBJoXijFCAG45XBsQXIurJ_t2TVu_e-7t3BQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
@@ -142,9 +142,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-04-18T14:26:33Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..CsPg24yEeCYiIHkbp1vnDLpqdF69jdrQiOUGf3o16ZrIjduI4W7qIfobhzt3hZ9t74prZPWP993UvgWqN23HAg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..-R6tBKPOuE0rSiHkDpswgl0DOxTmtEWpbKFHTUvd7hk5obcGadqAmQl5AjTNMUNwGk4i66B9sziG8NDfMCMyAg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
@@ -153,9 +153,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-04-18T14:25:07Z",
+      "created": "2022-08-17T14:41:37Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..hFEkceHTRFK73gaqrfXubu9dXiwJnKzTfIFxCqY0YA29QCNQ632dYEj_wTxTfxiqUddXpts1kQTO5GAtX_1QDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..1bzlSTV8Q14mP4JfQvs5kt9Oy9A12eBsBRMC1JxOdzHAZTtkg6VqJBkjDGwdC6W3shIF2f4BHc9k448O1EkiBQ"
     }
   }

--- a/docs/openapi/components/schemas/presentations/TraceablePresentation.yml
+++ b/docs/openapi/components/schemas/presentations/TraceablePresentation.yml
@@ -47,7 +47,7 @@ example: |-
           },
           "address":{
              "type":["PostalAddress"],
-             "organizationName":"Ratke - Bergstrom",
+             "name":"Ratke - Bergstrom",
              "streetAddress":"21851 Ima Heights",
              "addressLocality":"O'Connellborough",
              "addressRegion":"Missouri",

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -368,6 +368,102 @@ paths:
                 $ref: './components/schemas/common/ExternalResource.yml'
     
 
+  /schemas/common/FoodGradeInspection.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FoodGradeInspection.yml'
+    
+
+  /schemas/common/FoodGradeInspectionDefect.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FoodGradeInspectionDefect.yml'
+    
+
+  /schemas/common/FoodGradeInspectionLot.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FoodGradeInspectionLot.yml'
+    
+
+  /schemas/common/FoodGradeInspectionResult.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FoodGradeInspectionResult.yml'
+    
+
+  /schemas/common/FoodGradeInspectionSample.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FoodGradeInspectionSample.yml'
+    
+
+  /schemas/common/FoodGradeInspectionSampleProperty.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FoodGradeInspectionSampleProperty.yml'
+    
+
+  /schemas/common/ForeignChargeDeclaration.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/ForeignChargeDeclaration.yml'
+    
+
+  /schemas/common/FreightManifest.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FreightManifest.yml'
+    
+
   /schemas/common/FSMAAbstractKDE.yml:
     get:
       tags:
@@ -486,102 +582,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/FSMATransformingCTE.yml'
-    
-
-  /schemas/common/FoodGradeInspection.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FoodGradeInspection.yml'
-    
-
-  /schemas/common/FoodGradeInspectionDefect.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FoodGradeInspectionDefect.yml'
-    
-
-  /schemas/common/FoodGradeInspectionLot.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FoodGradeInspectionLot.yml'
-    
-
-  /schemas/common/FoodGradeInspectionResult.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FoodGradeInspectionResult.yml'
-    
-
-  /schemas/common/FoodGradeInspectionSample.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FoodGradeInspectionSample.yml'
-    
-
-  /schemas/common/FoodGradeInspectionSampleProperty.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FoodGradeInspectionSampleProperty.yml'
-    
-
-  /schemas/common/ForeignChargeDeclaration.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/ForeignChargeDeclaration.yml'
-    
-
-  /schemas/common/FreightManifest.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FreightManifest.yml'
     
 
   /schemas/common/GeoCoordinates.yml:
@@ -776,6 +776,18 @@ paths:
                 $ref: './components/schemas/common/IssuerAgent.yml'
     
 
+  /schemas/common/LegalEntityIdentifierCredential.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/LegalEntityIdentifierCredential.yml'
+    
+
   /schemas/common/LEIaddress.yml:
     get:
       tags:
@@ -834,18 +846,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/LEIregistration.yml'
-    
-
-  /schemas/common/LegalEntityIdentifierCredential.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/LegalEntityIdentifierCredential.yml'
     
 
   /schemas/common/LinkRole.yml:
@@ -1040,6 +1040,18 @@ paths:
                 $ref: './components/schemas/common/NaturalGasProduct.yml'
     
 
+  /schemas/common/Observation.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/Observation.yml'
+    
+
   /schemas/common/OGBillOfLading.yml:
     get:
       tags:
@@ -1052,7 +1064,7 @@ paths:
                 $ref: './components/schemas/common/OGBillOfLading.yml'
     
 
-  /schemas/common/Observation.yml:
+  /schemas/common/OrderedItem.yml:
     get:
       tags:
       - common
@@ -1061,7 +1073,7 @@ paths:
           content:
             application/yml:
               schema:
-                $ref: './components/schemas/common/Observation.yml'
+                $ref: './components/schemas/common/OrderedItem.yml'
     
 
   /schemas/common/OrderRegistrationCredential.yml:
@@ -1088,18 +1100,6 @@ paths:
                 $ref: './components/schemas/common/OrderRegistrationEvidenceDocument.yml'
     
 
-  /schemas/common/OrderedItem.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/OrderedItem.yml'
-    
-
   /schemas/common/Organization.yml:
     get:
       tags:
@@ -1110,30 +1110,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/Organization.yml'
-    
-
-  /schemas/common/PGAShipmentStatus.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/PGAShipmentStatus.yml'
-    
-
-  /schemas/common/PGAShipmentStatusList.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/PGAShipmentStatusList.yml'
     
 
   /schemas/common/Package.yml:
@@ -1244,6 +1220,30 @@ paths:
                 $ref: './components/schemas/common/Person.yml'
     
 
+  /schemas/common/PGAShipmentStatus.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/PGAShipmentStatus.yml'
+    
+
+  /schemas/common/PGAShipmentStatusList.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/PGAShipmentStatusList.yml'
+    
+
   /schemas/common/Phytosanitary.yml:
     get:
       tags:
@@ -1290,6 +1290,30 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/PostmanCollection.yml'
+    
+
+  /schemas/common/ppq203.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/ppq203.yml'
+    
+
+  /schemas/common/ppq587.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/ppq587.yml'
     
 
   /schemas/common/PriceSpecification.yml:
@@ -1412,30 +1436,6 @@ paths:
                 $ref: './components/schemas/common/RevocationList2020Status.yml'
     
 
-  /schemas/common/SIMASteelImportLicense.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/SIMASteelImportLicense.yml'
-    
-
-  /schemas/common/SIMASteelImportProductSpecifier.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/SIMASteelImportProductSpecifier.yml'
-    
-
   /schemas/common/Scorecard.yml:
     get:
       tags:
@@ -1506,6 +1506,30 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/ShippingStop.yml'
+    
+
+  /schemas/common/SIMASteelImportLicense.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/SIMASteelImportLicense.yml'
+    
+
+  /schemas/common/SIMASteelImportProductSpecifier.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/SIMASteelImportProductSpecifier.yml'
     
 
   /schemas/common/SoftwareBillOfMaterials.yml:
@@ -1652,6 +1676,18 @@ paths:
                 $ref: './components/schemas/common/TransportEvent.yml'
     
 
+  /schemas/common/UsdaSc6.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/UsdaSc6.yml'
+    
+
   /schemas/common/USMCACertifier.yml:
     get:
       tags:
@@ -1676,18 +1712,6 @@ paths:
                 $ref: './components/schemas/common/USMCAProductSpecifier.yml'
     
 
-  /schemas/common/UsdaSc6.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/UsdaSc6.yml'
-    
-
   /schemas/common/WayBillRegistrationCredential.yml:
     get:
       tags:
@@ -1710,30 +1734,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/Workflow.yml'
-    
-
-  /schemas/common/ppq203.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/ppq203.yml'
-    
-
-  /schemas/common/ppq587.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/ppq587.yml'
     
 
   /schemas/credentials/BillOfLadingCertificate.yml:
@@ -1772,18 +1772,6 @@ paths:
                 $ref: './components/schemas/credentials/CBP7501EntrySummaryCertificate.yml'
     
 
-  /schemas/credentials/CTPATCertificate.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/CTPATCertificate.yml'
-    
-
   /schemas/credentials/CertificationOfOrigin.yml:
     get:
       tags:
@@ -1820,6 +1808,18 @@ paths:
                 $ref: './components/schemas/credentials/CrudeOilProductCertificate.yml'
     
 
+  /schemas/credentials/CTPATCertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/CTPATCertificate.yml'
+    
+
   /schemas/credentials/DCSAShippingInstructionCertificate.yml:
     get:
       tags:
@@ -1854,6 +1854,30 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/DeMinimisShipmentCertificate.yml'
+    
+
+  /schemas/credentials/FoodGradeInspectionCertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FoodGradeInspectionCertificate.yml'
+    
+
+  /schemas/credentials/FreightManifestCertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FreightManifestCertificate.yml'
     
 
   /schemas/credentials/FSMACreatingCTECertificate.yml:
@@ -1926,30 +1950,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/FSMATransformingCTECertificate.yml'
-    
-
-  /schemas/credentials/FoodGradeInspectionCertificate.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/FoodGradeInspectionCertificate.yml'
-    
-
-  /schemas/credentials/FreightManifestCertificate.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/FreightManifestCertificate.yml'
     
 
   /schemas/credentials/HouseBillOfLadingCertificate.yml:
@@ -2048,18 +2048,6 @@ paths:
                 $ref: './components/schemas/credentials/NaturalGasProductCertificate.yml'
     
 
-  /schemas/credentials/PGAShipmentStatusCertificate.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/PGAShipmentStatusCertificate.yml'
-    
-
   /schemas/credentials/PackingListCertificate.yml:
     get:
       tags:
@@ -2070,6 +2058,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/PackingListCertificate.yml'
+    
+
+  /schemas/credentials/PGAShipmentStatusCertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/PGAShipmentStatusCertificate.yml'
     
 
   /schemas/credentials/ProformaInvoiceCertificate.yml:
@@ -2096,30 +2096,6 @@ paths:
                 $ref: './components/schemas/credentials/PurchaseOrderCertificate.yml'
     
 
-  /schemas/credentials/SIMASteelImportLicenseApplicationCertificate.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/SIMASteelImportLicenseApplicationCertificate.yml'
-    
-
-  /schemas/credentials/SIMASteelImportLicenseCertificate.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/SIMASteelImportLicenseCertificate.yml'
-    
-
   /schemas/credentials/SeaCargoManifestCertificate.yml:
     get:
       tags:
@@ -2142,6 +2118,30 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/ShippingInstructionsCertificate.yml'
+    
+
+  /schemas/credentials/SIMASteelImportLicenseApplicationCertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/SIMASteelImportLicenseApplicationCertificate.yml'
+    
+
+  /schemas/credentials/SIMASteelImportLicenseCertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/SIMASteelImportLicenseCertificate.yml'
     
 
   /schemas/credentials/SoftwareBillOfMaterialsCertificate.yml:


### PR DESCRIPTION
Change organizationName to name in the PostalAddress Object. The organizationName is not generic enough to represent all objects that use Postal Address object. They are not necessarely organizations as they can represent any entity. For example, Schema.org uses name inside the Postal Address schema.