### PR TITLE
Rename organic certificate to organic certification

### DIFF
--- a/docs/openapi/components/schemas/common/OrganicCertification.yml
+++ b/docs/openapi/components/schemas/common/OrganicCertification.yml
@@ -1,6 +1,6 @@
 $linkedData:
-  term: OrganicCertificate
-  '@id': https://w3id.org/traceability#OrganicCertificate
+  term: OrganicCertification
+  '@id': https://w3id.org/traceability#OrganicCertification
 title: Organic Certificate
 description: Information regarding the organic certificate.
 type: object
@@ -9,13 +9,13 @@ properties:
     type: array
     readOnly: true
     const:
-      - OrganicCertificate
+      - OrganicCertification
     default:
-      - OrganicCertificate
+      - OrganicCertification
     items:
       type: string
       enum:
-        - OrganicCertificate
+        - OrganicCertification
   countryOfIssuance:
     title: Country of Issuance
     description: The country issuing the organic certificate. This value should be a two letter country code as defined in ISO 3166 (e.g., "US" for United States, "CA" for Canada).
@@ -79,7 +79,7 @@ required:
   - type
 example: |-
   {
-    "type": ["OrganicCertificate"],
+    "type": ["OrganicCertification"],
     "countryOfIssuance": "US",
     "certifiedOperation": {
       "type": ["Organization"],

--- a/docs/openapi/components/schemas/common/OrganicProductCertification.yml
+++ b/docs/openapi/components/schemas/common/OrganicProductCertification.yml
@@ -23,12 +23,12 @@ properties:
     $linkedData:
       term: agricultureProduct
       '@id': https://www.gs1.org/voc/certificationSubject
-  organicCertificate:
+  organicCertification:
     title: Organic Certificate
-    description: The product's organic certificate.
-    $ref: ./OrganicCertificate.yml
+    description: The product's organic certification.
+    $ref: ./OrganicCertification.yml
     $linkedData:
-      term: organicCertificate
+      term: organicCertification
       '@id': https://www.gs1.org/voc/certification
   isCertified:
     title: Is Certified
@@ -86,8 +86,8 @@ example: |-
       "productImageUrl": "https://img.example.org/102934920857/937/903/",
       "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
     },
-    "organicCertificate": {
-      "type": ["OrganicCertificate"],
+    "organicCertification": {
+      "type": ["OrganicCertification"],
       "certifiedOperation": {
         "type": ["Organization"],
         "name": "John's Produce",

--- a/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
@@ -1,6 +1,6 @@
 $linkedData:
-  term: OrganicCertificateCredential
-  '@id': https://w3id.org/traceability#OrganicCertificateCredential
+  term: OrganicCertificationCredential
+  '@id': https://w3id.org/traceability#OrganicCertificationCredential
 title: Organic Certificate Credential
 tags:
   - Agriculture
@@ -35,15 +35,15 @@ properties:
     readOnly: true
     const:
       - VerifiableCredential
-      - OrganicCertificateCredential
+      - OrganicCertificationCredential
     default:
       - VerifiableCredential
-      - OrganicCertificateCredential
+      - OrganicCertificationCredential
     items:
       type: string
       enum:
         - VerifiableCredential
-        - OrganicCertificateCredential
+        - OrganicCertificationCredential
   id:
     type: string
   name:
@@ -57,7 +57,7 @@ properties:
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:
-    $ref: ../common/OrganicCertificate.yml
+    $ref: ../common/OrganicCertification.yml
   proof:
     $ref: ../snippets/proof.yml
   relatedLink:
@@ -82,7 +82,7 @@ example: |-
     "id": "https://example.com/credential/123",
     "type": [
       "VerifiableCredential",
-      "OrganicCertificateCredential"
+      "OrganicCertificationCredential"
     ],
     "name": "Organic Certificate Credential",
     "issuanceDate": "2021-12-11T03:50:55Z",
@@ -114,7 +114,7 @@ example: |-
     },
     "credentialSubject": {
       "type": [
-        "OrganicCertificate"
+        "OrganicCertification"
       ],
       "countryOfIssuance": "US",
       "certifiedOperation": {
@@ -172,9 +172,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-04T20:37:55Z",
+      "created": "2022-12-13T08:08:58Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..frl6jjb0DKpZLHjD1IbUlYlUNU8it0ITtFYQa98o0uOn3z-K1kqZrAM3kV_LrRdTzMlNN4_YKjxIqH5dzXTvDQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..XDdhNKT7Sfd2LnqIqrQv2lppgdG-Umnmzoc4RLee01SN-P0nn567ielhXjzVb0CVGm1BPp_C8vRBl7x1EwwwAw"
     }
   }

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -1196,7 +1196,7 @@ paths:
                 $ref: './components/schemas/common/OrderItem.yml'
     
 
-  /schemas/common/OrganicCertificate.yml:
+  /schemas/common/OrganicCertification.yml:
     get:
       tags:
       - common
@@ -1205,7 +1205,7 @@ paths:
           content:
             application/yml:
               schema:
-                $ref: './components/schemas/common/OrganicCertificate.yml'
+                $ref: './components/schemas/common/OrganicCertification.yml'
     
 
   /schemas/common/OrganicInspection.yml:


### PR DESCRIPTION
This PR renames organic certificate, as suggested in https://github.com/w3c-ccg/traceability-vocab/issues/616.