### PR TITLE
Update Bill of Lading to require location

### DIFF
--- a/docs/openapi/components/schemas/common/BillOfLading.yml
+++ b/docs/openapi/components/schemas/common/BillOfLading.yml
@@ -120,10 +120,16 @@ properties:
             title: Postal Address
             description: The postal address for an organization or place.
             $ref: ./PostalAddress.yml
+        additionalProperties: false
+        required:
+          - type
+          - geo
+          - address
     additionalProperties: false
     required:
       - type
       - name
+      - location
     $linkedData:
       term: carrier
       '@id': >-
@@ -486,25 +492,93 @@ example: |-
       "type": ["Organization"],
       "name": "Carrior Goods And More",
       "email": "Adaline29@example.com",
-      "phoneNumber": "+1 555-234-9983"
+      "phoneNumber": "+1 555-234-9983",
+      "location": {
+        "type": ["Place"],
+        "geo": {
+          "type": ["GeoCoordinates"],
+          "latitude": "-20.840731978309044",
+          "longitude": "-159.78393883134225"
+        },
+        "address": {
+          "type": ["PostalAddress"],
+          "name": "Hahn LLC",
+          "streetAddress": "786 Pfeffer Plains",
+          "addressLocality": "West Ottilie",
+          "addressRegion": "Nebraska",
+          "postalCode": "50878-0870",
+          "addressCountry": "Cook Islands"
+        }
+      }
     },
     "consignor": {
       "type": ["Organization"],
       "name": "Consignor Is Us",
       "email": "Idella60@example.org",
-      "phoneNumber": "+1-555-953-9479"
+      "phoneNumber": "+1-555-953-9479",
+      "location": {
+        "type": ["Place"],
+        "geo": {
+          "type": ["GeoCoordinates"],
+          "latitude": "-20.840731978309044",
+          "longitude": "-159.78393883134225"
+        },
+        "address": {
+          "type": ["PostalAddress"],
+          "name": "Hahn LLC",
+          "streetAddress": "786 Pfeffer Plains",
+          "addressLocality": "West Ottilie",
+          "addressRegion": "Nebraska",
+          "postalCode": "50878-0870",
+          "addressCountry": "Cook Islands"
+        }
+      }
     },
     "consignee": {
       "type": ["Organization"],
       "name": "Victorian Consignee",
       "email": "Victoria.Hane74@example.org",
-      "phoneNumber": "+1-555-455-9053"
+      "phoneNumber": "+1-555-455-9053",
+      "location": {
+        "type": ["Place"],
+        "geo": {
+          "type": ["GeoCoordinates"],
+          "latitude": "-20.840731978309044",
+          "longitude": "-159.78393883134225"
+        },
+        "address": {
+          "type": ["PostalAddress"],
+          "name": "Hahn LLC",
+          "streetAddress": "786 Pfeffer Plains",
+          "addressLocality": "West Ottilie",
+          "addressRegion": "Nebraska",
+          "postalCode": "50878-0870",
+          "addressCountry": "Cook Islands"
+        }
+      }
     },
     "notify": {
       "type": ["Organization"],
       "name": "Florida Contact Org",
       "email": "Florida91@example.net",
-      "phoneNumber": "+1-555-104-1126"
+      "phoneNumber": "+1-555-104-1126",
+      "location": {
+        "type": ["Place"],
+        "geo": {
+          "type": ["GeoCoordinates"],
+          "latitude": "-20.840731978309044",
+          "longitude": "-159.78393883134225"
+        },
+        "address": {
+          "type": ["PostalAddress"],
+          "name": "Hahn LLC",
+          "streetAddress": "786 Pfeffer Plains",
+          "addressLocality": "West Ottilie",
+          "addressRegion": "Nebraska",
+          "postalCode": "50878-0870",
+          "addressCountry": "Cook Islands"
+        }
+      }
     },
     "freight": {
       "type": ["ParcelDelivery"],

--- a/docs/openapi/components/schemas/common/BillOfLading.yml
+++ b/docs/openapi/components/schemas/common/BillOfLading.yml
@@ -123,7 +123,6 @@ properties:
         additionalProperties: false
         required:
           - type
-          - geo
           - address
     additionalProperties: false
     required:

--- a/docs/openapi/components/schemas/common/OGBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/OGBillOfLading.yml
@@ -127,7 +127,24 @@ example: |-
         ],
         "name": "Adaline",
         "email": "Adaline29@example.com",
