### PR TITLE
Standardize credential context declaration

### DIFF
--- a/docs/openapi/components/schemas/credentials/BillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCertificate.yml
@@ -17,6 +17,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -20,6 +20,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -10,6 +10,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/CommercialInvoiceCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CommercialInvoiceCertificate.yml
@@ -13,6 +13,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCertificate.yml
@@ -15,6 +15,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/DCSATransportDocumentCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/DCSATransportDocumentCertificate.yml
@@ -13,6 +13,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/DeMinimisShipmentCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/DeMinimisShipmentCertificate.yml
@@ -7,6 +7,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/FreightManifestCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FreightManifestCertificate.yml
@@ -14,6 +14,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/HouseBillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/HouseBillOfLadingCertificate.yml
@@ -11,6 +11,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/IATAAirWaybillCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/IATAAirWaybillCertificate.yml
@@ -13,6 +13,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCertificate.yml
@@ -9,6 +9,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/IntentToImportCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCertificate.yml
@@ -19,6 +19,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/MasterBillOfLadingCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/MasterBillOfLadingCertificate.yml
@@ -13,6 +13,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/MillTestReportCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCertificate.yml
@@ -10,6 +10,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
@@ -14,6 +14,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:

--- a/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
@@ -9,6 +9,13 @@ type: object
 properties:
   '@context':
     type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
     items:
       type: string
       enum:


### PR DESCRIPTION
Has all of the credentials use the same syntax for `@context` declaration.

```yml
  '@context':
    type: array
    readOnly: true
    const:
      - https://www.w3.org/2018/credentials/v1
      - https://w3id.org/traceability/v1
    default:
      - https://www.w3.org/2018/credentials/v1
      - https://w3id.org/traceability/v1
    items:
      type: string
      enum:
        - https://www.w3.org/2018/credentials/v1
        - https://w3id.org/traceability/v1
```