### PR TITLE
Add 'proof' schema to all credentials

### DIFF
--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -102,6 +102,36 @@ properties:
     $ref: ../common/BillOfLading.yml
   proof:
     $ref: ../snippets/proof.yml
+    # title: proof
+    # description: just a lowly proof, (baby dont hurt me, dont hurt me, no more). 
+    # type: object
+    # properties:
+    #   type:
+    #     type: string
+    #     description: Signature suite for the proof
+    #     enum:
+    #       - Ed25519Signature2018
+    #   created:
+    #     description: Creation timestamp for the proof in the form of an xml datestring
+    #     type: string
+    #   verificationMethod:
+    #     description: The fragment for where the public key can be de-referenced in the form of a uri
+    #     type: string
+    #   proofPurpose:
+    #     description: In the case of credentials, the proof should be a constant 'assertionMethod'
+    #     const: assertionMethod
+    #   jws:
+    #     description: The JSON Web Signature for the proof
+    #     type: string
+    # example: |-
+    #   {
+    #     "type": "Ed25519Signature2018",
+    #     "created": "2022-11-14T13:54:28Z",
+    #     "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+    #     "proofPurpose": "assertionMethod",
+    #     "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..AGCDysH5NGBJpBCw3_P5ZAQkv2Sqs_l6Vs45JKtVEVKfNKfQq6xw4eJ6Gsfj8Rq3HxF4nSLEujR9MV7b_J6-DA"
+    #   }
+      
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -101,7 +101,7 @@ properties:
   credentialSubject:
     $ref: ../common/BillOfLading.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -102,36 +102,6 @@ properties:
     $ref: ../common/BillOfLading.yml
   proof:
     $ref: ../snippets/proof.yml
-    # title: proof
-    # description: just a lowly proof, (baby dont hurt me, dont hurt me, no more). 
-    # type: object
-    # properties:
-    #   type:
-    #     type: string
-    #     description: Signature suite for the proof
-    #     enum:
-    #       - Ed25519Signature2018
-    #   created:
-    #     description: Creation timestamp for the proof in the form of an xml datestring
-    #     type: string
-    #   verificationMethod:
-    #     description: The fragment for where the public key can be de-referenced in the form of a uri
-    #     type: string
-    #   proofPurpose:
-    #     description: In the case of credentials, the proof should be a constant 'assertionMethod'
-    #     const: assertionMethod
-    #   jws:
-    #     description: The JSON Web Signature for the proof
-    #     type: string
-    # example: |-
-    #   {
-    #     "type": "Ed25519Signature2018",
-    #     "created": "2022-11-14T13:54:28Z",
-    #     "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-    #     "proofPurpose": "assertionMethod",
-    #     "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..AGCDysH5NGBJpBCw3_P5ZAQkv2Sqs_l6Vs45JKtVEVKfNKfQq6xw4eJ6Gsfj8Rq3HxF4nSLEujR9MV7b_J6-DA"
-    #   }
-      
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCredential.yml
@@ -43,7 +43,7 @@ properties:
   credentialSubject:
     $ref: ../common/ImmediateDelivery.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
@@ -43,7 +43,7 @@ properties:
   credentialSubject:
     $ref: ../common/EntrySummary.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -61,7 +61,7 @@ properties:
   credentialSubject:
     $ref: ../common/CTPAT.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -69,7 +69,7 @@ properties:
       - manufacturingCountry
       - dateOfExport
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
@@ -97,7 +97,7 @@ properties:
   credentialSubject:
     $ref: ../common/Invoice.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/CrudeOilProductCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CrudeOilProductCredential.yml
@@ -50,7 +50,7 @@ properties:
   credentialSubject:
     $ref: ../common/CrudeOilProduct.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
@@ -56,7 +56,7 @@ properties:
   credentialSubject:
     $ref: ../common/DCSAShippingInstruction.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
@@ -54,7 +54,7 @@ properties:
   credentialSubject:
     $ref: ../common/DCSATransportDocument.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
