### PR TITLE
Removing type oneOf (array or string)

### DIFF
--- a/docs/openapi/components/schemas/common/AdditionalProductCodeRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/common/AdditionalProductCodeRegistrationCredential.yml
@@ -7,14 +7,11 @@ description: Ecommerce Additional Product Code Registration Credential
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - AdditionalProductCodeRegistrationCredential
-      - type: string
-        const: AdditionalProductCodeRegistrationCredential
+    type: array
+    items:
+      type: string
+      enum:
+        - AdditionalProductCodeRegistrationCredential
   productVCid:
     title: productVCid
     description: Product VC ID of the registered product
@@ -51,7 +48,7 @@ required:
 additionalProperties: false
 example: |-
   {
-    "type": "AdditionalProductCodeRegistrationCredential",
+    "type": ["AdditionalProductCodeRegistrationCredential"],
     "productVCid": "https://vc.example.com/?queryID=7306f1f744a781480c521902a1a1dbf5f1d01e7ea21daf483e7668817e58597a",
     "addProductCode": 99746411868836,
     "addProductCodeType": "UPC",

--- a/docs/openapi/components/schemas/common/CargoItem.yml
+++ b/docs/openapi/components/schemas/common/CargoItem.yml
@@ -9,15 +9,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - CargoItem
-      - type: string
-        const:
-          - CargoItem 
+    type: array
+    items:
+      type: string
+      enum:
+        - CargoItem
   cargoLineItems:
     title: Cargo Line Item
     description: Identifies the specific details of packages within a cargo item.
@@ -92,7 +88,7 @@ properties:
         https://service.unece.org/trade/uncefact/vocabulary/uncefact/#packageTypeCode
 example: |-
   {
-    "type": "CargoItem",
+    "type": ["CargoItem"],
     "cargoLineItems": [{
       "type": "CargoLineItem",
       "cargoLineItemID": "3312591",

--- a/docs/openapi/components/schemas/common/CargoLineItem.yml
+++ b/docs/openapi/components/schemas/common/CargoLineItem.yml
@@ -6,15 +6,11 @@ description: Identifies the specific details of packages within a cargo item.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - CargoLineItem
-      - type: string
-        const:
-          - CargoLineItem 
+    type: array
+    items:
+      type: string
+      enum:
+        - CargoLineItem
   cargoLineItemID:
     title: cargoLineItemID
     description: >-
@@ -59,7 +55,7 @@ required:
   - shippingMarks
 example: |-
   {
-    "type": "CargoLineItem",
+    "type": ["CargoLineItem"],
     "cargoLineItemID": "3312591",
     "shippingMarks": "Premium break pads"
   }

--- a/docs/openapi/components/schemas/common/ChargeDeclaration.yml
+++ b/docs/openapi/components/schemas/common/ChargeDeclaration.yml
@@ -6,15 +6,11 @@ description: Charge Declaration definition based on IATA electronic Air Waybill.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ChargeDeclaration
-      - type: string
-        const:
-          - ChargeDeclaration 
+    type: array
+    items:
+      type: string
+      enum:
+        - ChargeDeclaration
   weightCharge:
     title: Weight Charge
     description: The weight/volume charge for air carriage. Box 24A and 24B.
@@ -63,7 +59,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "ChargeDeclaration",
+    "type": ["ChargeDeclaration"],
     "weightCharge": {
       "type": "chargeAndPaymentType",
       "chargeCollect": 822,

--- a/docs/openapi/components/schemas/common/ChemicalProperty.yml
+++ b/docs/openapi/components/schemas/common/ChemicalProperty.yml
@@ -8,15 +8,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ChemicalProperty
-      - type: string
-        const:
-          - ChemicalProperty 
+    type: array
+    items:
+      type: string
+      enum:
+        - ChemicalProperty
   identifier:
     title: Property Identifier
     description: Identifiers for a property.
@@ -77,7 +73,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "ChemicalProperty",
+    "type": ["ChemicalProperty"],
     "name": "Terbium",
     "formula": "Tb",
     "inchi": "InChI=1S/Tb",

--- a/docs/openapi/components/schemas/common/Commodity.yml
+++ b/docs/openapi/components/schemas/common/Commodity.yml
@@ -6,15 +6,11 @@ description: Commodity classification based on either WCO HS or USITS HTS codifi
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Commodity
-      - type: string
-        const:
-          - Commodity 
+    type: array
+    items:
+      type: string
+      enum:
+        - Commodity
   commodityCode:
     title: Commodity Code
     description: >-

--- a/docs/openapi/components/schemas/common/ConsignmentItem.yml
+++ b/docs/openapi/components/schemas/common/ConsignmentItem.yml
@@ -6,15 +6,11 @@ description: A separately identifiable collection of goods items to be transport
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ConsignmentItem
-      - type: string
-        const:
-          - ConsignmentItem 
+    type: array
+    items:
+      type: string
+      enum:
+        - ConsignmentItem
   marksAndNumbers: 
     title: Marks and Numbers
     description: Physical markings or labels on individual packages or transport units for shipping purposes.
@@ -80,7 +76,7 @@ properties:
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#manufacturerParty
 example: |-
   {
-    "type": "ConsignmentItem",
+    "type": ["ConsignmentItem"],
     "marksAndNumbers": "Espresso Italiano",
     "commodity": {
       "type": "Commodity",

--- a/docs/openapi/components/schemas/common/ConsignmentRatingDetail.yml
+++ b/docs/openapi/components/schemas/common/ConsignmentRatingDetail.yml
@@ -6,15 +6,11 @@ description: Consignment Rating Details, itemized consignment items of IATA Air 
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ConsignmentRatingDetail
-      - type: string
-        const:
-          - ConsignmentRatingDetail 
+    type: array
+    items:
+      type: string
+      enum:
+        - ConsignmentRatingDetail
   numberOfPieces:
     title: Number of Pieces and RCP
     description: The number of pieces for the applicable rating entry. Box 22A.
@@ -115,7 +111,7 @@ properties:
   additionalProperties: false
 example: |-
   {
-    "type": "ConsignmentRatingDetail",
+    "type": ["ConsignmentRatingDetail"],
     "numberOfPieces": 13,
     "grossWeight": 971,
     "grossWeightUnit": "Kg",

--- a/docs/openapi/components/schemas/common/Customer.yml
+++ b/docs/openapi/components/schemas/common/Customer.yml
@@ -12,15 +12,11 @@ required:
   - email
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Customer
-      - type: string
-        const:
-          - Customer 
+    type: array
+    items:
+      type: string
+      enum:
+        - Customer
   name:
     title: Name of the Customer
     type: string
@@ -51,7 +47,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "Customer",
+    "type": ["Customer"],
     "name": "Catharine Glover",
     "address": {
       "type": "PostalAddress",

--- a/docs/openapi/components/schemas/common/DCSAShippingInstruction.yml
+++ b/docs/openapi/components/schemas/common/DCSAShippingInstruction.yml
@@ -12,15 +12,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - DCSAShippingInstruction
-      - type: string
-        const:
-          - DCSAShippingInstruction 
+    type: array
+    items:
+      type: string
+      enum:
+        - DCSAShippingInstruction
   shippingInstructionID:
     title: Shipping Instruction ID
     description: >-
@@ -182,7 +178,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "DCSAShippingInstruction",
+    "type": ["DCSAShippingInstruction"],
     "carrierBookingReference": "XMANHR2102045",
     "transportDocumentType": "MBL",
     "shipper": {

--- a/docs/openapi/components/schemas/common/Entity.yml
+++ b/docs/openapi/components/schemas/common/Entity.yml
@@ -6,14 +6,11 @@ description: A person or organization
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Entity
-      - type: string
-        const: Entity
+    type: array
+    items:
+      type: string
+      enum:
+        - Entity
   entityType:
     description: The type of entity
     type: string
@@ -88,7 +85,7 @@ required:
 additionalProperties: true
 example: |-
   {
-    "type": "Entity",
+    "type": ["Entity"],
     "entityType" : "Person",
     "name" : "Kane Heller",
     "firstName": "Kane",

--- a/docs/openapi/components/schemas/common/Event.yml
+++ b/docs/openapi/components/schemas/common/Event.yml
@@ -6,15 +6,11 @@ description: An event such as a transformation, aggregation, commission, etc.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Event
-      - type: string
-        const:
-          - Event 
+    type: array
+    items:
+      type: string
+      enum:
+        - Event
   eventType:
     title: Event Type
     description: The Type of the Event.
@@ -65,7 +61,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "Event",
+    "type": ["Event"],
     "eventType": "commission",
     "eventId": "12345",
     "actor": [

--- a/docs/openapi/components/schemas/common/ForeignChargeDeclaration.yml
+++ b/docs/openapi/components/schemas/common/ForeignChargeDeclaration.yml
@@ -6,15 +6,11 @@ description: Foreign charge declaration definition based on IATA electronic Air 
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ForeignChargeDeclaration
-      - type: string
-        const:
-          - ForeignChargeDeclaration 
+    type: array
+    items:
+      type: string
+      enum:
+        - ForeignChargeDeclaration
   foreignCurrencyConvertionRate:
     title: Currency Conversion Rate
     description: >-

--- a/docs/openapi/components/schemas/common/FreightManifest.yml
+++ b/docs/openapi/components/schemas/common/FreightManifest.yml
@@ -6,15 +6,11 @@ description: Manifest documenting the cargo and freight of a vessel at time of a
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - FreightManifest
-      - type: string
-        const:
-          - FreightManifest 
+    type: array
+    items:
+      type: string
+      enum:
+        - FreightManifest
   carrier:
     title: Carrier
     description: >-
@@ -68,7 +64,7 @@ properties:
 additionalProperties: true
 example: |-
   {
-    "type": "FreightManifest",
+    "type": ["FreightManifest"],
     "carrier": {
       "type": "Entity",
       "name": "MULTI CONTAINER LINE",

--- a/docs/openapi/components/schemas/common/GeoCoordinates.yml
+++ b/docs/openapi/components/schemas/common/GeoCoordinates.yml
@@ -6,15 +6,11 @@ description: The geographic coordinates of a place or event.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - GeoCoordinates
-      - type: string
-        const:
-          - GeoCoordinates 
+    type: array
+    items:
+      type: string
+      enum:
+        - GeoCoordinates
   latitude:
     title: Latitude
     description: >-
@@ -39,7 +35,7 @@ required:
 additionalProperties: false
 example: |-
   {
-    "type": "GeoCoordinates",
+    "type": ["GeoCoordinates"],
     "latitude": "-80.5898",
     "longitude": "-13.4603"
   }

--- a/docs/openapi/components/schemas/common/HouseBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/HouseBillOfLading.yml
@@ -6,15 +6,11 @@ description: A separately identifiable collection of goods items to be transport
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - HouseBillOfLading
-      - type: string
-        const:
-          - HouseBillOfLading 
+    type: array
+    items:
+      type: string
+      enum:
+        - HouseBillOfLading
   billOfLadingNumber:
     title: Bill Of Lading Number
     description: >-
@@ -200,7 +196,7 @@ required:
 additionalProperties: false
 example: |-
   {
-    "type": "HouseBillOfLading",
+    "type": ["HouseBillOfLading"],
     "billOfLadingNumber": "FF873363210A",
     "bookingNumber": [
       "FF873363210"

--- a/docs/openapi/components/schemas/common/InspectionReport.yml
+++ b/docs/openapi/components/schemas/common/InspectionReport.yml
@@ -6,15 +6,11 @@ description: Series of observations
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - InspectionReport
-      - type: string
-        const:
-          - InspectionReport 
+    type: array
+    items:
+      type: string
+      enum:
+        - InspectionReport
   comment:
     title: Comment
     description: Comments, typically from users.
@@ -51,7 +47,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "InspectionReport",
+    "type": ["InspectionReport"],
     "inspectors": [ 
       {
         "type": "Person",

--- a/docs/openapi/components/schemas/common/Inspector.yml
+++ b/docs/openapi/components/schemas/common/Inspector.yml
@@ -6,15 +6,11 @@ description: Information on the person performing an inspection
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Inspector
-      - type: string
-        const:
-          - Inspector 
+    type: array
+    items:
+      type: string
+      enum:
+        - Inspector
   person:
     title: Person
     description: Person doing the inspection.
@@ -34,7 +30,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "Inspector",
+    "type": ["Inspector"],
     "person": {
       "type": "Person",
       "firstName": "Ilene",

--- a/docs/openapi/components/schemas/common/Instructions.yml
+++ b/docs/openapi/components/schemas/common/Instructions.yml
@@ -6,15 +6,11 @@ description: Information of an instructive or teaching nature that tells someone
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Instructions
-      - type: string
-        const:
-          - Instructions 
+    type: array
+    items:
+      type: string
+      enum:
+        - Instructions
   description:
     title: First Name
     description: A textual description.
@@ -25,6 +21,6 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "Instructions",
+    "type": ["Instructions"],
     "description": "Handle with care"
   }

--- a/docs/openapi/components/schemas/common/IntentToImport.yml
+++ b/docs/openapi/components/schemas/common/IntentToImport.yml
@@ -12,15 +12,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - IntentToImport
-      - type: string
-        const:
-          - IntentToImport 
+    type: array
+    items:
+      type: string
+      enum:
+        - IntentToImport
   exporter:
     title: Exporter
     description: >-
@@ -55,7 +51,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "IntentToImport",
+    "type": ["IntentToImport"],
     "exporter": {
       "type": "Organization",
       "name": "Maxi Acero Mexicano",

--- a/docs/openapi/components/schemas/common/Invoice.yml
+++ b/docs/openapi/components/schemas/common/Invoice.yml
@@ -6,12 +6,11 @@ description: A statement of the money due for goods or services; a bill.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Invoice
+    type: array
+    items:
+      type: string
+      enum:
+        - Invoice
   identifier:
     title: Property Identifier
     description: Identifiers for a property.

--- a/docs/openapi/components/schemas/common/InvoiceRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/common/InvoiceRegistrationCredential.yml
@@ -6,14 +6,11 @@ description: Ecommerce Invoice Registration Credential
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - InvoiceRegistrationCredential
-      - type: string
-        const: InvoiceRegistrationCredential
+    type: array
+    items:
+      type: string
+      enum:
+        - InvoiceRegistrationCredential
   invoiceID:
     title: invoiceID
     description: The seller specific Invoice number
@@ -52,7 +49,7 @@ required:
 additionalProperties: false
 example: |-
   {
-      "type": "InvoiceRegistrationCredential",
+      "type": ["InvoiceRegistrationCredential"],
       "invoiceID": "Invoice#490",
       "orderID": [],
       "productInOrder": [

--- a/docs/openapi/components/schemas/common/InvoiceRegistrationEvidenceDocument.yml
+++ b/docs/openapi/components/schemas/common/InvoiceRegistrationEvidenceDocument.yml
@@ -18,14 +18,11 @@ required:
   - referencesOrder
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - InvoiceRegistrationEvidenceDocument
-      - type: string
-        const: InvoiceRegistrationEvidenceDocument 
+    type: array
+    items:
+      type: string
+      enum:
+        - InvoiceRegistrationEvidenceDocument
   identifier:
     title: Identifier
     type: string
@@ -108,7 +105,7 @@ properties:
       '@id': https://schema.org/referencesOrder
 example: |-
   {
-    "type": "InvoiceRegistrationEvidenceDocument",
+    "type": ["InvoiceRegistrationEvidenceDocument"],
     "identifier": "Invoice#922",
     "description": "Invoice For Eva Oberbrunner for Order#112",
     "url": "http://maureen.info?queryid=Invoice#922",

--- a/docs/openapi/components/schemas/common/IssuerAgent.yml
+++ b/docs/openapi/components/schemas/common/IssuerAgent.yml
@@ -20,15 +20,11 @@ required:
   - amountInsurance
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - IssuerAgent
-      - type: string
-        const:
-          - IssuerAgent 
+    type: array
+    items:
+      type: string
+      enum:
+        - IssuerAgent
   issuerAgentOrg:
     title: IssuerAgentOrg
     $ref: ./Organization.yml
@@ -95,7 +91,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "IssuerAgent",
+    "type": ["IssuerAgent"],
     "issuerAgentOrg": {
       "type": "Organization",
       "name": "Lesch - Smith",

--- a/docs/openapi/components/schemas/common/LEIaddress.yml
+++ b/docs/openapi/components/schemas/common/LEIaddress.yml
@@ -12,14 +12,11 @@ required:
   - postalCode
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - LEIaddress
-      - type: string
-        const: LEIaddress
+    type: array
+    items:
+      type: string
+      enum:
+        - LEIaddress
   language:
     title: Language
     type: string
@@ -83,7 +80,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "LEIaddress",
+    "type": ["LEIaddress"],
     "language": "ru",
     "addressLines": [
       "Baumbach, O'Keefe and Feil",

--- a/docs/openapi/components/schemas/common/LEIauthority.yml
+++ b/docs/openapi/components/schemas/common/LEIauthority.yml
@@ -10,15 +10,11 @@ required:
   - validationAuthorityEntityID
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - LEIauthority
-      - type: string
-        const:
-          - LEIauthority 
+    type: array
+    items:
+      type: string
+      enum:
+        - LEIauthority
   validationAuthorityID:
     title: validationAuthorityID
     type: string
@@ -40,7 +36,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "LEIauthority",
+    "type": ["LEIauthority"],
     "validationAuthorityID": "RA000004",
     "otherValidationAuthorityID": "I9LWK4HR",
     "validationAuthorityEntityID": "IR6TTVJ948RGX9YQDM4V"

--- a/docs/openapi/components/schemas/common/LEIentity.yml
+++ b/docs/openapi/components/schemas/common/LEIentity.yml
@@ -22,14 +22,11 @@ required:
   - otherAddresses
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - LEIentity
-      - type: string
-        const: LEIentity
+    type: array
+    items:
+      type: string
+      enum:
+        - LEIentity
   legalName:
     title: Legalname
     type: string
@@ -135,7 +132,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "LEIentity",
+    "type": ["LEIentity"],
     "legalName": "Dicki Group",
     "legalNameLanguage": "cz",
     "otherNames": [

--- a/docs/openapi/components/schemas/common/LEIevidenceDocument.yml
+++ b/docs/openapi/components/schemas/common/LEIevidenceDocument.yml
@@ -11,14 +11,11 @@ required:
   - bic
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - LEIevidenceDocument
-      - type: string
-        const: LEIevidenceDocument
+    type: array
+    items:
+      type: string
+      enum:
+        - LEIevidenceDocument
   lei:
     title: Lei
     type: string
@@ -48,7 +45,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "LEIevidenceDocument",
+    "type": ["LEIevidenceDocument"],
     "lei": "1GS89XTLP3YKEINUGJM9",
     "entity": {
       "type": "LEIentity",

--- a/docs/openapi/components/schemas/common/LEIregistration.yml
+++ b/docs/openapi/components/schemas/common/LEIregistration.yml
@@ -14,15 +14,11 @@ required:
   - validationAuthority
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - LEIregistration
-      - type: string
-        const:
-          - LEIregistration 
+    type: array
+    items:
+      type: string
+      enum:
+        - LEIregistration
   initialRegistrationDate:
     title: Initialregistrationdate
     type: string
@@ -70,7 +66,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "LEIregistration",
+    "type": ["LEIregistration"],
     "initialRegistrationDate": "2020-01-01",
     "lastUpdateDate": "2020-01-01",
     "status": "CONFIRMED",

--- a/docs/openapi/components/schemas/common/LegalEntityIdentifierCredential.yml
+++ b/docs/openapi/components/schemas/common/LegalEntityIdentifierCredential.yml
@@ -8,15 +8,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - LegalEntityIdentifierCredential
-      - type: string
-        const:
-          - LegalEntityIdentifierCredential 
+    type: array
+    items:
+      type: string
+      enum:
+        - LegalEntityIdentifierCredential
   leiCode:
     title: leiCode
     description: >-
@@ -39,7 +35,7 @@ required:
 additionalProperties: false
 example: |-
   {
-    "type": "LegalEntityIdentifierCredential",
+    "type": ["LegalEntityIdentifierCredential"],
     "leiCode": "X1VP3GQ3TP91GVP4F446",
     "certificateName": "US Legal Entity Certificate"
   }

--- a/docs/openapi/components/schemas/common/LinkRole.yml
+++ b/docs/openapi/components/schemas/common/LinkRole.yml
@@ -6,15 +6,11 @@ description: A Role that represents a Web link e.g. as expressed via the 'url' p
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - LinkRole
-      - type: string
-        const:
-          - LinkRole 
+    type: array
+    items:
+      type: string
+      enum:
+        - LinkRole
   target:
     title: Target
     description: An entry point, within some Web-based protocol.
@@ -32,7 +28,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "LinkRole",
+    "type": ["LinkRole"],
     "target": "https://example.com/related/link/123",
     "linkRelationship": "alternate"
   }

--- a/docs/openapi/components/schemas/common/MapResource.yml
+++ b/docs/openapi/components/schemas/common/MapResource.yml
@@ -6,14 +6,11 @@ description: Map resource in the form of an external reference or included data.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - MapResource
-      - type: string
-        const: MapResource
+    type: array
+    items:
+      type: string
+      enum:
+        - MapResource
   resourceType:
     description: The type of resource.
     type: string
@@ -40,7 +37,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "MapResource",
+    "type": ["MapResource"],
     "resourceType": "External",
     "external": {
       "type": "ExternalResource",

--- a/docs/openapi/components/schemas/common/MasterBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MasterBillOfLading.yml
@@ -6,15 +6,11 @@ description: A separately identifiable collection of goods items to be transport
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - MasterBillOfLading
-      - type: string
-        const:
-          - MasterBillOfLading
+    type: array
+    items:
+      type: string
+      enum:
+        - MasterBillOfLading
   billOfLadingNumber:
     title: Bill Of Lading Number
     description: >-
@@ -217,7 +213,7 @@ required:
 additionalProperties: false
 example: |-
   {
-    "type": "MasterBillOfLading",
+    "type": ["MasterBillOfLading"],
     "billOfLadingNumber": "EX600822199A",
     "bookingNumber": [
       "EX600822199"

--- a/docs/openapi/components/schemas/common/MeasuredValue.yml
+++ b/docs/openapi/components/schemas/common/MeasuredValue.yml
@@ -6,15 +6,11 @@ description: The measurement of an Observation.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - MeasuredValue
-      - type: string
-        const:
-          - MeasuredValue
+    type: array
+    items:
+      type: string
+      enum:
+        - MeasuredValue
   value:
     title: Measurement Value
     description: >-

--- a/docs/openapi/components/schemas/common/MechanicalProperty.yml
+++ b/docs/openapi/components/schemas/common/MechanicalProperty.yml
@@ -8,15 +8,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - MechanicalProperty
-      - type: string
-        const:
-          - MechanicalProperty
+    type: array
+    items:
+      type: string
+      enum:
+        - MechanicalProperty
   identifier:
     title: Property Identifier
     description: Identifiers for a property.

--- a/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
@@ -6,15 +6,11 @@ description: A separately identifiable collection of goods items to be transport
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - MultiModalBillOfLading
-      - type: string
-        const:
-          - MultiModalBillOfLading
+    type: array
+    items:
+      type: string
+      enum:
+        - MultiModalBillOfLading
   billOfLadingNumber:
     title: Bill Of Lading Number
     description: >-
@@ -217,7 +213,7 @@ required:
 additionalProperties: false
 example: |-
   {
-    "type": "MultiModalBillOfLading",
+    "type": ["MultiModalBillOfLading"],
     "billOfLadingNumber": "EX600822199A",
     "bookingNumber": [
       "EX600822199"

--- a/docs/openapi/components/schemas/common/Observation.yml
+++ b/docs/openapi/components/schemas/common/Observation.yml
@@ -8,15 +8,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Observation
-      - type: string
-        const:
-          - Observation
+    type: array
+    items:
+      type: string
+      enum:
+        - Observation
   property:
     title: Measured Property
     description: The property of an Observation.
@@ -41,7 +37,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "Observation",
+    "type": ["Observation"],
     "date": "2019-12-11T03:50:55Z",
     "property": {
       "type": "ChemicalProperty",

--- a/docs/openapi/components/schemas/common/OrderRegistrationEvidenceDocument.yml
+++ b/docs/openapi/components/schemas/common/OrderRegistrationEvidenceDocument.yml
@@ -18,14 +18,11 @@ required:
   - orderedItem
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - OrderRegistrationEvidenceDocument
-      - type: string
-        const: OrderRegistrationEvidenceDocument
+    type: array
+    items:
+      type: string
+      enum:
+        - OrderRegistrationEvidenceDocument
   orderNumber:
     title: Number for eCommerce Order
     type: string
@@ -104,7 +101,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "OrderRegistrationEvidenceDocument",
+    "type": ["OrderRegistrationEvidenceDocument"],
     "orderNumber": "Order#538",
     "orderDate": "2020-01-07",
     "orderStatus": "OrderPaymentDue",

--- a/docs/openapi/components/schemas/common/OrderedItem.yml
+++ b/docs/openapi/components/schemas/common/OrderedItem.yml
@@ -11,15 +11,11 @@ required:
   - orderQuantity
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - OrderedItem
-      - type: string
-        const:
-          - OrderedItem
+    type: array
+    items:
+      type: string
+      enum:
+        - OrderedItem
   name:
     title: Name
     type: string
@@ -58,7 +54,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "OrderedItem",
+    "type": ["OrderedItem"],
     "name": "ACME Laptop 3000",
     "productID": "https://vc.example.com/?queryID=7306f1f744a781480c521902a1a1dbf5f1d01e7ea21daf483e7668817e58599e",
     "unitPrice": 0,

--- a/docs/openapi/components/schemas/common/Organization.yml
+++ b/docs/openapi/components/schemas/common/Organization.yml
@@ -6,14 +6,11 @@ description: An organization such as a corporation, firm, club, etc.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Organization
-      - type: string
-        const: Organization 
+    type: array
+    items:
+      type: string
+      enum:
+        - Organization
   name:
     title: Name
     description: Name of the organization.
@@ -128,7 +125,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "Organization",
+    "type": ["Organization"],
     "name": "Glover - Gleason",
     "legalName": "Glover and Gleason, Llc.",
     "description": "Customs Brokering since 2012",

--- a/docs/openapi/components/schemas/common/Package.yml
+++ b/docs/openapi/components/schemas/common/Package.yml
@@ -8,15 +8,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Package
-      - type: string
-        const:
-          - Package
+    type: array
+    items:
+      type: string
+      enum:
+        - Package
   physicalShippingMarks:
     title: Physical Shipping Marks
     description: >-
@@ -93,7 +89,7 @@ properties:
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#grossVolumeMeasure
 example: |-
   {
-    "type": "Package",
+    "type": ["Package"],
     "physicalShippingMarks": "by ACRE AGE IS THE NEW BLACK",
     "perPackageUnitQuantity": 1,
     "includedTradeLineItems": [

--- a/docs/openapi/components/schemas/common/PackageItem.yml
+++ b/docs/openapi/components/schemas/common/PackageItem.yml
@@ -11,14 +11,11 @@ required:
   - productInOrder
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - PackageItem
-      - type: string
-        const: PackageItem 
+    type: array
+    items:
+      type: string
+      enum:
+        - PackageItem
   productReceiptID:
     title: productReceiptID
     description: >-
@@ -54,7 +51,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "PackageItem",
+    "type": ["PackageItem"],
     "productReceiptID": "https://vc.example.com/?queryID=0xF74adE972a00d1B5C0adB9ecf3a6deBF81BDdc3c0b71c1Cd27BEC833CfF6fbBf",
     "packingListID": "https://vc.example.com/?queryID=0xFDdB6eCedEc650A514Ee7d2d900Af7DeCc2722B2ECaEae72D8eA6B62D00f77c5",
     "orderID": "https://vc.example.com/?queryID=AB06f1f744a781480c521902a1a1dbf5f1d01e7ea21daf483e7668817e58597a",

--- a/docs/openapi/components/schemas/common/PackageRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/common/PackageRegistrationCredential.yml
@@ -10,14 +10,11 @@ required:
   - certificateName
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - PackageRegistrationCredential
-      - type: string
-        const: PackageRegistrationCredential 
+    type: array
+    items:
+      type: string
+      enum:
+        - PackageRegistrationCredential
   trackingID:
     title: Tracking Number of the Carrier
     type: string
@@ -43,7 +40,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "PackageRegistrationCredential",
+    "type": ["PackageRegistrationCredential"],
     "trackingID": "662796962028",
     "packageItems": [
       {

--- a/docs/openapi/components/schemas/common/PackingListItem.yml
+++ b/docs/openapi/components/schemas/common/PackingListItem.yml
@@ -9,14 +9,11 @@ required:
   - productInOrder
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - PackingListItem
-      - type: string
-        const: PackingListItem 
+    type: array
+    items:
+      type: string
+      enum:
+        - PackingListItem
   orderID:
     title: orderID
     description: The seller specific Order VC ID
@@ -36,7 +33,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "PackingListItem",
+    "type": ["PackingListItem"],
     "orderID": "https://vc.example.com/?queryID=AB06f1f744a781480c521902a1a1dbf5f1d01e7ea21daf483e7668817e58597a",
     "productInOrder": [
       "https://vc.example.com/?queryID=7306f1f744a781480c521902a1a1dbf5f1d01e7ea21daf483e7668817e58598a",

--- a/docs/openapi/components/schemas/common/PackingListRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/common/PackingListRegistrationCredential.yml
@@ -6,14 +6,11 @@ description: Ecommerce Packing List Registration Credential
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - PackingListRegistrationCredential
-      - type: string
-        const: PackingListRegistrationCredential
+    type: array
+    items:
+      type: string
+      enum:
+        - PackingListRegistrationCredential
   packageItems:
     title: packageItems
     type: array
@@ -36,7 +33,7 @@ required:
 additionalProperties: false
 example: |-
   {
-    "type": "PackingListRegistrationCredential",
+    "type": ["PackingListRegistrationCredential"],
     "packageItems": [
       {
         "type": "PackingListItem",

--- a/docs/openapi/components/schemas/common/PartOfOrder.yml
+++ b/docs/openapi/components/schemas/common/PartOfOrder.yml
@@ -9,15 +9,11 @@ type: object
 required: []
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - PartOfOrder
-      - type: string
-        const:
-          - PartOfOrder
+    type: array
+    items:
+      type: string
+      enum:
+        - PartOfOrder
   manufacturer:
     title: Manufacturer
     $ref: ./Organization.yml
@@ -81,7 +77,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "PartOfOrder",
+    "type": ["PartOfOrder"],
     "packageQuantity": 540,
     "transportPackages": [
       {

--- a/docs/openapi/components/schemas/common/Person.yml
+++ b/docs/openapi/components/schemas/common/Person.yml
@@ -6,15 +6,11 @@ description: A person
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Person
-      - type: string
-        const:
-          - Person 
+    type: array
+    items:
+      type: string
+      enum:
+        - Person
   firstName:
     title: First Name
     description: Person's first name.
@@ -69,7 +65,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "Person",
+    "type": ["Person"],
     "firstName": "Amelie",
     "lastName": "Pfeffer",
     "email": "Felton_Hauck15@example.com",

--- a/docs/openapi/components/schemas/common/Place.yml
+++ b/docs/openapi/components/schemas/common/Place.yml
@@ -6,15 +6,11 @@ description: Entities that have a somewhat fixed, physical location.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Place
-      - type: string
-        const:
-          - Place
+    type: array
+    items:
+      type: string
+      enum:
+        - Place
   globalLocationNumber:
     title: Global Location Number (GLN)
     description: >-
@@ -67,7 +63,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "Place",
+    "type": ["Place"],
     "globalLocationNumber": "7472903507697",
     "geo": {
       "type": "GeoCoordinates",

--- a/docs/openapi/components/schemas/common/PostalAddress.yml
+++ b/docs/openapi/components/schemas/common/PostalAddress.yml
@@ -8,15 +8,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - PostalAddress
-      - type: string
-        const:
-          - PostalAddress   
+    type: array
+    items:
+      type: string
+      enum:
+        - PostalAddress
   organizationName:
     title: Organization Name
     description: The name of the organization expressed in text.
@@ -97,7 +93,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "PostalAddress",
+    "type": ["PostalAddress"],
     "organizationName": "Lebsack Inc",
     "streetAddress": "758 Huel Neck",
     "addressLocality": "Hagenesstad",

--- a/docs/openapi/components/schemas/common/PriceSpecification.yml
+++ b/docs/openapi/components/schemas/common/PriceSpecification.yml
@@ -6,15 +6,11 @@ description: A structured value representing a price or price range.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - PriceSpecification
-      - type: string
-        const:
-          - PriceSpecification
+    type: array
+    items:
+      type: string
+      enum:
+        - PriceSpecification
   price:
     title: Price
     description: >-

--- a/docs/openapi/components/schemas/common/Product.yml
+++ b/docs/openapi/components/schemas/common/Product.yml
@@ -6,15 +6,11 @@ description: A product
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Product
-      - type: string
-        const:
-          - Product
+    type: array
+    items:
+      type: string
+      enum:
+        - Product
   productID:
     title: Product ID
     description: Product number of registering Legal Entity such as an ISBN
@@ -122,7 +118,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "Product",
+    "type": ["Product"],
     "manufacturer": {
       "type": "Organization",
       "name": "Lawson Weber",

--- a/docs/openapi/components/schemas/common/Purchase.yml
+++ b/docs/openapi/components/schemas/common/Purchase.yml
@@ -6,14 +6,11 @@ description: A purchase of a Product
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Purchase
-      - type: string
-        const: Purchase
+    type: array
+    items:
+      type: string
+      enum:
+        - Purchase
   customer:
     title: Customer
     description: The buying party of a purchase

--- a/docs/openapi/components/schemas/common/Qualification.yml
+++ b/docs/openapi/components/schemas/common/Qualification.yml
@@ -6,15 +6,11 @@ description: Skills, certifications, etc., required to perform a job properly.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Qualification
-      - type: string
-        const:
-          - Qualification
+    type: array
+    items:
+      type: string
+      enum:
+        - Qualification
   qualificationCategory:
     title: Qualification Category
     description: The type of qualification, credential, or certification the person has.
@@ -34,7 +30,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "Qualification",
+    "type": ["Qualification"],
     "qualificationCategory": "National Directives Engineer",
     "qualificationValue": "Consultant"
   }

--- a/docs/openapi/components/schemas/common/QuantitativeValue.yml
+++ b/docs/openapi/components/schemas/common/QuantitativeValue.yml
@@ -6,15 +6,11 @@ description: A point value or interval for product characteristics and other pur
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - QuantitativeValue
-      - type: string
-        const:
-          - QuantitativeValue
+    type: array
+    items:
+      type: string
+      enum:
+        - QuantitativeValue
   unitCode:
     title: Unit Code
     description: Unit of measurement.
@@ -32,7 +28,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "QuantitativeValue",
+    "type": ["QuantitativeValue"],
     "unitCode": "hg/ha",
     "value": "4121"
   }

--- a/docs/openapi/components/schemas/common/SIMASteelImportProductSpecifier.yml
+++ b/docs/openapi/components/schemas/common/SIMASteelImportProductSpecifier.yml
@@ -6,12 +6,11 @@ description: A finished or unfinished manufactured steel product
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - SIMASteelImportProductSpecifier
+    type: array
+    items:
+      type: string
+      enum:
+        - SIMASteelImportProductSpecifier
   steelProduct:
     title: Steel Product
     description: >-

--- a/docs/openapi/components/schemas/common/SeaCargoManifest.yml
+++ b/docs/openapi/components/schemas/common/SeaCargoManifest.yml
@@ -6,15 +6,11 @@ description: The Sea Cargo Manifest is issued by the ocean carrier listing out a
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - SeaCargoManifest
-      - type: string
-        const: 
-          - SeaCargoManifest 
+    type: array
+    items:
+      type: string
+      enum:
+        - SeaCargoManifest
   vesselName: 
     title: Vessel Name
     description: Identifier of the means of transport such as IMO vessel number or truck license place. 
@@ -116,7 +112,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "SeaCargoManifest",
+    "type": ["SeaCargoManifest"],
     "vesselName": "MS Seventh Sea",
     "vesselNumber": "IMO1208812",
     "voyageNumber": "W-0239",

--- a/docs/openapi/components/schemas/common/Seal.yml
+++ b/docs/openapi/components/schemas/common/Seal.yml
@@ -9,15 +9,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Seal
-      - type: string
-        const:
-          - Seal
+    type: array
+    items:
+      type: string
+      enum:
+        - Seal
   sealNumber:
     title: Seal Number
     description: Identifies a seal affixed to the container.
@@ -62,7 +58,7 @@ required:
   - sealNumber
 example: |-
   {
-    "type": "Seal",
+    "type": ["Seal"],
     "sealNumber": "PTW-002290109692",
     "sealSource": "SHI",
     "sealType": "BLT"

--- a/docs/openapi/components/schemas/common/ServiceCharge.yml
+++ b/docs/openapi/components/schemas/common/ServiceCharge.yml
@@ -6,15 +6,11 @@ description: A charge made for services rendered or assessed, such as freight ch
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ServiceCharge
-      - type: string
-        const:
-          - ServiceCharge
+    type: array
+    items:
+      type: string
+      enum:
+        - ServiceCharge
   chargeCode:
     description: The unique identifier for this logistics service charge.
     type: string
@@ -68,7 +64,7 @@ properties:
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#appliedAmount
 example: |-
   {
-    "type": "ServiceCharge",
+    "type": ["ServiceCharge"],
     "chargeCode": "basicFreight",
     "paymentTerm": "collect",
     "chargeText": "Negotiated ocean freight",

--- a/docs/openapi/components/schemas/common/ShippingStop.yml
+++ b/docs/openapi/components/schemas/common/ShippingStop.yml
@@ -8,15 +8,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - ShippingStop
-      - type: string
-        const:
-          - ShippingStop
+    type: array
+    items:
+      type: string
+      enum:
+        - ShippingStop
   from:
     title: From
     $ref: ./Place.yml
@@ -55,7 +51,7 @@ properties:
       '@id': https://schema.org/description
 example: |-
   {
-    "type": "ShippingStop",
+    "type": ["ShippingStop"],
     "shippingStopAddress": {
       "type": "PostalAddress",
       "organizationName": "Tremblay, Prosacco and Beatty",

--- a/docs/openapi/components/schemas/common/SteelProduct.yml
+++ b/docs/openapi/components/schemas/common/SteelProduct.yml
@@ -6,15 +6,11 @@ description: A finished or unfinished manufactured steel product
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - SteelProduct
-      - type: string
-        const:
-          - SteelProduct
+    type: array
+    items:
+      type: string
+      enum:
+        - SteelProduct
   heatNumber:
     title: Heat Number
     description: >-
@@ -100,7 +96,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "SteelProduct",
+    "type": ["SteelProduct"],
     "heatNumber": "4761",
     "specification": "ASTM-66272",
     "grade": ["95913"],

--- a/docs/openapi/components/schemas/common/Template.yml
+++ b/docs/openapi/components/schemas/common/Template.yml
@@ -6,15 +6,11 @@ description: A template for rendering schemas for example with JSON Schema Forms
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Template
-      - type: string
-        const:
-          - Template 
+    type: array
+    items:
+      type: string
+      enum:
+        - Template
   id:
     type: string
   industryTags:
@@ -77,6 +73,7 @@ required:
 additionalProperties: false
 example: |-
   {
+    "type": ["Template"],
     "id": "d35f9540-7390-4130-904d-3dfb560cf1d9",
     "industryTags": [
         "E-Commerce",

--- a/docs/openapi/components/schemas/common/TradeLineItem.yml
+++ b/docs/openapi/components/schemas/common/TradeLineItem.yml
@@ -8,15 +8,11 @@ type: object
 required: []
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - TradeLineItem
-      - type: string
-        const:
-          - TradeLineItem
+    type: array
+    items:
+      type: string
+      enum:
+        - TradeLineItem
   purchaseOrderNumber: 
     title: Purchase Order Number
     type: string

--- a/docs/openapi/components/schemas/common/Transport.yml
+++ b/docs/openapi/components/schemas/common/Transport.yml
@@ -6,15 +6,11 @@ description: A transport which can be a leg of a journey.
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - Transport
-      - type: string
-        const:
-          - Transport
+    type: array
+    items:
+      type: string
+      enum:
+        - Transport
   loadLocation:
     title: Load Location
     $ref: ./Place.yml
@@ -77,7 +73,7 @@ properties:
         https://service.unece.org/trade/uncefact/vocabulary/uncefact/#TransportMovement
 example: |-
   {
-    "type": "Transport",
+    "type": ["Transport"],
     "loadLocation": {
       "type": "Place",
       "unLocode": "ITMIL"

--- a/docs/openapi/components/schemas/common/TransportEquipment.yml
+++ b/docs/openapi/components/schemas/common/TransportEquipment.yml
@@ -9,15 +9,11 @@ description: >-
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - TransportEquipment
-      - type: string
-        const:
-          - TransportEquipment
+    type: array
+    items:
+      type: string
+      enum:
+        - TransportEquipment
   equipmentReference:
     title: Equipment Reference
     description: >-
@@ -99,7 +95,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "TransportEquipment",
+    "type": ["TransportEquipment"],
     "equipmentReference": "APZU4812090",
     "ISOEquipmentCode": "40GP",
     "seals": [

--- a/docs/openapi/components/schemas/common/USMCAProductSpecifier.yml
+++ b/docs/openapi/components/schemas/common/USMCAProductSpecifier.yml
@@ -6,14 +6,11 @@ description: USMCA product origin specifier
 type: object
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - USMCAProductSpecifier
-      - type: string
-        const: USMCAProductSpecifier
+    type: array
+    items:
+      type: string
+      enum:
+        - USMCAProductSpecifier
   product:
     title: Product
     description: >-
@@ -67,7 +64,7 @@ properties:
 additionalProperties: true
 example: |-
   {
-    "type": "USMCAProductSpecifier",
+    "type": ["USMCAProductSpecifier"],
     "product": {
       "type": [
         "Product"

--- a/docs/openapi/components/schemas/common/WayBillRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/common/WayBillRegistrationCredential.yml
@@ -15,14 +15,11 @@ required:
   - certificateName
 properties:
   type:
-    oneOf:
-      - type: array
-        items:
-          type: string
-          enum:
-            - WayBillRegistrationCredential
-      - type: string
-        const: WayBillRegistrationCredential
+    type: array
+    items:
+      type: string
+      enum:
+        - WayBillRegistrationCredential
   wayBillID:
     title: Way Bill Number
     type: string
@@ -77,7 +74,7 @@ properties:
 additionalProperties: false
 example: |-
   {
-    "type": "WayBillRegistrationCredential",
+    "type": ["WayBillRegistrationCredential"],
     "wayBillID": "ACMEWayBill#956",
     "carrierName": "Veum LLC",
     "modeOfTransport": "Sea",


### PR DESCRIPTION
This prioritizes consistency and readability over flexibility by removing optionality of specifying types as a basic strings. 

This is quite abstract to decipher: 
```
  type:
    oneOf:
      - type: array
        items:
          type: string
          enum:
            - MyTypeName
      - type: string
        const: MyTypeName 
```

I've only touched "our" schemas. I encourage y'all to follow the same pattern for consistency and simplification. 