### PR TITLE
Move claims to credential subject for Certification Of Origin

### DIFF
--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -48,6 +48,24 @@ properties:
     type: object
   credentialSubject:
     type: object
+    properties:
+      items:
+        type: array
+        items:
+          $ref: ../common/TradeLineItem.yml
+      manufacturingCountry:
+        title: Manufacturing Country
+        description: The country of manufacture of this trade product.
+        type: string
+      dateOfExport:
+        title: Date of Export
+        description: The date, time, date time, or other date time value when the subject line item(s) will exit, or has(have) exited from the last port, airport, or border post of the country of export.
+        type: string
+    additionalProperties: false
+    required:
+      - items
+      - manufacturingCountry
+      - dateOfExport
   proof:
     type: object
   relatedLink:
@@ -56,21 +74,6 @@ properties:
     type: array
     items:
       $ref: ../common/LinkRole.yml
-  manufacturingCountry:
-    title: Manufacturing Country
-    description: Manufacturing country.
-    type: string
-    $linkedData:
-      term: manufacturingCountry
-      '@id': https://w3id.org/traceability#manufacturingCountry
-  dateOfExport:
-    title: Date of Export
-    description: The date, time, date time, or other date time value when the subject line item(s) will exit, or has(have) exited from the last port, airport, or border post of the country of export.
-    type: string
-    $linkedData:
-      term: dateOfExport
-      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exportExitDateTime
-      '@type': http://www.w3.org/2001/XMLSchema#dateTime
 additionalProperties: false
 required:
   - '@context'
@@ -107,7 +110,7 @@ example: |-
           "name": "Espresso Italiano",
           "description": "Premium Prosumer Espresso Makers - Model Dolce",
           "product": {
-            "type": "Product",
+            "type": ["Product"],
             "commodity": {
               "type": [
                 "Commodity"
@@ -117,15 +120,15 @@ example: |-
             }
           }
         }
-      ]
+      ],
+      "manufacturingCountry": "IT",
+      "dateOfExport": "2022-02-02T09:30:00Z"
     },
-    "manufacturingCountry": "IT",
-    "dateOfExport": "2022-02-02T09:30:00Z",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-03T12:11:43Z",
+      "created": "2022-10-27T08:26:29Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..uadaYo6v3sv3DrZ0rF_-W1mR4Gj9u7ePaG7yu-Xs7uII83cI3d_FmxRBBe3Dv8xMb4i9nHU4hIfxGU5vycdGDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..e1Ht4mqGCCTDV9jBkaEgyVOZDDQMhqrvjr8gx4zjKuDuBSbY0-r44_fHlgaHPF8PGQuECtlMfyY2K_IrUn8SBg"
     }
   }

--- a/packages/traceability-schemas/scripts/rootTerms.json
+++ b/packages/traceability-schemas/scripts/rootTerms.json
@@ -10,7 +10,12 @@
     "@id": "https://w3id.org/traceability#LinkRole"
   },
   "manufacturer": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#manufacturerParty",
+  "manufacturingCountry": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#manufactureCountry",
   "product": "https://w3id.org/traceability#SteelProduct",
   "rawMaterial": "https://w3id.org/traceability#rawMaterial",
-  "items": "https://schema.org/ItemList"
+  "items": "https://schema.org/ItemList",
+  "dateOfExport": {
+    "@id": "https://service.unece.org/trade/uncefact/vocabulary/uncefact/#exportExitDateTime",
+    "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+  }
 }


### PR DESCRIPTION
In the `Certification Of Origin`, we have claims for `manufacturingCountry` and `dateOfExport` which are being declared in the verifiable credential aggregate. These claims have been moved to the `credentialSubject`. 

- Added terms to root terms
- Added required fields for credentialSubject