### PR TITLE
Create PPQ587, Application for Permit to Import Plants or Plant Products

### DIFF
--- a/docs/openapi/components/schemas/common/AgricultureProduct.yml
+++ b/docs/openapi/components/schemas/common/AgricultureProduct.yml
@@ -50,9 +50,16 @@ properties:
     $linkedData:
       term: gtin
       '@id': https://www.gs1.org/voc/gtin
+  countryOfOrigin:
+    title: Country of Origin
+    description: The country in which this product originated.
+    type: string
+    $linkedData:
+      term: countryOfOrigin
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#originCountry
   product:
     title: Product
-    description: Product details as specified in the Product schema
+    description: Product details as specified in the Product schema.
     $ref: ./Product.yml
     $linkedData:
       term: product
@@ -66,10 +73,17 @@ properties:
     type: string
     $linkedData:
       term: scientificName
-      '@id': https://w3id.org/traceability#scientificName
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#scientificName
+  plantParts:
+    title: Plant Parts
+    description: If applicable, the type of plant parts this product consists of (seeds, cuttings, rhizomes, plants, bulbs, fruits, etc.).
+    type: string
+    $linkedData:
+      term: plantParts
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#description
   labelImageUrl:
     title: Label Image URL
-    description: Image of the package label
+    description: Image of the package label.
     type: string
     $linkedData:
       term: labelImageUrl
@@ -115,6 +129,7 @@ example: |-
     "upc": "033383401508",
     "plu": "94225",
     "gtin": "033383401508",
