### PR TITLE
Remove lerna test from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,5 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test
-        run: npm run test
-
       - name: Jest
         run: cd packages/traceability-schemas && npm run test


### PR DESCRIPTION
In our CI we have

```
      - name: Test
        run: npm run test

      - name: Jest
        run: cd packages/traceability-schemas && npm run test
```

The first `test` is going to call `npm run test`, which is mapped to `lerna run test`. This is going to call the `npm run test` method for each one of the packages. And since we only have one package, these two commands are doing the same thing. 