### PR TITLE
Fix path resolution to credential directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ docs/sections/credentials.html
 docs/testsuite/index.html
 docs/openapi/openapi.yml
 docs/testsuite/jest-html-reporters-attach/result.js
+docs/testsuite/jest-html-reporters-attach/index.js
 
 packages/traceability-schemas/data/*.json

--- a/packages/traceability-schemas/scripts/regenerate.js
+++ b/packages/traceability-schemas/scripts/regenerate.js
@@ -59,7 +59,27 @@ const issueCredential = async (candidate, filename) => {
 };
 
 const main = async () => {
-  const path = '../../../docs/openapi/components/schemas/credentials';
+  const currentDirectory = process.cwd().split('/').pop();
+  let path = '';
+  switch (currentDirectory) {
+    case 'scripts':
+      path = '../../../docs/openapi/components/schemas/credentials';
+      break;
+    case 'traceability-schemas':
+      path = '../../docs/openapi/components/schemas/credentials';
+      break;
+    case 'packages':
+      path = '../docs/openapi/components/schemas/credentials';
+      break;
+    default:
+      path = './docs/openapi/components/schemas/credentials';
+      break;
+  }
+
+  if (!fs.existsSync(path)) {
+    throw new Error('Cannot find credentials directory');
+  }
+
   const files = fs.readdirSync(path);
 
   await Promise.all(

--- a/packages/traceability-schemas/scripts/regenerate.js
+++ b/packages/traceability-schemas/scripts/regenerate.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { resolve } = require('path');
 
 const transmute = require('@transmute/vc.js');
 const {
@@ -59,22 +60,10 @@ const issueCredential = async (candidate, filename) => {
 };
 
 const main = async () => {
-  const currentDirectory = process.cwd().split('/').pop();
-  let path = '';
-  switch (currentDirectory) {
-    case 'scripts':
-      path = '../../../docs/openapi/components/schemas/credentials';
-      break;
-    case 'traceability-schemas':
-      path = '../../docs/openapi/components/schemas/credentials';
-      break;
-    case 'packages':
-      path = '../docs/openapi/components/schemas/credentials';
-      break;
-    default:
-      path = './docs/openapi/components/schemas/credentials';
-      break;
-  }
+  const path = resolve(
+    __dirname,
+    '../../../docs/openapi/components/schemas/credentials'
+  );
 
   if (!fs.existsSync(path)) {
     throw new Error('Cannot find credentials directory');


### PR DESCRIPTION
PR https://github.com/w3c-ccg/traceability-vocab/pull/537 changed the documentation from 

```bash
cd ./packages/traceability-schemas/scripts/
node regenerate.js
```

to 

```bash
cd ./packages/traceability-schemas
npm run regenerate
```

doesn't work because the current working directory of the script is different causing the script to not be able to find the `credentials` folder.  This PR addresses this to make path resolve the relative path to the credential directory. 