### PR TITLE
Narrowly define schema for commercial invoice

### DIFF
--- a/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
@@ -95,7 +95,278 @@ properties:
       - type
       - name
   credentialSubject:
-    $ref: ../common/Invoice.yml
+    title: Invoice
+    description: A statement of the money due for goods or services; a bill.
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - Invoice
+        default:
+          - Invoice
+        items:
+          type: string
+          enum:
+            - Invoice
+      identifier:
+        title: Property Identifier
+        description: Identifiers for a property.
+        type: string
+      invoiceNumber:
+        title: Invoice Number
+        description: Invoice Number.
+        type: string
+      customerReferenceNumber: 
+        title: Customer's Reference Number
+        description: Oversees customer’s reference number.
+        type: string
+      billOfLadingNumber:
+        title: Bill of Lading Number
+        description: Carrier-issued number for the associated Bill of Lading or Waybill. 
+        type: string
+      letterOfCreditNumber:
+        title: Letter of Credit Number
+        description: A letter of credit document referenced in the trade agreement or settlement.
+        type: string
+      portOfEntry:
+        title: Port Of Entry
+        description: Port where the purchased goods will enter first.
+        $ref: ../common/Place.yml
+      originCountry:
+        title: Origin Country
+        description: A country of origin for the consignment, consignment item, or product.
+        type: string
+      destinationCountry:
+        title: Destination Country
+        description: Country to which the purchased product will be delivered
+        type: string
+      invoiceDate:
+        title: Invoice Date
+        description: A date, time, date time, or other date time value of the invoice in the trade settlement.
+        type: string
+      purchaseDate:
+        title: Purchase Date
+        description: The date that payment is made.
+        type: string
+      seller: 
+        title: Seller
+        description: An entity which offers (sells, leases, lends, or loans) the services or goods. A seller may also be a provider.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Organization
+            default:
+              - Organization
+            items:
+              type: string
+              enum:
+                - Organization
+          id:
+            title: Identifier
+            description: Identifier for the seller
+            type: string
+          name:
+            title: Name
+            description: Name of the seller
+            type: string
+          url:
+            title: URL
+            description: URL of the seller
+            type: string
+          description:
+            title: Description
+            description: Description of the seller
+            type: string
+          email:
+            title: Email Address
+            description: Seller's primary email address.
+            type: string
+          phoneNumber:
+            title: Phone Number
+            description: Seller's contact phone number.
+            type: string
+          location:
+            title: Location
+            description: Seller's physical location, such as address or coordinates.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - Place
+                default:
+                  - Place
+                items:
+                  type: string
+                  enum:
+                    - Place
+              geo:
+                title: Geographic Coordinates
+                description: Links to information about geocoordinates for a place.
+                $ref: ../common/GeoCoordinates.yml
+              address:
+                title: Postal Address
+                description: The postal address for an organization or place.
+                $ref: ../common/PostalAddress.yml
+            additionalProperties: false
+            required:
+              - type
+        additionalProperties: false
+        required:
+          - type
+      buyer:
+        title: Buyer
+        description: Importer of record. Party placing the order or paying the invoice.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Organization
+            default:
+              - Organization
+            items:
+              type: string
+              enum:
+                - Organization
+          id:
+            title: Identifier
+            description: Identifier for the buyer
+            type: string
+          name:
+            title: Name
+            description: Name of the buyer
+            type: string
+          url:
+            title: URL
+            description: URL of the buyer
+            type: string
+          description:
+            title: Description
+            description: Description of the buyer
+            type: string
+          email:
+            title: Email Address
+            description: Buyer's primary email address.
+            type: string
+          phoneNumber:
+            title: Phone Number
+            description: Buyer's contact phone number.
+            type: string
+          location:
+            title: Location
+            description: Buyer's physical location, such as address or coordinates.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - Place
+                default:
+                  - Place
+                items:
+                  type: string
+                  enum:
+                    - Place
+              geo:
+                title: Geographic Coordinates
+                description: Links to information about geocoordinates for a place.
+                $ref: ../common/GeoCoordinates.yml
+              address:
+                title: Postal Address
+                description: The postal address for an organization or place.
+                $ref: ../common/PostalAddress.yml
+            additionalProperties: false
+            required:
+              - type
+        additionalProperties: false
+        required:
+          - type
+      itemsShipped:
+        title: Items Shipped
+        description: Itemized list of shipped goods.
+        type: array
+        items:
+          $ref: ../common/TradeLineItem.yml
+      comments:
+        title: Comments
+        description: Free text comments. 
+        type: array
+        items:
+          type: string
+      packageQuantity:
+        title: Package Quantity
+        description: Total number of packages.
+        type: number
+      totalWeight:
+        title: Total Weight
+        description: Total weight of the products.
+        $ref: ../common/QuantitativeValue.yml
+      termsOfDelivery: 
+        title: Terms of Delivery
+        description: The conditions agreed upon between the parties with regard to the delivery of goods and or services.
+        type: string
+      termsOfPayment: 
+        title: Terms of Payment
+        description: Terms, conditions, and currency of settlement, as agreed upon by the vendor and purchaser per the pro forma invoice, customer purchase order, and/or the letter of credit.
+        type: string
+      currencyOfSettlement: 
+        title: Terms of Settlement
+        description: Currency agreed upon between seller and buyer as payment.
+        type: string
+      invoiceSubtotal:
+        title: Invoice Subtotal
+        description: The subtotal of line items.
+        $ref: ../common/PriceSpecification.yml
+      discounts: 
+        title: Discounts
+        description: Applicable discounts.
+        type: array
+        items: 
+          $ref: ../common/PriceSpecification.yml
+      deductions: 
+        title: Additions
+        description: Applicable additions.
+        type: array
+        items: 
+          $ref: ../common/PriceSpecification.yml
+      tax: 
+        title: Tax
+        description: Applicable tax.
+        $ref: ../common/PriceSpecification.yml
+      freightCost: 
+        title: Freight Cost
+        description: Included cost of freight.
+        $ref: ../common/PriceSpecification.yml
+      insuranceCost: 
+        title: Freight Cost
+        description: Included cost of insurance.
+        $ref: ../common/PriceSpecification.yml
+      totalPaymentDue:
+        title: Total Payment Due
+        description: The total amount due.
+        $ref: ../common/PriceSpecification.yml
+      referencesOrder: 
+        title: References Order
+        description: The Order(s) related to this Invoice. One or more Orders may be combined into a single Invoice.
+        type: array
+        items: 
+          type: string
+    additionalProperties: false
+    required:
+      - type
+      - seller
+      - buyer
+      - itemsShipped
+      - totalPaymentDue
   proof:
     $ref: ../snippets/proof.yml
   relatedLink:
@@ -186,6 +457,13 @@ example: |-
           "type": [
             "Place"
           ],
+          "geo": {
+            "type": [
+              "GeoCoordinates"
+            ],
+            "latitude": "42.362317531471845",
+            "longitude": "-83.21923339315515"
+          },
           "address": {
             "type": [
               "PostalAddress"
@@ -346,9 +624,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-15T08:18:10Z",
+      "created": "2022-11-29T13:22:24Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..7chlSvwn-wDwPHjSHxenOxVVRt3Pi9tIdAr8JSe_aODuzbcj-OY5CFmjKy-CJy0oM_mIQg3X044Q8gZ7DyC1BA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..WHMxmHoV2nMu13RCd6X2kFE84GDSkryWKG7jztCFa95Cd_RdJmU6tkoW_KiQ5C9foFowI3XBszyUiCwdAUtECg"
     }
   }


### PR DESCRIPTION
For the commercial invoice certificate, we are including `exporter`, `importer`, `shipFromParty`, `shipToParty`, `provider`. Which provides too much flexibility for a single credential type. To accommodate these situations we can define more invoice types. 