### PR TITLE
CTPAT claims moved into credentialSubject

### DIFF
--- a/docs/openapi/components/schemas/common/CTPAT.yml
+++ b/docs/openapi/components/schemas/common/CTPAT.yml
@@ -1,0 +1,101 @@
+$linkedData:
+  term: CTPAT
+  '@id': https://w3id.org/traceability#CTPAT
+title: CTPAT
+description: CTPAT classification based on either WCO HS or USITS HTS codification.
+type: object
+properties:
+  type:
+    oneOf:
+      - type: array
+        items:
+          type: string
+          enum:
+            - CTPAT
+  ctpatMember:
+    title: CTPAT Member
+    description: CTPAT member organization.
+    $ref: ./Organization.yml
+    $linkedData:
+      term: ctparMember
+      '@id': https://schema.org/member
+  sviNumber:
+    title: SVI Number
+    description: >-
+      Status Verification Interface number.
+    type: string
+    $linkedData:
+      term: sviNumber
+      '@id': https://w3id.org/traceability#sviNumber
+  ctpatAccountNumber:
+    title: CTPAT Account Number
+    description: >-
+      CTPAT issued account number for certified entity.
+    type: string
+    $linkedData:
+      term: ctpatAccountNumber
+      '@id': https://w3id.org/traceability#ctpatAccountNumber
+  tradeSector:
+    title: CTPAT Trade Sector
+    description: >-
+      Trade sectors elegible for CTPAT certification.
+    enum:
+      - U.S. Importers
+      - Highway Carriers
+      - Foreign Manufacturers
+      - Consolidators
+      - Licensed U.S. Customs Brokers
+      - Mexican Long Haul Highway Carriers
+      - U.S. Exporters
+      - Third Party Logistics Providers
+      - Sea Carrier
+      - Marine Port Authority and Terminal Operators
+      - Foreign Based Marine Port Terminal Operators
+      - Air Carriers
+      - Rail Carriers
+    $linkedData:
+      term: tradeSector
+      '@id': https://schema.org/industry
+  dateOfLastValidation:
+    title: Date of Last Validation
+    description: >-
+      Date of last validation.
+    type: string
+    $linkedData:
+      term: dateOfLastValidation
+      '@id': https://schema.org/Date
+  issuingCountry:
+    title: Issuing Country
+    description: >-
+      Issuing country.
+    type: string
+    $linkedData:
+      term: issuingCountry
+      '@id': https://schema.org/addressCountry
+additionalProperties: false
+example: |-
+  {
+    "type": "CTPAT",
+    "ctpatMember": {
+      "type": [
+        "Organization"
+      ],
+      "id": "did:key:z6MkhfZ7sNYEJ8vFSpwJaeyN7zNUaTxS4TBxW3y6R9ZKRaQ4",
+      "name": "Trans-Atlantic Shipping Co. Ltd.",
+      "address": {
+        "type": [
+          "PostalAddress"
+        ],
+        "organizationName": "Trans-Atlantic Shipping Co. Ltd.",
+        "streetAddress": "82 Whitchurch Road",
+        "addressLocality": "Elsworth",
+        "postalCode": "CB3 8NW",
+        "addressCountry": "UK"
+      }
+    },
+    "sviNumber": "57118961",
+    "ctpatAccountNumber": "12008",
+    "tradeSector": "Sea Carrier",
+    "dateOfLastValidation": "2022-01-06T11:50:00Z",
+    "issuingCountry": "US"
+  }

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -43,64 +43,10 @@ properties:
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:
-    $ref: ../common/Organization.yml
+    $ref: ../common/CTPAT.yml
   proof:
     type: object
