### PR TITLE
Ensure credential subject has a schema definition

### DIFF
--- a/docs/openapi/components/schemas/credentials/DCSATransportDocumentCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/DCSATransportDocumentCertificate.yml
@@ -43,7 +43,7 @@ properties:
   issuer:
     type: object
   credentialSubject:
-    type: object
+    $ref: ../common/DCSATransportDocument.yml
   proof:
     type: object
   relatedLink:

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCertificate.yml
@@ -39,7 +39,7 @@ properties:
   issuer:
     type: object
   credentialSubject:
-    type: object
+    $ref: ../common/SIMASteelImportLicense.yml
   proof:
     type: object
   relatedLink:

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCertificate.yml
@@ -39,7 +39,7 @@ properties:
   issuer:
     type: object
   credentialSubject:
-    type: object
+    $ref: ../common/SIMASteelImportLicense.yml
   proof:
     type: object
   licenseNumber:

--- a/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
@@ -44,7 +44,7 @@ properties:
   issuer:
     type: object
   credentialSubject:
-    type: object
+    $ref: ../common/USMCAProductSpecifier.yml
   proof:
     type: object
   exporterDetails:


### PR DESCRIPTION
These schemas currently have `credentialSubject` defined as a generic object. This PR updates them to use a specific schema file for `credentialSubject` definition. 

```yml
   credentialSubject:
    type: object
```

1. DCSATransportDocument
2. SIMASteelImportLicenseApplicationCertificate
3. SIMASteelImportLicenseCertificate
4. USMCACertificationOfOrigin