### PR TITLE
Add optional expiration date to schemas

### DIFF
--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -51,6 +51,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCredential.yml
@@ -36,6 +36,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
@@ -36,6 +36,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -54,6 +54,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -44,6 +44,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
@@ -47,6 +47,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/CrudeOilProductCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CrudeOilProductCredential.yml
@@ -43,6 +43,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: string
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
@@ -49,6 +49,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
@@ -47,6 +47,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
@@ -41,6 +41,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/EventCredential.yml
+++ b/docs/openapi/components/schemas/credentials/EventCredential.yml
@@ -41,6 +41,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
@@ -49,6 +49,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
@@ -49,6 +49,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
@@ -49,6 +49,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
@@ -49,6 +49,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
@@ -49,6 +49,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
@@ -49,6 +49,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
@@ -53,6 +53,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
@@ -52,6 +52,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
@@ -55,6 +55,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/FreightManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FreightManifestCredential.yml
@@ -48,6 +48,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
@@ -51,6 +51,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
@@ -45,6 +45,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
@@ -47,6 +47,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
@@ -43,6 +43,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -53,6 +53,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
@@ -47,6 +47,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -44,6 +44,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
@@ -46,6 +46,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/NaturalGasProductCredential.yml
+++ b/docs/openapi/components/schemas/credentials/NaturalGasProductCredential.yml
@@ -43,6 +43,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: string
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
@@ -52,6 +52,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
@@ -43,6 +43,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/PackingListCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PackingListCredential.yml
@@ -42,6 +42,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
@@ -46,6 +46,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
@@ -47,6 +47,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
@@ -43,6 +43,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
@@ -44,6 +44,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
@@ -39,6 +39,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
@@ -48,6 +48,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: object
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
@@ -41,6 +41,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
@@ -37,6 +37,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   issuer:
     type: string
   credentialSubject:

--- a/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
@@ -41,6 +41,8 @@ properties:
     type: string
   issuanceDate:
     type: string
+  expirationDate:
+    type: string
   credentialSubject:
     type: object
     properties:


### PR DESCRIPTION
Right now expirationDate is implied by the vc-data-model but not explicitly defined in our JSON schema. This PR adds expirationDate as an optional parameter to our credential schemas. 