### PR TITLE
Removing geo coordinates from Bill Of Lading

### DIFF
--- a/docs/openapi/components/schemas/common/BillOfLading.yml
+++ b/docs/openapi/components/schemas/common/BillOfLading.yml
@@ -112,10 +112,6 @@ properties:
               type: string
               enum:
                 - Place
-          geo:
-            title: Geographic Coordinates
-            description: Links to information about geocoordinates for a place.
-            $ref: ./GeoCoordinates.yml
           address:
             title: Postal Address
             description: The postal address for an organization or place.
@@ -191,10 +187,6 @@ properties:
               type: string
               enum:
                 - Place
-          geo:
-            title: Geographic Coordinates
-            description: Links to information about geocoordinates for a place.
-            $ref: ./GeoCoordinates.yml
           address:
             title: Postal Address
             description: The postal address for an organization or place.
@@ -263,10 +255,6 @@ properties:
               type: string
               enum:
                 - Place
-          geo:
-            title: Geographic Coordinates
-            description: Links to information about geocoordinates for a place.
-            $ref: ./GeoCoordinates.yml
           address:
             title: Postal Address
             description: The postal address for an organization or place.
@@ -338,10 +326,6 @@ properties:
               type: string
               enum:
                 - Place
-          geo:
-            title: Geographic Coordinates
-            description: Links to information about geocoordinates for a place.
-            $ref: ./GeoCoordinates.yml
           address:
             title: Postal Address
             description: The postal address for an organization or place.
@@ -414,10 +398,6 @@ properties:
               type: string
               enum:
                 - Place
-          geo:
-            title: Geographic Coordinates
-            description: Links to information about geocoordinates for a place.
-            $ref: ./GeoCoordinates.yml
           address:
             title: Postal Address
             description: The postal address for an organization or place.
@@ -431,7 +411,7 @@ properties:
       '@id': >-
         https://service.unece.org/trade/uncefact/vocabulary/uncefact/#freightForwarderParty
   freight:
-    title: 'Freight '
+    title: Freight
     description: Content described by the bill of lading
     $ref: ./ParcelDelivery.yml
     $linkedData:
