### PR TITLE
Replace "Entity" in inspection schemas

### DIFF
--- a/docs/openapi/components/schemas/common/USDAPPQ391SpecimensForDetermination.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ391SpecimensForDetermination.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: USDAPPQ309APestInterceptionRecord
-  '@id': https://w3id.org/traceability#USDAPPQ309APestInterceptionRecord
-title: USDA PPQ 309A Pest Interception Record
+  term: USDAPPQ391SpecimensForDetermination
+  '@id': https://w3id.org/traceability#USDAPPQ391SpecimensForDetermination
+title: USDA PPQ 391 Specimens for Determination
 description: A record describing a pest sample submitted to a USDA APHIS (Animal and Plant Health Inspection Service) PPQ (Plant Protection and Quarantine) office as well as the findings of the recipient lab.
 type: object
 properties:
@@ -9,13 +9,13 @@ properties:
     type: array
     readOnly: true
     const:
-      - USDAPPQ309APestInterceptionRecord
+      - USDAPPQ391SpecimensForDetermination
     default:
-      - USDAPPQ309APestInterceptionRecord
+      - USDAPPQ391SpecimensForDetermination
     items:
       type: string
       enum:
-        - USDAPPQ309APestInterceptionRecord
+        - USDAPPQ391SpecimensForDetermination
   priority:
     title: Priority
     description: "The priority of the determination. Must be one of: Urgent, Prompt, Routine."
@@ -155,7 +155,7 @@ required:
   - type
 example: |-
   {
-    "type": ["USDAPPQ309APestInterceptionRecord"],
+    "type": ["USDAPPQ391SpecimensForDetermination"],
     "priority": "Prompt",
     "priorityExplanation": "Samples exected to decay within a week",
     "collectionNumber": "21-RTH-80",


### PR DESCRIPTION
This PR replaces `Entity` in ag inspection schemas with `Person` or `Organization`. Two naming issues are also addressed (an incorrect file name and an incorrect schema term).