-        "phoneNumber": "+1 555-234-9983"
+        "phoneNumber": "+1 555-234-9983",
+        "location": {
+          "type": ["Place"],
+          "geo": {
+            "type": ["GeoCoordinates"],
+            "latitude": "-20.840731978309044",
+            "longitude": "-159.78393883134225"
+          },
+          "address": {
+            "type": ["PostalAddress"],
+            "name": "Hahn LLC",
+            "streetAddress": "786 Pfeffer Plains",
+            "addressLocality": "West Ottilie",
+            "addressRegion": "Nebraska",
+            "postalCode": "50878-0870",
+            "addressCountry": "Cook Islands"
+          }
+        }
       },
       "consignor": {
         "type": [
@@ -135,7 +152,24 @@ example: |-
         ],
         "name": "Idella",
         "email": "Idella60@example.org",
-        "phoneNumber": "555-953-9479"
+        "phoneNumber": "555-953-9479",
+        "location": {
+          "type": ["Place"],
+          "geo": {
+            "type": ["GeoCoordinates"],
+            "latitude": "-20.840731978309044",
+            "longitude": "-159.78393883134225"
+          },
+          "address": {
+            "type": ["PostalAddress"],
+            "name": "Hahn LLC",
+            "streetAddress": "786 Pfeffer Plains",
+            "addressLocality": "West Ottilie",
+            "addressRegion": "Nebraska",
+            "postalCode": "50878-0870",
+            "addressCountry": "Cook Islands"
+          }
+        }
       },
       "consignee": {
         "type": [
@@ -143,7 +177,24 @@ example: |-
         ],
         "name": "Victoria Hane",
         "email": "Victoria.Hane74@example.org",
-        "phoneNumber": "555-455-9053"
+        "phoneNumber": "555-455-9053",
+        "location": {
+          "type": ["Place"],
+          "geo": {
+            "type": ["GeoCoordinates"],
+            "latitude": "-20.840731978309044",
+            "longitude": "-159.78393883134225"
+          },
+          "address": {
+            "type": ["PostalAddress"],
+            "name": "Hahn LLC",
+            "streetAddress": "786 Pfeffer Plains",
+            "addressLocality": "West Ottilie",
+            "addressRegion": "Nebraska",
+            "postalCode": "50878-0870",
+            "addressCountry": "Cook Islands"
+          }
+        }
       },
       "notify": {
         "type": [
@@ -151,7 +202,24 @@ example: |-
         ],
         "name": "Floridas",
         "email": "Florida91@example.net",
-        "phoneNumber": "555-104-1126"
+        "phoneNumber": "555-104-1126",
+        "location": {
+          "type": ["Place"],
+          "geo": {
+            "type": ["GeoCoordinates"],
+            "latitude": "-20.840731978309044",
+            "longitude": "-159.78393883134225"
+          },
+          "address": {
+            "type": ["PostalAddress"],
+            "name": "Hahn LLC",
+            "streetAddress": "786 Pfeffer Plains",
+            "addressLocality": "West Ottilie",
+            "addressRegion": "Nebraska",
+            "postalCode": "50878-0870",
+            "addressCountry": "Cook Islands"
+          }
+        }
       },
       "freight": {
         "type": ["ParcelDelivery"],

--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -177,19 +177,19 @@ example: |-
             "type": [
               "GeoCoordinates"
             ],
-            "latitude": "-20.840731978309044",
-            "longitude": "-159.78393883134225"
+            "latitude": "41.50337024251974",
+            "longitude": "-99.38345352117118"
           },
           "address": {
             "type": [
               "PostalAddress"
             ],
-            "name": "Hahn LLC",
-            "streetAddress": "786 Pfeffer Plains",
-            "addressLocality": "West Ottilie",
+            "name": "Carrior Goods And More",
+            "streetAddress": "9101 W Dodge Rd",
+            "addressLocality": "Omaha",
             "addressRegion": "Nebraska",
-            "postalCode": "50878-0870",
-            "addressCountry": "Cook Islands"
+            "postalCode": "68114",
+            "addressCountry": "United States"
           }
         }
       },
@@ -208,19 +208,19 @@ example: |-
             "type": [
               "GeoCoordinates"
             ],
-            "latitude": "-20.840731978309044",
-            "longitude": "-159.78393883134225"
+            "latitude": "38.48348914310496",
+            "longitude": "-98.31598605848262"
           },
           "address": {
             "type": [
               "PostalAddress"
             ],
-            "name": "Hahn LLC",
-            "streetAddress": "786 Pfeffer Plains",
-            "addressLocality": "West Ottilie",
-            "addressRegion": "Nebraska",
-            "postalCode": "50878-0870",
-            "addressCountry": "Cook Islands"
+            "name": "Consignor Is Us",
+            "streetAddress": "220 S Main St",
+            "addressLocality": "Wichita",
+            "addressRegion": "Kansas",
+            "postalCode": "67202",
+            "addressCountry": "United States"
           }
         }
       },
@@ -239,19 +239,19 @@ example: |-
             "type": [
               "GeoCoordinates"
             ],
