### PR TITLE
feat: add country of issuance to organic certificate

### DIFF
--- a/docs/openapi/components/schemas/common/OrganicCertificate.yml
+++ b/docs/openapi/components/schemas/common/OrganicCertificate.yml
@@ -16,6 +16,13 @@ properties:
       type: string
       enum:
         - OrganicCertificate
+  countryOfIssuance:
+    title: Country of Issuance
+    description: The country issuing the organic certificate. This value should be a two letter country code as defined in ISO 3166 (e.g., "US" for United States, "CA" for Canada).
+    type: string
+    $linkedData:
+      term: countryOfIssuance
+      '@id': https://www.gs1.org/voc/countryCode
   certifiedOperation:
     title: Certified Operation
     description: The operation certified as organic, including name (all legal names) and address(es).
@@ -71,6 +78,7 @@ additionalProperties: false
 example: |-
   {
     "type": ["OrganicCertificate"],
+    "countryOfIssuance": "US",
     "certifiedOperation": {
       "type": ["Organization"],
       "name": "John's Produce",

--- a/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
@@ -114,6 +114,7 @@ example: |-
       "type": [
         "OrganicCertificate"
       ],
+      "countryOfIssuance": "US",
       "certifiedOperation": {
         "type": [
           "Organization"
@@ -169,9 +170,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-31T00:02:55Z",
+      "created": "2022-11-04T20:37:55Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..dvB899U_YVclulx6yJY3j9eP0qgyzpYzOoRwYeXrjAFmYmiOnZe0-ZkIWHH5mttIkMyZp0K7rVeTJT6Lnkr5Aw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..frl6jjb0DKpZLHjD1IbUlYlUNU8it0ITtFYQa98o0uOn3z-K1kqZrAM3kV_LrRdTzMlNN4_YKjxIqH5dzXTvDQ"
     }
   }


### PR DESCRIPTION
This PR adds a `countryOfIssuance` property to `OrganicCertificate`, to describe international usage of the credential.