### PR TITLE
Fix InspectionReport.yml syntax

### DIFF
--- a/docs/openapi/components/schemas/common/InspectionReport.yml
+++ b/docs/openapi/components/schemas/common/InspectionReport.yml
@@ -26,7 +26,8 @@ properties:
   inspectors:
     title: inspectors
     description: Persons responsible for identifying and documenting the observations.
-    type: array
+    items:
+      $ref: ./Person.yml
     $linkedData:
       term: inspectors
       '@id': https://schema.org/Person

--- a/docs/openapi/components/schemas/common/InspectionReport.yml
+++ b/docs/openapi/components/schemas/common/InspectionReport.yml
@@ -26,6 +26,7 @@ properties:
   inspectors:
     title: inspectors
     description: Persons responsible for identifying and documenting the observations.
+    type: array
     items:
       $ref: ./Person.yml
     $linkedData:

--- a/docs/openapi/components/schemas/common/InspectionReport.yml
+++ b/docs/openapi/components/schemas/common/InspectionReport.yml
@@ -67,15 +67,18 @@ example: |-
             "type": ["Organization"],
             "name": "IRON APPROVERS INC.",
             "description": "Inpsections for Iron Commodities",
-            "address": {
+            "location": {
+              "type": ["Place"],
+              "address": {
                 "@type": ["PostalAddress"],
                 "streetAddress": "21 Jump Street",
                 "addressLocality": "Salem",
                 "addressRegion": "Oregon",
                 "postalCode": "21445",
                 "addressCountry": "US"
+              }
             }
-        },
+          },
         "jobTitle": "Cheif Inspector"
       },
       {
@@ -89,15 +92,18 @@ example: |-
             "globalLocationNumber": "3348622345363",
             "name": "IRON APPROVERS INC.",
             "description": "Inpsections for Iron Commodities",
-            "address": {
-                "type": ["PostalAddress"],
-                "streetAddress": "76468 Jump Street",
-                "addressLocality": "Salem",
-                "addressRegion": "Oregon",
-                "postalCode": "21445",
-                "addressCountry": "US"
+            "location": {
+              "type": ["Place"],
+              "address": {
+                  "type": ["PostalAddress"],
+                  "streetAddress": "76468 Jump Street",
+                  "addressLocality": "Salem",
+                  "addressRegion": "Oregon",
+                  "postalCode": "21445",
+                  "addressCountry": "US"
+              }
             }
-        },
+          },
         "jobTitle": "Chemical Specialist"
       }
     ],

--- a/docs/openapi/components/schemas/common/InspectionReport.yml
+++ b/docs/openapi/components/schemas/common/InspectionReport.yml
@@ -70,7 +70,7 @@ example: |-
             "location": {
               "type": ["Place"],
               "address": {
-                "@type": ["PostalAddress"],
+                "type": ["PostalAddress"],
                 "streetAddress": "21 Jump Street",
                 "addressLocality": "Salem",
                 "addressRegion": "Oregon",

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -288,6 +288,40 @@ example: |-
           "type": [
             "InspectionReport"
           ],
+          "inspectors": [
+            {
+              "type": [
+                "Person"
+              ],
+              "firstName": "John",
+              "lastName": "Doe",
+              "email": "john@doe.com",
+              "phoneNumber": "555-615-4231",
+              "worksFor": {
+                "type": [
+                  "Organization"
+                ],
+                "name": "IRON APPROVERS INC.",
+                "description": "Inpsections for Iron Commodities",
+                "location": {
+                  "type": [
+                    "Place"
+                  ],
+                  "address": {
+                    "type": [
+                      "PostalAddress"
+                    ],
+                    "streetAddress": "21 Jump Street",
+                    "addressLocality": "Salem",
+                    "addressRegion": "Oregon",
+                    "postalCode": "21445",
+                    "addressCountry": "US"
+                  }
+                }
+              },
+              "jobTitle": "Cheif Inspector"
+            }
+          ],
           "observation": [
             {
               "type": [
@@ -657,9 +691,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-29T14:31:08Z",
+      "created": "2022-12-06T09:12:16Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..peTRkBvkYqxWqSsPBlHMOdJv5XoAUBqoRXVZW0XCd2h6dv7Wzwy262uykGhMp6yB2CDf9rfdKUzXYGOxhma7Cg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..5TaDOB7DUIT27iEtmtpaXz8Se5zbagMPiw607MwNmF-ga_nbQMLBiHAzQE6a9N8YvZ6p6mAoiZhfdz9QvqqJCA"
     }
   }


### PR DESCRIPTION
For `inspectors` an array was being defined without defining any items. Previously wasn't caught because our examples are a subset of our schemas. https://github.com/w3c-ccg/traceability-vocab/issues/637