### PR TITLE
Remove instructional related links

### DIFF
--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
@@ -169,9 +169,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-11T17:29:06Z",
+      "created": "2022-10-19T02:41:58Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..M8nb8MLsxILtiN76abwkdXWE_TpIZN76PN0_vTS7z-O8ds-J7-e4e0A209RthqlRrXnUqsfslETJtHQ4ngizCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..GCgIxZwgFnHdSYcYMgfyl2Gbl2LYkmhURNjO2kYPQtuoAYq95uPA_ZZmzmXfwyPSdK2VZsy07W-ECW5NcvFVAw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
@@ -164,9 +164,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-17T18:04:46Z",
+      "created": "2022-10-13T04:28:54Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2ZpStuw6MRb2c6eHCI2R5o9KOXbu7u1jSjUcQAfPpTcN9ANELTtgEYZ83kYJ4nqSP1fvqcH8Bf4RYZSnFpp5CQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ZMwKRj9vwLcJo8CYpstB_46NOUUDgbwm7ui1V5VqeAB4WyisBWg83XC_Uhzxq6nHPxEahsYtSiBAHMY4Zp2gBw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECertificate.yml
@@ -75,15 +75,6 @@ example: |-
       "FSMACreatingCTECertificate"
     ],
     "name": "FSMA Creating CTE Certificate",
-    "relatedLink": [
-      {
-        "type": [
-          "LinkRole"
-        ],
-        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
-        "linkRelationship": "traceabilityRuleInformationLink"
-      }
-    ],
     "issuanceDate": "2021-12-11T03:50:55Z",
     "issuer": {
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
@@ -154,9 +154,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-11T17:29:07Z",
+      "created": "2022-10-19T02:41:59Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..m82hx7GgW3Q7wRjIrhm91cX7e76YNsAsHmsdTpEBMiY9bszJyP_sG7p7PrA9T65aREYsaQyXGmpefvGiGA4eDQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..8FEW55PEsfIVsJKU6GineEpRIDwFiog7W9iKbAYPl3BqeyLtjE6QJ_05OYjPP4bHfvJJq46vxs6183JHNxrUCA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
@@ -75,15 +75,6 @@ example: |-
       "FSMAFirstReceiverDataCertificate"
     ],
     "name": "FSMA First Receiver Data Certificate",
-    "relatedLink": [
-      {
-        "type": [
-          "LinkRole"
-        ],
-        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
-        "linkRelationship": "traceabilityRuleInformationLink"
-      }
-    ],
     "issuanceDate": "2021-12-11T03:50:55Z",
     "issuer": {
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCertificate.yml
@@ -116,7 +116,9 @@ example: |-
           "locationName": "John's Tomato Farm #1"
         },
         "lotCodeGeneratorPOC": {
-          "type": ["Entity"],
+          "type": [
+            "Entity"
+          ],
           "entityType": "Person",
           "name": "John Davis",
           "email": "produce@example.com",
@@ -147,9 +149,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-17T18:04:46Z",
+      "created": "2022-10-13T04:28:55Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..jrWpR7v5pCZhnmYqINQkk2AgMA7-6AiXMF4zpVU559W8ediPjpntXJH_0YxtD24RdkCYrmmZCOJ6-QJNXYneDQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DW3fvfe6faEzZ4BV7M2KlRxNTaBgT62bgZPy-mETCw9FzJRE2JFnlxOenCO16zJ3ByYga9JBAxg-sgBbHdYrDw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
@@ -75,15 +75,6 @@ example: |-
       "FSMAGrowingCTECertificate"
     ],
     "name": "FSMA Growing CTE Certificate",