+    "countryOfOrigin": "United States",
     "product": {
       "type": ["Product"],
       "manufacturer": {
@@ -144,6 +159,7 @@ example: |-
       "sku": "71266019767"
     },
     "scientificName": "Persea americana",
+    "plantParts": "fruit",
     "labelImageUrl": "https://img.example.org/033383401508/640/480/",
     "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "name": "Avocados",

--- a/docs/openapi/components/schemas/common/USDAPPQ587PlantImportApplication.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ587PlantImportApplication.yml
@@ -34,14 +34,14 @@ properties:
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedProduct
   intendedUse:
     title: Intended Use
-    description: 'The intended use for these plants or plant products, such as: "Plants for planting (Nursery stock)"; "Small lots of seed"; "Fruit and vegetables", or other.'
+    description: 'The intended use for these plants or plant products, such as: "Plants for planting (Nursery stock)"; "Small lots of seed"; "Fruit and vegetables"; or other.'
     type: string
     $linkedData:
       term: intendedUse
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#intendedUse
   meansOfTransportation:
     title: Means of Transportation
-    description: 'The means of transportation for these plants or plant products, such as: "Mail or Express carrier"; "Cargo shipment"; "Personal baggage or car", or other.'
+    description: 'The means of transportation for these plants or plant products, such as: "Mail or Express carrier"; "Cargo shipment"; "Personal baggage or car"; or other.'
     type: string
     $linkedData:
       term: meansOfTransportation

--- a/docs/openapi/components/schemas/common/USDAPPQ587PlantImportApplication.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ587PlantImportApplication.yml
@@ -1,0 +1,132 @@
+$linkedData:
+  term: USDAPPQ587PlantImportApplication
+  '@id': https://w3id.org/traceability#USDAPPQ587PlantImportApplication
+title: USDA PPQ 587 Application for Permit to Import Plants or Plant Products
+description: USDA APHIS (Animal and Plant Health Inspection Service) PPQ (Plant Protection and Quarantine) 587, Application for Permit to Import Plants or Plant Products.
+type: object
+properties:
+  type:
+    type: array
+    readOnly: true
+    const:
+      - USDAPPQ587PlantImportApplication
+    default:
+      - USDAPPQ587PlantImportApplication
+    items:
+      type: string
+      enum:
+        - USDAPPQ587PlantImportApplication
+  applicant:
+    title: Applicant
+    description: Details regarding the person responsible for the importation. Applicant must be a United States resident. Include the organization name and address, if applicable.
+    $ref: ./Person.yml
+    $linkedData:
+      term: applicant
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#associatedParty
+  plantProductsImported:
+    title: Plants or Plant Products to be Imported
+    description: Details regarding the plants or plant products to be imported
+    type: array
+    items:
+      $ref: ./AgricultureProduct.yml
+    $linkedData:
+      term: plantProductsImported
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#specifiedProduct
+  intendedUse:
+    title: Intended Use
+    description: 'The intended use for these plants or plant products, such as: "Plants for planting (Nursery stock)"; "Small lots of seed"; "Fruit and vegetables", or other.'
+    type: string
+    $linkedData:
+      term: intendedUse
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#intendedUse
+  meansOfTransportation:
+    title: Means of Transportation
+    description: 'The means of transportation for these plants or plant products, such as: "Mail or Express carrier"; "Cargo shipment"; "Personal baggage or car", or other.'
+    type: string
+    $linkedData:
+      term: meansOfTransportation
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#usedTransportMeans
+  date:
+    title: Date
+    description: The date of completion for this application.
+    type: string
+    $linkedData:
+      term: date
+      '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#creationDateTime
+additionalProperties: false
+required:
+  - type
+example: |-
+  {
+    "type": ["USDAPPQ587PlantImportApplication"],
+    "applicant": {
+      "type": [
+        "Person"
+      ],
+      "firstName": "Jocelyn",
+      "lastName": "Grates",
+      "email": "jgrates@example.com",
+      "phoneNumber": "+1-460-555-4373",
+      "worksFor": {
+        "type": [
+          "Organization"
+        ],
+        "name": "New Fields Foodstuff logistics",
+        "description": "Agricultural goods distribution",
+        "email": "contact@example.net",
+        "phoneNumber": "+1-521-555-6143",
+        "faxNumber": "+1-150-555-7668"
+      },
+      "jobTitle": "Principal Data Supervisor"
+    },
+    "plantProductsImported": [
+      {
+        "type": [
+          "AgricultureProduct"
+        ],
+        "upc": "033383401508",
+        "plu": "94225",
+        "gtin": "033383401508",
+        "countryOfOrigin": "United States",
+        "product": {
+          "type": [
+            "Product"
+          ],
+          "manufacturer": {
+            "type": [
+              "Organization"
+            ],
+            "email": "Ashlee.Grady@example.net",
+            "phoneNumber": "+1-899-555-1399"
+          },
+          "name": "Avocados",
+          "description": "Avocados, 4 pack boxes",
+          "sizeOrAmount": {
+            "type": [
+              "QuantitativeValue"
+            ],
+            "unitCode": "hg/ha",
+            "value": "60"
+          },
+          "weight": {
+            "type": [
+              "QuantitativeValue"
+            ],
+            "unitCode": "hg/ha",
+            "value": "6960"
+          },
+          "sku": "81055399441"
+        },
+        "plantParts": "fruit",
+        "scientificName": "Persea americana",
+        "labelImageUrl": "https://img.example.org/033383401508/640/480/",
+        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "name": "Avocados",
+        "productImageUrl": "https://img.example.org/102934920857/937/903/",
+        "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+      }
+    ],
+    "intendedUse": "Fruits and vegetables",
+    "meansOfTransportation": "Cargo shipment",
+    "date": "2022-08-10"
+  }

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
@@ -556,9 +556,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-29T02:13:59Z",
+      "created": "2022-12-15T20:37:36Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..jQU2H1WXqhONwyd1qyr8M-kl3h6nGhQlNunPy-mQ2JJgJotpqKovySHrSx1VQw7rsuMMmNdCU_AgzBXfGRlQCQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BY0ns1R0r9TeSo_fm5qeloghhxym1osoD01dDu2JEYRZC40lN_mPa5zJ1E-dcXyDmOT5lejIeb3N8lFrTqCNBw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
@@ -358,9 +358,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-29T02:14:02Z",
+      "created": "2022-12-15T20:37:39Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..TxrZrTho0gE7XhfFkqLZ44UBTEeeRnMGlHXElyr4ucZ9xv8PmExPSV2ybGgzyCvffedPq4l-waXe_jzbhFCoDw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..usTdO_ygF5G2AskWlOrupLYldR5fzy-VJOelwsw3rWxP5Ropwb0hlBEgKbzL1ky9FSdL8jFLWF4MfLc5tz54BQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
@@ -305,9 +305,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-29T02:13:57Z",
+      "created": "2022-12-15T20:37:47Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HYOdOfM1e_8ZfT9zEtehmAPgpsFL-XPHCRtM9-_Y2KK_1ic4hA5B7didMUf82dBlIaos0HRPsBxcfXbidQXTAA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..0_wlfQoFQmnv3ve6UQPjqp7nZN9GIPwsL1Eyu5AAnnSq4kKYWb9FZ34NGnevujpbAk3huTHGfsyyk3XpWA5wDA"
     }
   }

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -1904,6 +1904,18 @@ paths:
                 $ref: './components/schemas/common/USDAPPQ519ComplianceAgreement.yml'
     
 
+  /schemas/common/USDAPPQ587PlantImportApplication.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/USDAPPQ587PlantImportApplication.yml'
+    
+
   /schemas/common/USDAPPQ587PlantImportPermit.yml:
     get:
       tags:


### PR DESCRIPTION
This PR creates a schema for ppq 587,  Application for Permit to Import Plants or Plant Products. `AgricultureProduct` is also altered to better integrate it into `USDAPPQ587PlantImportApplication`.

For reference:
https://www.aphis.usda.gov/library/forms/pdf/PPQ587.pdf