### PR TITLE
Narrow scope of schema definitions for Mill Test Report

### DIFF
--- a/docs/credentials-with-undefined-terms.json
+++ b/docs/credentials-with-undefined-terms.json
@@ -45,7 +45,7 @@
   },
   {
     "type": "PlantSystemsInspectionCredential",
-    "count": 53
+    "count": 2
   },
   {
     "type": "PackingListCredential",
@@ -57,7 +57,7 @@
   },
   {
     "type": "OrganicCertificateCredential",
-    "count": 15
+    "count": 0
   },
   {
     "type": "NaturalGasProductCredential",
@@ -133,7 +133,7 @@
   },
   {
     "type": "EventCredential",
-    "count": 1
+    "count": 9
   },
   {
     "type": "DeMinimisShipmentCredential",

--- a/docs/openapi/components/schemas/common/RawMaterial.yml
+++ b/docs/openapi/components/schemas/common/RawMaterial.yml
@@ -33,6 +33,8 @@ properties:
 additionalProperties: false
 required:
   - type
+  - name
+  - inchiKey
 example: |-
   {
     "type": [

--- a/docs/openapi/components/schemas/common/SteelProduct.yml
+++ b/docs/openapi/components/schemas/common/SteelProduct.yml
@@ -99,6 +99,10 @@ properties:
 additionalProperties: false  
 required:
   - type
+  - heatNumber
+  - specification
+  - grade
+  - originalCountryOfMeltAndPour
 example: |-
   {
     "type": ["SteelProduct"],

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -180,26 +180,7 @@ example: |-
       "type": ["Organization"],
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "name": "Melt Global, Inc.",
-      "phoneNumber": "+1 702-647-9292",
-      "location": {
-        "type": [
-          "Place"
-        ],
-        "geo": {
-          "type": ["GeoCoordinates"],
-          "latitude": "30.893066748785927",
-          "longitude": "-93.80232474809726"
-        },
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "addressLocality": "Hunter Valley",
-          "addressRegion": "Texas",
-          "postalCode": "78599",
-          "addressCountry": "United States"
-        }
-      }
+      "phoneNumber": "+1 702-647-9292"
     },
     "issuanceDate": "2022-06-06T08:10:00+00:00",
     "credentialSubject": {
@@ -630,37 +611,11 @@ example: |-
         }
       }
     },
-    "issuer": {
-      "type": "Organization",
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "Melt Global, Inc.",
-      "phoneNumber": "+1 702-647-9292",
-      "location": {
-        "type": [
-          "Place"
-        ],
-        "geo": {
-          "type": "GeoCoordinates",
-          "latitude": "30.893066748785927",
-          "longitude": "-93.80232474809726"
-        },
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "addressLocality": "Hunter Valley",
-          "addressRegion": "Texas",
-          "postalCode": "78599",
-          "addressCountry": "United States"
-        }
-      }
-    },
-    "issuanceDate": "2022-06-06T08:10:00+00:00",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-12T00:29:36Z",
+      "created": "2022-11-15T20:01:31Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..tpPTiLmm7d2H9XdEO9x0QhP9EuaDKyrJYBO0H74lujqMmFSwmq2gBWdJxLCR-KCbJ-almMdOTmLk6rtbQUxwDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..bDmAmbrEj6FEltOb1i-ETSx1QzS2zxnRRl4qs_q3SRrGsD5ciTd_rohZ6Ob3f9VWtz0KSHcQqQ-tzC5vFJZvAA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -94,11 +94,44 @@ properties:
     description: Test results made by a manufacturer of a metal product.
     type: object
     properties:
-      # Schema Definition
       manufacturer:
-        $ref: ../common/Organization.yml
         title: Manufacturer
-        description: The manufacturer
+        description: A manufacturer of a Mill Test Report
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Organization
+            default:
+              - Organization
+            items:
+              type: string
+              enum:
+                - Organization
+          id: 
+            title: Identifier
+            description: Organization identifier.
+            type: string
+          name:
+            title: Name
+            description: Name of the organization.
+            type: string
+          phoneNumber:
+            title: Phone Number
+            description: Organization's contact phone number.
+            type: string
+          location:
+            title: Location
+            description: The location of the facility where the Mill Test Report was conducted
+            $ref: ../common/Place.yml
+        additionalProperties: false
+        required:
+          - type
+          - name
+          - phoneNumber
+          - location
       # Schema Definition
       product:
         $ref: ../common/SteelProduct.yml

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -45,7 +45,50 @@ properties:
   issuanceDate:
     type: string
   issuer:
+    title: Issuer
+    description: An issuing organization
     type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - Organization
+        default:
+          - Organization
+        items:
+          type: string
+          enum:
+            - Organization
+      id:
+        title: Identifier
+        description: Decentralized identifier for the issuer
+        type: string
+      name:
+        title: Name
+        description: Name of the issuer.
+        type: string
+      url:
+        title: URL
+        description: URL of the organization.
+        type: string
+      description:
+        title: Description
+        description: Description of the company.
+        type: string
+      email:
+        title: Email Address
+        description: Organization's primary email address.
+        type: string
+      phoneNumber:
+        title: Phone Number
+        description: Organization's contact phone number.
+        type: string
+    additionalProperties: false
+    required:
+      - id
+      - type
+      - name
   credentialSubject:
     title: Mill Test Report
     description: Test results made by a manufacturer of a metal product.
@@ -527,36 +570,19 @@ example: |-
       }
     },
     "issuer": {
-      "type": "Organization",
+      "type": [
+        "Organization"
+      ],
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "name": "Melt Global, Inc.",
-      "phoneNumber": "+1 702-647-9292",
-      "location": {
-        "type": [
-          "Place"
-        ],
-        "geo": {
-          "type": "GeoCoordinates",
-          "latitude": "30.893066748785927",
-          "longitude": "-93.80232474809726"
-        },
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "addressLocality": "Hunter Valley",
-          "addressRegion": "Texas",
-          "postalCode": "78599",
-          "addressCountry": "United States"
-        }
-      }
+      "phoneNumber": "+1 702-647-9292"
     },
     "issuanceDate": "2022-06-06T08:10:00+00:00",
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-19T07:41:12Z",
+      "created": "2022-11-12T00:29:36Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..6w9wqNGcTrCeEHOi3lxwq52x_3g_BJc3dcYjvdMhKOvny6r23mIW3ZaQv-JhAjbSsloxet9sYmeMekcsJPUnAw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..tpPTiLmm7d2H9XdEO9x0QhP9EuaDKyrJYBO0H74lujqMmFSwmq2gBWdJxLCR-KCbJ-almMdOTmLk6rtbQUxwDA"
     }
   }


### PR DESCRIPTION
This pull request narrowly defines the specific attributes expected for fields inside a Mill Test Report. These definitions reference existing fields from the `@context` definitions and were made without changes to the existing tooling.

It is recommended that this approach be expanded because it provides several benefits which are described in this issue: https://github.com/w3c-ccg/traceability-vocab/issues/624/ 