@@ -48,7 +48,7 @@ properties:
   credentialSubject:
     $ref: ../common/DeMinimisShipment.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/EventCredential.yml
+++ b/docs/openapi/components/schemas/credentials/EventCredential.yml
@@ -53,7 +53,7 @@ properties:
       - $ref: ../common/TransformEvent.yml
       - $ref: ../common/TransportEvent.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
 additionalProperties: false
 required:
   - '@context'

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
@@ -56,7 +56,7 @@ properties:
   credentialSubject:
     $ref: ../common/FSMACreatingCTE.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
@@ -56,7 +56,7 @@ properties:
   credentialSubject:
     $ref: ../common/FSMAFirstReceiverData.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
@@ -56,7 +56,7 @@ properties:
   credentialSubject:
     $ref: ../common/FSMAGrowingCTE.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
@@ -56,7 +56,7 @@ properties:
   credentialSubject:
     $ref: ../common/FSMAReceivingCTE.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
@@ -56,7 +56,7 @@ properties:
   credentialSubject:
     $ref: ../common/FSMAShippingCTE.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
@@ -56,7 +56,7 @@ properties:
   credentialSubject:
     $ref: ../common/FSMATransformingCTE.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
@@ -60,7 +60,7 @@ properties:
   credentialSubject:
     $ref: ../common/FoodDefenseInspection.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCertificate.yml
@@ -59,7 +59,7 @@ properties:
   credentialSubject:
     $ref: ../common/PlantSystemsInspection.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
@@ -62,7 +62,7 @@ properties:
   credentialSubject:
     $ref: ../common/FoodGradeInspection.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/FreightManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FreightManifestCredential.yml
@@ -55,7 +55,7 @@ properties:
   credentialSubject:
     $ref: ../common/FreightManifest.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
@@ -58,7 +58,7 @@ properties:
   credentialSubject:
     $ref: ../common/GAPInspection.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
@@ -52,7 +52,7 @@ properties:
   credentialSubject:
     $ref: ../common/HouseBillOfLading.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
@@ -54,7 +54,7 @@ properties:
   credentialSubject:
     $ref: ../common/IATAAirWaybill.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
@@ -50,7 +50,7 @@ properties:
   credentialSubject:
     $ref: ../common/ImporterSecurityFiling.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -60,7 +60,7 @@ properties:
   credentialSubject:
     $ref: ../common/IntentToImport.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
@@ -54,7 +54,7 @@ properties:
   credentialSubject:
     $ref: ../common/MasterBillOfLading.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -150,7 +150,7 @@ properties:
       - product
     additionalProperties: true
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
@@ -53,7 +53,7 @@ properties:
   credentialSubject:
     $ref: ../common/MultiModalBillOfLading.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/NaturalGasProductCredential.yml
+++ b/docs/openapi/components/schemas/credentials/NaturalGasProductCredential.yml
@@ -50,7 +50,7 @@ properties:
   credentialSubject:
     $ref: ../common/NaturalGasProduct.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
@@ -59,7 +59,7 @@ properties:
   credentialSubject:
     $ref: ../common/OrganicCertificate.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
@@ -50,7 +50,7 @@ properties:
   credentialSubject:
     $ref: ../common/PGAShipmentStatusList.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/PackingListCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PackingListCredential.yml
@@ -49,7 +49,7 @@ properties:
   credentialSubject:
     $ref: ../common/PackingList.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
@@ -53,7 +53,7 @@ properties:
   credentialSubject:
     $ref: ../common/Invoice.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
@@ -54,7 +54,7 @@ properties:
   credentialSubject:
     $ref: ../common/PurchaseOrder.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
@@ -50,7 +50,7 @@ properties:
   credentialSubject:
     $ref: ../common/SIMASteelImportLicense.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
@@ -54,7 +54,7 @@ properties:
   credentialSubject:
     $ref: ../common/SIMASteelImportLicense.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