@@ -494,11 +474,6 @@ example: |-
       "phoneNumber": "+1 555-234-9983",
       "location": {
         "type": ["Place"],
-        "geo": {
-          "type": ["GeoCoordinates"],
-          "latitude": "-20.840731978309044",
-          "longitude": "-159.78393883134225"
-        },
         "address": {
           "type": ["PostalAddress"],
           "name": "Hahn LLC",
@@ -517,11 +492,6 @@ example: |-
       "phoneNumber": "+1-555-953-9479",
       "location": {
         "type": ["Place"],
-        "geo": {
-          "type": ["GeoCoordinates"],
-          "latitude": "-20.840731978309044",
-          "longitude": "-159.78393883134225"
-        },
         "address": {
           "type": ["PostalAddress"],
           "name": "Hahn LLC",
@@ -540,11 +510,6 @@ example: |-
       "phoneNumber": "+1-555-455-9053",
       "location": {
         "type": ["Place"],
-        "geo": {
-          "type": ["GeoCoordinates"],
-          "latitude": "-20.840731978309044",
-          "longitude": "-159.78393883134225"
-        },
         "address": {
           "type": ["PostalAddress"],
           "name": "Hahn LLC",
@@ -563,11 +528,6 @@ example: |-
       "phoneNumber": "+1-555-104-1126",
       "location": {
         "type": ["Place"],
-        "geo": {
-          "type": ["GeoCoordinates"],
-          "latitude": "-20.840731978309044",
-          "longitude": "-159.78393883134225"
-        },
         "address": {
           "type": ["PostalAddress"],
           "name": "Hahn LLC",
@@ -583,11 +543,6 @@ example: |-
       "type": ["ParcelDelivery"],
       "deliveryAddress": {
         "type": ["Place"],
-        "geo": {
-          "type": ["GeoCoordinates"],
-          "latitude": "-20.840731978309044",
-          "longitude": "-159.78393883134225"
-        },
         "address": {
           "type": ["PostalAddress"],
           "name": "Hahn LLC",
@@ -600,11 +555,6 @@ example: |-
       },
       "originAddress": {
         "type": ["Place"],
-        "geo": {
-          "type": ["GeoCoordinates"],
-          "latitude": "-23.25979250428427",
-          "longitude": "-58.36431415044023"
-        },
         "address": {
           "type": ["PostalAddress"],
           "name": "Rosenbaum, Hills and Pagac",

--- a/docs/openapi/components/schemas/common/OGBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/OGBillOfLading.yml
@@ -130,11 +130,6 @@ example: |-
         "phoneNumber": "+1 555-234-9983",
         "location": {
           "type": ["Place"],
-          "geo": {
-            "type": ["GeoCoordinates"],
-            "latitude": "-20.840731978309044",
-            "longitude": "-159.78393883134225"
-          },
           "address": {
             "type": ["PostalAddress"],
             "name": "Hahn LLC",
@@ -155,11 +150,6 @@ example: |-
         "phoneNumber": "555-953-9479",
         "location": {
           "type": ["Place"],
-          "geo": {
-            "type": ["GeoCoordinates"],
-            "latitude": "-20.840731978309044",
-            "longitude": "-159.78393883134225"
-          },
           "address": {
             "type": ["PostalAddress"],
             "name": "Hahn LLC",
@@ -180,11 +170,6 @@ example: |-
         "phoneNumber": "555-455-9053",
         "location": {
           "type": ["Place"],
-          "geo": {
-            "type": ["GeoCoordinates"],
-            "latitude": "-20.840731978309044",
-            "longitude": "-159.78393883134225"
-          },
           "address": {
             "type": ["PostalAddress"],
             "name": "Hahn LLC",
@@ -205,11 +190,6 @@ example: |-
         "phoneNumber": "555-104-1126",
         "location": {
           "type": ["Place"],
-          "geo": {
-            "type": ["GeoCoordinates"],
-            "latitude": "-20.840731978309044",
-            "longitude": "-159.78393883134225"
-          },
           "address": {
             "type": ["PostalAddress"],
             "name": "Hahn LLC",

--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -173,13 +173,6 @@ example: |-
           "type": [
             "Place"
           ],
-          "geo": {
-            "type": [
-              "GeoCoordinates"
-            ],
-            "latitude": "41.50337024251974",
-            "longitude": "-99.38345352117118"
-          },
           "address": {
             "type": [
               "PostalAddress"
@@ -204,13 +197,6 @@ example: |-
           "type": [
             "Place"
           ],
-          "geo": {
-            "type": [
-              "GeoCoordinates"
-            ],
-            "latitude": "38.48348914310496",
-            "longitude": "-98.31598605848262"
-          },
           "address": {
             "type": [
               "PostalAddress"
@@ -235,13 +221,6 @@ example: |-
           "type": [
             "Place"
           ],
-          "geo": {
-            "type": [
-              "GeoCoordinates"
-            ],
-            "latitude": "42.33526603746952",
-            "longitude": "-71.12159711569939"
-          },
           "address": {
             "type": [
               "PostalAddress"
@@ -266,13 +245,6 @@ example: |-
           "type": [
             "Place"
           ],
-          "geo": {
-            "type": [
-              "GeoCoordinates"
-            ],
-            "latitude": "26.138581937299737",
-            "longitude": "-80.13053917016346"
-          },
           "address": {
             "type": [
               "PostalAddress"
@@ -294,13 +266,6 @@ example: |-
           "type": [
             "Place"
           ],
-          "geo": {
-            "type": [
-              "GeoCoordinates"
-            ],
-            "latitude": "-20.840731978309044",
-            "longitude": "-159.78393883134225"
-          },
           "address": {
             "type": [
               "PostalAddress"
@@ -317,13 +282,6 @@ example: |-
           "type": [
             "Place"
           ],
-          "geo": {
-            "type": [
-              "GeoCoordinates"
-            ],
-            "latitude": "-23.25979250428427",
-            "longitude": "-58.36431415044023"
-          },
           "address": {
             "type": [
               "PostalAddress"
@@ -354,9 +312,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-29T07:37:53Z",
+      "created": "2023-01-03T12:20:40Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..l1tV4AhrdeQYr4d9Iv8SAidHTQ4VUudwe8kA8BtC5JlxU2dlkCMFlqXPM9lDJaX3ApVd1kq2XBldBmsGL9VdCA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..QSZY9xYilSs25ZP4y554yARq660dQs6apppsIRk9Pg-PUi0U2M7K5H1kFw2uySFKDjymzSmHJ6vx1Ia1TejSCg"
     }
   }


### PR DESCRIPTION
BLs have never had geo coordinates. Requiring them is an obstacle to adoption as this is not a piece of data available within carriers' BL issuing systems. 