-            "latitude": "-20.840731978309044",
-            "longitude": "-159.78393883134225"
+            "latitude": "42.33526603746952",
+            "longitude": "-71.12159711569939"
           },
           "address": {
             "type": [
               "PostalAddress"
             ],
-            "name": "Hahn LLC",
-            "streetAddress": "786 Pfeffer Plains",
-            "addressLocality": "West Ottilie",
-            "addressRegion": "Nebraska",
-            "postalCode": "50878-0870",
-            "addressCountry": "Cook Islands"
+            "name": "Victorian Consignee",
+            "streetAddress": "361 Washington St",
+            "addressLocality": "Brookline",
+            "addressRegion": "Massachusetts",
+            "postalCode": "02445",
+            "addressCountry": "United States"
           }
         }
       },
@@ -270,19 +270,19 @@ example: |-
             "type": [
               "GeoCoordinates"
             ],
-            "latitude": "-20.840731978309044",
-            "longitude": "-159.78393883134225"
+            "latitude": "26.138581937299737",
+            "longitude": "-80.13053917016346"
           },
           "address": {
             "type": [
               "PostalAddress"
             ],
-            "name": "Hahn LLC",
-            "streetAddress": "786 Pfeffer Plains",
-            "addressLocality": "West Ottilie",
-            "addressRegion": "Nebraska",
-            "postalCode": "50878-0870",
-            "addressCountry": "Cook Islands"
+            "name": "Florida Contact Org",
+            "streetAddress": "1300 E Sunrise Blvd",
+            "addressLocality": "Fort Lauderdale",
+            "addressRegion": "Florida",
+            "postalCode": "33304",
+            "addressCountry": "United States"
           }
         }
       },
@@ -354,9 +354,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-29T07:01:00Z",
+      "created": "2022-11-29T07:37:53Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yv773IbYH0EyFXmdZ6EOKso2hrgV25h9-ylLGAslnizOt6DjhLddjFmjvukvs81kDS9vlzU7N-vzJHCi9eZgCQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..l1tV4AhrdeQYr4d9Iv8SAidHTQ4VUudwe8kA8BtC5JlxU2dlkCMFlqXPM9lDJaX3ApVd1kq2XBldBmsGL9VdCA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -166,7 +166,24 @@ example: |-
         ],
         "name": "Carrior Goods And More",
         "email": "Adaline29@example.com",