@@ -51,7 +51,7 @@ properties:
   credentialSubject:
     $ref: ../common/SeaCargoManifest.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
@@ -46,7 +46,7 @@ properties:
   credentialSubject:
     $ref: ../common/ShippingInstructions.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
@@ -55,7 +55,7 @@ properties:
   credentialSubject:
     $ref: ../common/SoftwareBillOfMaterials.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
@@ -64,7 +64,7 @@ properties:
   credentialSubject:
     $ref: ../common/USMCAProductSpecifier.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
@@ -48,7 +48,7 @@ properties:
   credentialSubject:
     $ref: ../common/Organization.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: >-

--- a/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
@@ -44,7 +44,7 @@ properties:
   credentialSubject:
     $ref: ../common/PostmanCollection.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
@@ -51,7 +51,7 @@ properties:
       items:
         $ref: ../common/Scorecard.yml
   proof:
-    type: object
+    $ref: ../snippets/proof.yml
   relatedLink:
     title: Related Link
     description: Links related to this verifiable credential

--- a/docs/openapi/components/schemas/snippets/proof.yml
+++ b/docs/openapi/components/schemas/snippets/proof.yml
@@ -14,7 +14,7 @@ properties:
     description: The fragment from which the public key can be de-referenced, in the form of a URI
     type: string
   proofPurpose:
-    description: In the case of credentials, the proof should be a constant 'assertionMethod'
+    description: In the case of credentials, the proof should be the constant, 'assertionMethod'
     const: assertionMethod
   jws:
     description: The JSON Web Signature for the proof

--- a/docs/openapi/components/schemas/snippets/proof.yml
+++ b/docs/openapi/components/schemas/snippets/proof.yml
@@ -1,0 +1,30 @@
+title: proof
+description: just a lowly proof, (baby dont hurt me, dont hurt me, no more). 
+type: object
+properties:
+  type:
+    type: string
+    description: Signature suite for the proof
+    enum:
+      - Ed25519Signature2018
+  created:
+    description: Creation timestamp for the proof in the form of an xml datestring
+    type: string
+  verificationMethod:
+    description: The fragment for where the public key can be de-referenced in the form of a uri
+    type: string
+  proofPurpose:
+    description: In the case of credentials, the proof should be a constant 'assertionMethod'
+    const: assertionMethod
+  jws:
+    description: The JSON Web Signature for the proof
+    type: string
+example: |-
+  {
+    "type": "Ed25519Signature2018",
+    "created": "2022-11-14T13:54:28Z",
+    "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+    "proofPurpose": "assertionMethod",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..AGCDysH5NGBJpBCw3_P5ZAQkv2Sqs_l6Vs45JKtVEVKfNKfQq6xw4eJ6Gsfj8Rq3HxF4nSLEujR9MV7b_J6-DA"
+  }
+  

--- a/docs/openapi/components/schemas/snippets/proof.yml
+++ b/docs/openapi/components/schemas/snippets/proof.yml
@@ -1,5 +1,5 @@
 title: proof
-description: just a lowly proof, (baby dont hurt me, dont hurt me, no more). 
+description: A JSON Web Signature proof for a credential as defined by the VC data model 
 type: object
 properties:
   type:

--- a/docs/openapi/components/schemas/snippets/proof.yml
+++ b/docs/openapi/components/schemas/snippets/proof.yml
@@ -8,7 +8,7 @@ properties:
     enum:
       - Ed25519Signature2018
   created:
-    description: Creation timestamp for the proof in the form of an xml datestring
+    description: Creation timestamp for the proof in the form of an XML datestring
     type: string
   verificationMethod:
     description: The fragment from which the public key can be de-referenced, in the form of a URI

--- a/docs/openapi/components/schemas/snippets/proof.yml
+++ b/docs/openapi/components/schemas/snippets/proof.yml
@@ -11,7 +11,7 @@ properties:
     description: Creation timestamp for the proof in the form of an xml datestring
     type: string
   verificationMethod:
-    description: The fragment for where the public key can be de-referenced in the form of a uri
+    description: The fragment from which the public key can be de-referenced, in the form of a URI
     type: string
   proofPurpose:
     description: In the case of credentials, the proof should be a constant 'assertionMethod'

--- a/packages/traceability-schemas/scripts/openapi-to-context.js
+++ b/packages/traceability-schemas/scripts/openapi-to-context.js
@@ -18,12 +18,11 @@ const showUndefinedTerms = false;
 
 const schemasToContext = (srcSchemas, srcContext) => {
   const context = srcSchemas.reduce((prev, curr) => {
-    if (!curr.$linkedData) {
-      return curr;
-    }
-
-    const { term } = curr.$linkedData;
     const clone = { ...prev };
+    if (!curr.$linkedData) {
+      return clone;
+    }
+    const { term } = curr.$linkedData;
     const rdfClass = {
       '@id': curr.$linkedData['@id'],
       '@context': {},

--- a/packages/traceability-schemas/scripts/openapi-to-context.js
+++ b/packages/traceability-schemas/scripts/openapi-to-context.js
@@ -18,6 +18,10 @@ const showUndefinedTerms = false;
 
 const schemasToContext = (srcSchemas, srcContext) => {
   const context = srcSchemas.reduce((prev, curr) => {
+    if (!curr.$linkedData) {
+      return curr;
+    }
+
     const { term } = curr.$linkedData;
     const clone = { ...prev };
     const rdfClass = {

--- a/packages/traceability-schemas/scripts/schemas-to-openapi.js
+++ b/packages/traceability-schemas/scripts/schemas-to-openapi.js
@@ -19,9 +19,6 @@ const getTagsFromDirectory = () => {
 };
 
 const getEndpointsFromSchemaNames = (tag) => {
-  if (tag === 'snippets') {
-    return [];
-  }
   const newSchemas = getAllJsonFilesFromDirectory(
     path.resolve(__dirname, `../../../docs/openapi/components/schemas/${tag}`)
   );

--- a/packages/traceability-schemas/scripts/schemas-to-openapi.js
+++ b/packages/traceability-schemas/scripts/schemas-to-openapi.js
@@ -19,6 +19,9 @@ const getTagsFromDirectory = () => {
 };
 
 const getEndpointsFromSchemaNames = (tag) => {
+  if (tag === 'snippets') {
+    return [];
+  }
   const newSchemas = getAllJsonFilesFromDirectory(
     path.resolve(__dirname, `../../../docs/openapi/components/schemas/${tag}`)
   );

--- a/packages/traceability-schemas/scripts/schemas-to-vocab.js
+++ b/packages/traceability-schemas/scripts/schemas-to-vocab.js
@@ -15,6 +15,9 @@ const baseUrl = 'https://w3id.org/traceability';
 
 const buildLinkedDataTable = (schema) => {
   const { $id, $linkedData } = schema;
+  if (!$linkedData) {
+    return '';
+  }
   const section = `
   <table class="simple">
   <tbody>
@@ -59,6 +62,10 @@ const buildClass = (schema) => {
     console.error('error building table: ', e);
   }
 
+  if (!schema.$linkedData) {
+    return '';
+  }
+
   const props = schema.properties ? Object.keys(schema.properties) : [];
   const dependencies = props
     .filter((key) => schema.properties[key].$ref)
@@ -100,6 +107,10 @@ const separateSchemas = (schemaList) => {
 
   // Separates Schemas into Credentials and Vocabulary
   schemaList.forEach((schema) => {
+    if (!schema.example) {
+      return;
+    }
+
     const { example } = schema;
     const obj = JSON.parse(example);
     const type = Array.isArray(obj.type) ? obj.type : [obj.type];


### PR DESCRIPTION
Right now we're only definition `proof` as `type: object`. This PR provides specific schema for the proof object. 