-    "relatedLink": [
-      {
-        "type": [
-          "LinkRole"
-        ],
-        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
-        "linkRelationship": "traceabilityRuleInformationLink"
-      }
-    ],
     "issuanceDate": "2021-12-11T03:50:55Z",
     "issuer": {
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
@@ -116,7 +116,9 @@ example: |-
           "locationName": "John's Tomato Farm #1"
         },
         "lotCodeGeneratorPOC": {
-          "type": ["Entity"],
+          "type": [
+            "Entity"
+          ],
           "entityType": "Person",
           "name": "John Davis",
           "email": "produce@example.com",
@@ -134,9 +136,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-17T18:04:44Z",
+      "created": "2022-10-13T04:28:56Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..vsSV3tUzJJ7XxUQ55lwvmJ9mjlqJT_qvB3b51uVL5eZRNMe-Hv7b_Iom3lqr6l_Tj0hKuUZJLZkZXDPw6TOsBQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..mZR44xZrWAufhXcjwwT0YF26AKsBGbGWOUi7ZWqYXZSiPB-uU_hBubmkuqPZKTyrsNoo7mo3NWmjGebWlZypAA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECertificate.yml
@@ -141,9 +141,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-11T17:29:08Z",
+      "created": "2022-10-19T02:42:00Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..OQo5JOs0WAvsfgnngYYCNfBXV9YWv62J2gnoJobfMWpZ6kgck19Y4DU02jeWXuWzxPUgPdC_GhLCrnhkPATyCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wJB_PdSpm3rFz6buVxrJ7WyZxGw5H2sEjLPD9pZP2DnA787ZFMaY89rq-w_fphELxM-efuXqCZo6aNyXE0qEDg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
@@ -78,11 +78,15 @@ example: |-
     "issuanceDate": "2021-12-11T03:50:55Z",
     "issuer": {
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "type": ["Organization"],
+      "type": [
+        "Organization"
+      ],
       "name": "Fresh Promise",
       "description": "The very freshest transformed goods",
       "address": {
-        "type": ["PostalAddress"],
+        "type": [
+          "PostalAddress"
+        ],
         "streetAddress": "374 Fischer Dam Suite 435",
         "addressLocality": "Port Mark",
         "addressRegion": "LA",
@@ -93,13 +97,21 @@ example: |-
       "phoneNumber": "175.353.7703"
     },
     "credentialSubject": {
-      "type": ["FSMAReceivingCTE"],
+      "type": [
+        "FSMAReceivingCTE"
+      ],
       "shipment": {
-        "type": ["FSMAShipment"],
+        "type": [
+          "FSMAShipment"
+        ],
         "product": {
-          "type": ["FSMAProduct"],
+          "type": [
+            "FSMAProduct"
+          ],
           "traceabilityLot": {
-            "type": ["FSMATraceabilityLot"],
+            "type": [
+              "FSMATraceabilityLot"
+            ],
             "lotCode": "CHE-MIG-TTF1-061321-H37J",
             "lotCodeAssignmentMethod": "Lot codes are assigned based on the commodity, variety, location, harvest date and a random 4 digit string.",
             "lotCodeGeneratorLocation": {
@@ -120,7 +132,9 @@ example: |-
               "locationName": "John's Tomato Farm #1"
             },
             "lotCodeGeneratorPOC": {
-              "type": ["Entity"],
+              "type": [
+                "Entity"
+              ],
               "entityType": "Person",
               "name": "John Davis",
               "email": "produce@example.com",
@@ -132,42 +146,58 @@ example: |-
           "unit": "Field Bins",
           "additionalData": [
             {
-              "type": ["FSMAAbstractKDE"],
+              "type": [
+                "FSMAAbstractKDE"
+              ],
               "name": "Category code",
               "value": "659351253"
             },
             {
-              "type": ["FSMAAbstractKDE"],
+              "type": [
+                "FSMAAbstractKDE"
+              ],
               "name": "Category name",
               "value": "Tomatoes"
             },
             {
-              "type": ["FSMAAbstractKDE"],
+              "type": [
+                "FSMAAbstractKDE"
+              ],
               "name": "Brand name",
               "value": "John's Produce"
             },
             {
-              "type": ["FSMAAbstractKDE"],
+              "type": [
+                "FSMAAbstractKDE"
+              ],
               "name": "Commodity",
               "value": "Cherry Tomatoes"
             },
             {
-              "type": ["FSMAAbstractKDE"],
+              "type": [
+                "FSMAAbstractKDE"
+              ],
               "name": "Variety",
               "value": "Mighty Sweet Hybrid"
             },
             {
-              "type": ["FSMAAbstractKDE"],
+              "type": [
+                "FSMAAbstractKDE"
+              ],
               "name": "Product name",
               "value": "N/A"
             },
             {
-              "type": ["FSMAAbstractKDE"],
+              "type": [
+                "FSMAAbstractKDE"
+              ],
               "name": "Packaging size",
               "value": "Bulk"
             },
             {
-              "type": ["FSMAAbstractKDE"],
+              "type": [
+                "FSMAAbstractKDE"
+              ],
               "name": "Packaging style",
               "value": "Field Bins"
             }
@@ -178,7 +208,9 @@ example: |-
             "Place"
           ],
           "geo": {
-            "type": ["GeoCoordinates"],
+            "type": [
+              "GeoCoordinates"
+            ],
             "latitude": "44.859038",
             "longitude": "70.916213"
           },
@@ -200,7 +232,9 @@ example: |-
             "Place"
           ],
           "geo": {
-            "type": ["GeoCoordinates"],
+            "type": [
+              "GeoCoordinates"
+            ],
             "latitude": "31.319706",
             "longitude": "-92.117524"
           },
@@ -219,17 +253,23 @@ example: |-
         },
         "additionalData": [
           {
-            "type": ["FSMAAbstractKDE"],
+            "type": [
+              "FSMAAbstractKDE"
+            ],
             "name": "Reference record type and number",
             "value": "BOL 24884"
           },
           {
-            "type": ["FSMAAbstractKDE"],
+            "type": [
+              "FSMAAbstractKDE"
+            ],
             "name": "Import entry number",
             "value": "N/A"
           },
           {
-            "type": ["FSMAAbstractKDE"],
+            "type": [
+              "FSMAAbstractKDE"
+            ],
             "name": "Transporter name",
             "value": "Local Trucking Co."
           }
@@ -239,9 +279,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-08-17T18:04:52Z",
+      "created": "2022-10-13T04:28:57Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..JysHHXfz9BoHcmfxjPsYCBBLP6Xo4rJpQ4kaDRLHhPr1tuVVFvHYOdNPuGtbJCysnZZ0uruMGbd3rLvCQICeCA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..lcqcviudN9MoOXMxeonbZCwFsm1ewZGPaxgOXL-DNit85HfYB_SQ9IZjrvI2EI8_QDr0oWGuj3PVyJD09aD-Bg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
@@ -284,9 +284,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-11T17:29:09Z",
+      "created": "2022-10-19T02:42:01Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..1L5UeklBXYp6rcIgbUrS7surBR5jopOsD6DfEWw4FTQK7migL7k6CT_XKkpbxUxV-tMTKc5xYbV2MTf6B_k7AQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..3MW7wCKxufuW4OExm_Y5U3HdE8jT4UFJasBwum_72bKffsxMH3w1HK6wA8CigOHDzyYXVKYlwj1PlzvlEx1iAw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECertificate.yml
@@ -75,15 +75,6 @@ example: |-
       "FSMAReceivingCTECertificate"
     ],
     "name": "FSMA Receiving CTE Certificate",
-    "relatedLink": [
-      {
-        "type": [
-          "LinkRole"
-        ],
-        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
-        "linkRelationship": "traceabilityRuleInformationLink"
-      }
-    ],
     "issuanceDate": "2021-12-11T03:50:55Z",
     "issuer": {
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
@@ -75,15 +75,6 @@ example: |-
       "FSMAShippingCTECertificate"
     ],
     "name": "FSMA Shipping CTE Certificate",
-    "relatedLink": [
-      {
-        "type": [
-          "LinkRole"
-        ],
-        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
-        "linkRelationship": "traceabilityRuleInformationLink"
-      }
-    ],
     "issuanceDate": "2021-12-11T03:50:55Z",
     "issuer": {
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
@@ -288,9 +288,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-03T15:09:02Z",
+      "created": "2022-10-13T04:28:59Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..V0sdAi4YGgpN_hpkAq-qV67iooIGaG9ht_lZ3zZwm9e2_oiPV9xAQYBvyGtMeuf7yd0eNq7LTFflP3kg8Eh0BA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..kcWMm3ilgMicEQDm-_fAiu18YnSIZS-Z4TG3hqI0o76luBRK5u_3N1EUb2j4X_6nU4xvnX3xauObnZwcRvzBBA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECertificate.yml
@@ -293,9 +293,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-11T17:29:11Z",
+      "created": "2022-10-19T02:42:02Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..jjVlZJ7dR_w8Th4ThjaVC9S6slQL94m5SYfvj05NlOr6B90pQMrZZti1roLLja_Y6W3ZvagFVh-xePHqeZjFAA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xF847ptdjIqI05TqpHnZ_niObUybjAkUJZu8rFStkMr-32st_Enw_ol4p-2V3takUyLA83U3Pii0QOWqSQpGBg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
@@ -281,9 +281,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-11T17:29:12Z",
+      "created": "2022-10-19T02:42:04Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Si5imRuXWn1Ruvv6gxgh8iuKKFLjQkOJS36EcdqeDoa0XuKS0ZoxH5IbLqKgnsnrN2QllDK5QnNNKFTeyvuzCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fCkqcbVXriqJs4Lc-zF1iGA6Dt5bXK6U64Js4D9q5ncqV1xuiie_fUOpScg8-mBhdK-6KXEAKzr5JKiB7SZcCA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
@@ -276,9 +276,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-03T15:09:04Z",
+      "created": "2022-10-13T04:29:00Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xEVqhRGv09bGQrOqVGcYiq87cH9jjK8K624bZGNmu17sYfxEPm9bH5rpd045azBjhw2pwINGjI_MKkG8TUFEBw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BToY3s6A5UUwoHkvaG39FjqcOQ6vKwE1UskllYhnXJG6phMPDIJKVKz2R5g_aXSjXvoKbvKax5BK2t9gZlSCBw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECertificate.yml
@@ -75,15 +75,6 @@ example: |-
       "FSMATransformingCTECertificate"
     ],
     "name": "FSMA Transforming CTE Certificate",
-    "relatedLink": [
-      {
-        "type": [
-          "LinkRole"
-        ],
-        "target": "https://www.fda.gov/food/food-safety-modernization-act-fsma/fsma-proposed-rule-food-traceability",
-        "linkRelationship": "traceabilityRuleInformationLink"
-      }
-    ],
     "issuanceDate": "2021-12-11T03:50:55Z",
     "issuer": {
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
@@ -81,15 +81,6 @@ example: |-
       "FoodGradeInspectionCertificate"
     ],
     "name": "Food Grade Inspection Certificate",
-    "relatedLink": [
-      {
-        "type": [
-          "LinkRole"
-        ],
-        "target": "https://www.ams.usda.gov/grades-standards",
-        "linkRelationship": "usdaAmsGradesAndStandardsLink"
-      }
-    ],
     "issuanceDate": "2021-12-11T03:50:55Z",
     "issuer": {
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
@@ -545,9 +545,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-11T03:17:13Z",
+      "created": "2022-10-13T04:29:02Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wVrbYL_cALo8eWUglg0TV4rGlZq__Lsk9z8m0CcFJnKCjxBZX7AAfHItS0ZpfvHO80qWRss1QuvG1i5Ve_xSAw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..XROG-csn2n3PsPIuMC8VdPUlU3kqq5vV8Dc5CM5gzyCAosz59DHEkaOodk9LavJ7oqmIaSB5RoC6oMLLr6FnCQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
@@ -550,9 +550,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-11T19:48:18Z",
+      "created": "2022-10-19T02:42:05Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..gAADTDVn4LasZWg6Wtbppmilb4GNvlf22kwKur5a4lFor7fahF4af62AACJUbRrHi0cstYUHnhkFIHwB4zl-CA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..WK5fQPkFfWrswHT9VlCjMp5LYSr8kKg6zciJUPmRNEiiGER4-2XDY2lOx404d8aWkXX5R-MuJi4GGj7PJJUnDg"
     }
   }


### PR DESCRIPTION
Several certificates have `relatedLinks` linking to sites which provide additional information about the _form_, rather than to content relating to the specific example credential. This PR removes those `relatedLinks` entirely.