### PR TITLE
fix: 3461 typo

### DIFF
--- a/docs/credentials-with-undefined-terms.json
+++ b/docs/credentials-with-undefined-terms.json
@@ -149,7 +149,7 @@
   },
   {
     "type": "CBP3461ImmediateDeliveryCertificate",
-    "count": 75
+    "count": 17
   },
   {
     "type": "BillOfLadingCertificate",

--- a/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCertificate.yml
@@ -73,7 +73,7 @@ example: |-
     },
     "credentialSubject": {
       "type": [
-        "CBP3461ImmediateDeliveryCertificate"
+        "ImmediateDelivery"
       ],
       "portOfEntry": {
         "type": [
@@ -177,9 +177,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-23T19:05:23Z",
+      "created": "2022-08-23T20:09:56Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..iQwaP4ww8oGSMjceXaPxB70Sre8CRrtdTmTkAvPKiN3qpOZxwe2XWtjgoUfk22K_4lcPkzD91-ug_-M5Nx9kBw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..1_mEnyYo9BTAvmZtcjHYgu5qCNnIiaZ1noOFW-1eOIhfMs9rjU4MpwTebTD424NNukQjTdURZW054Nsxhfe6Bg"
     }
   }


### PR DESCRIPTION
I just introduced an awful typo earlier today, mixing up `CBP3461ImmediateDeliveryCertificate` and `ImmediateDelivery`. I'm gonna take the liberty to fix that quick, out of order. 