### PR TITLE
Port openapi-to-context.js to editable script

### DIFF
--- a/packages/traceability-schemas/scripts/openapi-to-context.js
+++ b/packages/traceability-schemas/scripts/openapi-to-context.js
@@ -1,5 +1,6 @@
 /* eslint-disable implicit-arrow-linebreak */
 /* eslint-disable operator-linebreak */
+
 const fs = require('fs');
 const path = require('path');
 
@@ -10,17 +11,59 @@ const rootTerms = require('./rootTerms.json');
 
 const contextPath = path.resolve(
   __dirname,
-  '../../../docs/contexts/traceability-v1.jsonld'
+  '../../../docs/contexts/traceability-v2.jsonld'
 );
 
-(async () => {
-  console.log('🧪 build context from api');
-  const context = jsonldSchema.schemasToContext(schemas, {
-    version: 1.1,
-    vocab: 'https://w3id.org/traceability/#undefinedTerm',
-    id: '@id',
-    type: '@type',
-    rootTerms,
-  });
-  fs.writeFileSync(contextPath, stringify(context, { space: '  ' }));
-})();
+const schemasToContext = (srcSchemas, srcContext) => {
+  console.log(srcSchemas[0]);
+  const context = srcSchemas.reduce((prev, curr) => {
+    const { term } = curr.$linkedData;
+    const clone = { ...prev };
+    clone[`${term}`] = {
+      '@id': curr.$linkedData['@id'],
+      '@context': {},
+    };
+
+    if (!curr.properties) {
+      console.log('No properties for current');
+      console.log(curr);
+      return prev;
+    }
+
+    const keys = Object.keys(curr.properties);
+    console.log(`--- ${term} ---`);
+    keys.forEach((key) => {
+      console.log(key);
+      if (key === 'type') {
+        return;
+      }
+
+      if (!curr.properties[`${key}`].$linkedData) {
+        return;
+      }
+
+      clone[`${term}`]['@context'][
+        `${curr.properties[`${key}`].$linkedData.term}`
+      ] = {
+        '@id': curr.properties[`${key}`].$linkedData['@id'],
+      };
+    });
+
+    return clone;
+  }, srcContext);
+  return {
+    '@context': context,
+  };
+};
+
+console.log('🧪 build context from api');
+
+const context = schemasToContext(schemas, {
+  version: 1.1,
+  vocab: 'https://w3id.org/traceability/#undefinedTerm',
+  id: '@id',
+  type: '@type',
+  ...rootTerms,
+});
+
+fs.writeFileSync(contextPath, stringify(context, { space: '  ' }));


### PR DESCRIPTION
Right now our openapi to context script is calling a library from `@transmute/jsonld-schema`. This PR updates our script to run directly in the repository as opposed to having to edit an external library to make changes to how the `@context` file is produced. 