-  sviNumber:
-    title: SVI Number
-    description: >-
-      Status Verification Interface number.
-    type: string
-    $linkedData:
-      term: sviNumber
-      '@id': https://w3id.org/traceability#sviNumber
-  ctpatAccountNumber:
-    title: CTPAT Account Number
-    description: >-
-      CTPAT issued account number for certified entity.
-    type: string
-    $linkedData:
-      term: ctpatAccountNumber
-      '@id': https://w3id.org/traceability#ctpatAccountNumber
-  tradeSector:
-    title: CTPAT Trade Sector
-    description: >-
-      Trade sectors elegible for CTPAT certification.
-    enum:
-      - U.S. Importers
-      - Highway Carriers
-      - Foreign Manufacturers
-      - Consolidators
-      - Licensed U.S. Customs Brokers
-      - Mexican Long Haul Highway Carriers
-      - U.S. Exporters
-      - Third Party Logistics Providers
-      - Sea Carrier
-      - Marine Port Authority and Terminal Operators
-      - Foreign Based Marine Port Terminal Operators
-      - Air Carriers
-      - Rail Carriers
-    $linkedData:
-      term: tradeSector
-      '@id': https://schema.org/industry
-  dateOfLastValidation:
-    title: Date of Last Validation
-    description: >-
-      Date of last validation.
-    type: string
-    $linkedData:
-      term: dateOfLastValidation
-      '@id': https://schema.org/Date
-  issuingCountry:
-    title: Issuing Country
-    description: >-
-      Issuing country.
-    type: string
-    $linkedData:
-      term: issuingCountry
-      '@id': https://schema.org/addressCountry
-additionalProperties: true
-required: []
+additionalProperties: false
 example: |-
   {
     "type": [
@@ -123,32 +69,34 @@ example: |-
     },
     "issuanceDate": "2022-01-13T09:16:46Z",
     "credentialSubject": {
-      "type": [
-        "Organization"
-      ],
-      "id": "did:key:z6MkhfZ7sNYEJ8vFSpwJaeyN7zNUaTxS4TBxW3y6R9ZKRaQ4",
-      "name": "Trans-Atlantic Shipping Co. Ltd.",
-      "address": {
+      "ctpatMember": {
         "type": [
-          "PostalAddress"
+          "Organization"
         ],
-        "organizationName": "Trans-Atlantic Shipping Co. Ltd.",
-        "streetAddress": "82 Whitchurch Road",
-        "addressLocality": "Elsworth",
-        "postalCode": "CB3 8NW",
-        "addressCountry": "UK"
-      }
+        "id": "did:key:z6MkhfZ7sNYEJ8vFSpwJaeyN7zNUaTxS4TBxW3y6R9ZKRaQ4",
+        "name": "Trans-Atlantic Shipping Co. Ltd.",
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "organizationName": "Trans-Atlantic Shipping Co. Ltd.",
+          "streetAddress": "82 Whitchurch Road",
+          "addressLocality": "Elsworth",
+          "postalCode": "CB3 8NW",
+          "addressCountry": "UK"
+        }
+      },
+      "sviNumber": "57118961",
+      "ctpatAccountNumber": "12008",
+      "tradeSector": "Sea Carrier",
+      "dateOfLastValidation": "2022-01-06T11:50:00Z",
+      "issuingCountry": "US"
     },
-    "sviNumber": "57118961",
-    "ctpatAccountNumber": "12008",
-    "tradeSector": "Sea Carrier",
-    "dateOfLastValidation": "2022-01-06T11:50:00Z",
-    "issuingCountry": "US",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-01T15:05:08Z",
+      "created": "2022-08-16T10:02:41Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ssF9IW3w2ebfuIcbNeSsXCBoiY4hD1W-jxA4L8HGNZ6QGLFWKrleFauUeJXDo5fzqbNuR7pd6qSjJ7R4e_NiAg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..t5RUppe_hBhMTE_w9IY9Djw1uCsKy7MM5FDrezCzDAFE_kTZ1c-S0FY6StdjNLJPT5zHlpKsyHuJaMX_iuM_CQ"
     }
   }


### PR DESCRIPTION
This moves all CTPAT claims (sviNumber, tradeSector, etc) into the credentialSubject. 