-        "phoneNumber": "+1 555-234-9983"
+        "phoneNumber": "+1 555-234-9983",
+        "location": {
+          "type": ["Place"],
+          "geo": {
+            "type": ["GeoCoordinates"],
+            "latitude": "-20.840731978309044",
+            "longitude": "-159.78393883134225"
+          },
+          "address": {
+            "type": ["PostalAddress"],
+            "name": "Hahn LLC",
+            "streetAddress": "786 Pfeffer Plains",
+            "addressLocality": "West Ottilie",
+            "addressRegion": "Nebraska",
+            "postalCode": "50878-0870",
+            "addressCountry": "Cook Islands"
+          }
+        }
       },
       "consignor": {
         "type": [
@@ -174,7 +191,24 @@ example: |-
         ],
         "name": "Consignor Is Us",
         "email": "Idella60@example.org",
-        "phoneNumber": "+1-555-953-9479"
+        "phoneNumber": "+1-555-953-9479",
+        "location": {
+          "type": ["Place"],
+          "geo": {
+            "type": ["GeoCoordinates"],
+            "latitude": "-20.840731978309044",
+            "longitude": "-159.78393883134225"
+          },
+          "address": {
+            "type": ["PostalAddress"],
+            "name": "Hahn LLC",
+            "streetAddress": "786 Pfeffer Plains",
+            "addressLocality": "West Ottilie",
+            "addressRegion": "Nebraska",
+            "postalCode": "50878-0870",
+            "addressCountry": "Cook Islands"
+          }
+        }
       },
       "consignee": {
         "type": [
@@ -182,7 +216,24 @@ example: |-
         ],
         "name": "Victorian Consignee",
         "email": "Victoria.Hane74@example.org",
-        "phoneNumber": "+1-555-455-9053"
+        "phoneNumber": "+1-555-455-9053",
+        "location": {
+          "type": ["Place"],
+          "geo": {
+            "type": ["GeoCoordinates"],
+            "latitude": "-20.840731978309044",
+            "longitude": "-159.78393883134225"
+          },
+          "address": {
+            "type": ["PostalAddress"],
+            "name": "Hahn LLC",
+            "streetAddress": "786 Pfeffer Plains",
+            "addressLocality": "West Ottilie",
+            "addressRegion": "Nebraska",
+            "postalCode": "50878-0870",
+            "addressCountry": "Cook Islands"
+          }
+        }
       },
       "notify": {
         "type": [
@@ -190,7 +241,24 @@ example: |-
         ],
         "name": "Florida Contact Org",
         "email": "Florida91@example.net",
-        "phoneNumber": "+1-555-104-1126"
+        "phoneNumber": "+1-555-104-1126",
+        "location": {
+          "type": ["Place"],
+          "geo": {
+            "type": ["GeoCoordinates"],
+            "latitude": "-20.840731978309044",
+            "longitude": "-159.78393883134225"
+          },
+          "address": {
+            "type": ["PostalAddress"],
+            "name": "Hahn LLC",
+            "streetAddress": "786 Pfeffer Plains",
+            "addressLocality": "West Ottilie",
+            "addressRegion": "Nebraska",
+            "postalCode": "50878-0870",
+            "addressCountry": "Cook Islands"
+          }
+        }
       },
       "freight": {
         "type": [

--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -147,7 +147,9 @@ example: |-
     "issuanceDate": "2019-12-11T03:50:55Z",
     "issuer": {
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "type": ["Organization"],
+      "type": [
+        "Organization"
+      ],
       "name": "Hauck Group",
       "description": "Focused secondary synergy",
       "email": "Bernita.Quitzon98@example.com",
@@ -168,14 +170,20 @@ example: |-
         "email": "Adaline29@example.com",
         "phoneNumber": "+1 555-234-9983",
         "location": {
-          "type": ["Place"],
+          "type": [
+            "Place"
+          ],
           "geo": {
-            "type": ["GeoCoordinates"],
+            "type": [
+              "GeoCoordinates"
+            ],
             "latitude": "-20.840731978309044",
             "longitude": "-159.78393883134225"
           },
           "address": {
-            "type": ["PostalAddress"],
+            "type": [
+              "PostalAddress"
+            ],
             "name": "Hahn LLC",
             "streetAddress": "786 Pfeffer Plains",
             "addressLocality": "West Ottilie",
@@ -193,14 +201,20 @@ example: |-
         "email": "Idella60@example.org",
         "phoneNumber": "+1-555-953-9479",
         "location": {
-          "type": ["Place"],
+          "type": [
+            "Place"
+          ],
           "geo": {
-            "type": ["GeoCoordinates"],
+            "type": [
+              "GeoCoordinates"
+            ],
             "latitude": "-20.840731978309044",
             "longitude": "-159.78393883134225"
           },
           "address": {
-            "type": ["PostalAddress"],
+            "type": [
+              "PostalAddress"
+            ],
             "name": "Hahn LLC",
             "streetAddress": "786 Pfeffer Plains",
             "addressLocality": "West Ottilie",
@@ -218,14 +232,20 @@ example: |-
         "email": "Victoria.Hane74@example.org",
         "phoneNumber": "+1-555-455-9053",
         "location": {
-          "type": ["Place"],
+          "type": [
+            "Place"
+          ],
           "geo": {
-            "type": ["GeoCoordinates"],
+            "type": [
+              "GeoCoordinates"
+            ],
             "latitude": "-20.840731978309044",
             "longitude": "-159.78393883134225"
           },
           "address": {
-            "type": ["PostalAddress"],
+            "type": [
+              "PostalAddress"
+            ],
             "name": "Hahn LLC",
             "streetAddress": "786 Pfeffer Plains",
             "addressLocality": "West Ottilie",
@@ -243,14 +263,20 @@ example: |-
         "email": "Florida91@example.net",
         "phoneNumber": "+1-555-104-1126",
         "location": {
-          "type": ["Place"],
+          "type": [
+            "Place"
+          ],
           "geo": {
-            "type": ["GeoCoordinates"],
+            "type": [
+              "GeoCoordinates"
+            ],
             "latitude": "-20.840731978309044",
             "longitude": "-159.78393883134225"
           },
           "address": {
-            "type": ["PostalAddress"],
+            "type": [
+              "PostalAddress"
+            ],
             "name": "Hahn LLC",
             "streetAddress": "786 Pfeffer Plains",
             "addressLocality": "West Ottilie",
@@ -328,9 +354,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-14T13:54:28Z",
+      "created": "2022-11-29T07:01:00Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..AGCDysH5NGBJpBCw3_P5ZAQkv2Sqs_l6Vs45JKtVEVKfNKfQq6xw4eJ6Gsfj8Rq3HxF4nSLEujR9MV7b_J6-DA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yv773IbYH0EyFXmdZ6EOKso2hrgV25h9-ylLGAslnizOt6DjhLddjFmjvukvs81kDS9vlzU7N-vzJHCi9eZgCQ"
     }
   }


### PR DESCRIPTION
Removing more optionality from bill of lading. We don't want objects like address to be optional. Either the address is required and it's part of the form, otherwise it's not required and not included. 

Related to: https://github.com/w3c-ccg/traceability-vocab/issues/637 for examples being non-spanning. 