### PR TITLE
Fixing www.schema.org

### DIFF
--- a/docs/openapi/components/schemas/common/AgricultureActivity.yml
+++ b/docs/openapi/components/schemas/common/AgricultureActivity.yml
@@ -55,7 +55,7 @@ properties:
     type: string
     $linkedData:
       term: activityType
-      '@id': https://www.schema.org/value
+      '@id': https://schema.org/value
   agricultureProduct:
     title: Product List
     description: Agricultural Product the Activity was performed on if known

--- a/docs/openapi/components/schemas/common/AgricultureInspectionGeneric.yml
+++ b/docs/openapi/components/schemas/common/AgricultureInspectionGeneric.yml
@@ -36,7 +36,7 @@ properties:
     type: string
     $linkedData:
       term: inspectionType
-      '@id': https://www.schema.org/value
+      '@id': https://schema.org/value
   observation:
     title: Observation List
     description: >-
@@ -54,14 +54,14 @@ properties:
     type: string
     $linkedData:
       term: name
-      '@id': https://www.schema.org/name
+      '@id': https://schema.org/name
   status:
     title: Status
     description: Status of inspection (e.g. pending, NA, pass, fail).
     type: string
     $linkedData:
       term: status
-      '@id': https://www.schema.org/status
+      '@id': https://schema.org/status
 additionalProperties: false
 required:
   - type

--- a/docs/openapi/components/schemas/common/AgricultureProduct.yml
+++ b/docs/openapi/components/schemas/common/AgricultureProduct.yml
@@ -103,7 +103,7 @@ properties:
     type: string
     $linkedData:
       term: name
-      '@id': https://www.schema.org/name
+      '@id': https://schema.org/name
   productImageUrl:
     title: Product Image URL
     description: Image of the product.

--- a/docs/openapi/components/schemas/common/MeasuredValue.yml
+++ b/docs/openapi/components/schemas/common/MeasuredValue.yml
@@ -1,6 +1,6 @@
 $linkedData:
   term: MeasuredValue
-  '@id': https://www.schema.org/QuantitativeValue
+  '@id': https://schema.org/QuantitativeValue
 title: Measured Value
 description: The measurement of an Observation.
 type: object
@@ -24,7 +24,7 @@ properties:
     type: string
     $linkedData:
       term: value
-      '@id': https://www.schema.org/value
+      '@id': https://schema.org/value
   unitCode:
     title: Measurement Unit
     description: >-

--- a/docs/openapi/components/schemas/common/OGBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/OGBillOfLading.yml
@@ -43,21 +43,21 @@ properties:
     type: string
     $linkedData:
       term: valuePerItem
-      '@id': https://www.schema.org/value
+      '@id': https://schema.org/value
   totalOrderValue:
     title: Total Order Value
     description: Total value of the order
     type: string
     $linkedData:
       term: totalOrderValue
-      '@id': https://www.schema.org/value
+      '@id': https://schema.org/value
   freightChargeTerms:
     title: freight Charge Terms
     description: Terms of the freight charge
     type: string
     $linkedData:
       term: freightChargeTerms
-      '@id': https://www.schema.org/value
+      '@id': https://schema.org/value
   batchNumber:
     title: Batch Number
     description: A tracking number for commodities

--- a/docs/openapi/components/schemas/common/Phytosanitary.yml
+++ b/docs/openapi/components/schemas/common/Phytosanitary.yml
@@ -168,7 +168,7 @@ properties:
     type: string
     $linkedData:
       term: inspectionType
-      '@id': https://www.schema.org/value
+      '@id': https://schema.org/value
   notes:
     title: Inspection Notes
     description: >-

--- a/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP3461ImmediateDeliveryCredential.yml
@@ -212,9 +212,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-10T05:33:21Z",
+      "created": "2023-01-05T10:32:34Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..anio-yAPvmFAiePiUf0Hk2hV3FihrCZRf4tLx2mripO9O3gZqdgyI88SZkYdLrxpNHQtAqxdqOtX1_VyJJ4fAw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..u4dGZaXQPX6rpwYn5sPhx_RbqaYSOlokoJ2w8vLazS4TMcZA5ovGTa73WMrxuiSgv8YU2cL8PgKwcJLCZ1WPBQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CrudeOilProductCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CrudeOilProductCredential.yml
@@ -206,9 +206,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-19T07:59:35Z",
+      "created": "2023-01-05T10:32:40Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BPk7B85ZkgZkQM8SbwK3YkrbaKUKmEYgI0Hs7WcPo5ty6IGxp2yclKUPNJrs7Dl3XujOyhh6yVcHFv0FzHIEDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..X4hOPrVMPiyjyiZsaZ0K7rAByZd7dklTbB7cmSXh0OWxTqWkW8Hygy52b6rpmyvUivTCInWfZxj-jkn7ZCikBw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
@@ -556,9 +556,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-12-15T20:37:36Z",
+      "created": "2023-01-05T10:32:48Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..BY0ns1R0r9TeSo_fm5qeloghhxym1osoD01dDu2JEYRZC40lN_mPa5zJ1E-dcXyDmOT5lejIeb3N8lFrTqCNBw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..CbqnPgKfgF-t-giDly4wR957kqBCNnzr3rGvmj00nJtfE1tEKS3_0WFOGJ1myned_K2BaHa-FhRJGcbDREYKBg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
@@ -358,9 +358,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-12-15T20:37:39Z",
+      "created": "2023-01-05T10:32:51Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..usTdO_ygF5G2AskWlOrupLYldR5fzy-VJOelwsw3rWxP5Ropwb0hlBEgKbzL1ky9FSdL8jFLWF4MfLc5tz54BQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..A3KG5Id2UumSqsV--VzRGkFwW30eyZyMnD6PiijSVDCAINB_5iPeYoTBKYv5h0Wypb2XN-i426Vac4_cmcoTBg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -708,9 +708,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-01-04T15:55:40Z",
+      "created": "2023-01-05T10:32:57Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..EHV9e8GKND-3KPVAm-H5Jx0oF6Cwg4y0FuRCAnGWOPPM9MgM_mRaeNyYMN0hJSB7ZHs8q2lFu9dlNJPAjrL_Dg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..FpIO8IDvnQMVUuQCmyDjkUY6FPFietIwIqsKDRe6-0L2xTVeWwVhGjJdjch7AdzV4BBIp9t56FVFihLpBd_bDw"
     }
   }

--- a/docs/openapi/components/schemas/credentials/NaturalGasProductCredential.yml
+++ b/docs/openapi/components/schemas/credentials/NaturalGasProductCredential.yml
@@ -183,9 +183,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-19T07:41:16Z",
+      "created": "2023-01-05T10:33:00Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..gMVEeOeCcRRvJL1AIMhCQSzm61VM2_LiojnVLcuWaLXDokTBIEKEYYkzQFPGH-gUlMoYdrfAgyyDk8wx5WgCAw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..KDTIY5QYTpORXsTZRhawYPyoEYdgzgvXVvLNDcn9DM4dSbvGh1oLjrEGN2LjA4I52x1rCTEYuxUknx_RRCmBAg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
@@ -305,9 +305,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-12-15T20:37:47Z",
+      "created": "2023-01-05T10:33:03Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..0_wlfQoFQmnv3ve6UQPjqp7nZN9GIPwsL1Eyu5AAnnSq4kKYWb9FZ34NGnevujpbAk3huTHGfsyyk3XpWA5wDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..IbOFakBJv1Xjjpu5_YkZtxjyTPpSu_-uSgc5j2nNG3I9CVe-01_EFgt6n5cRunq3Hr3AObsKbLxsePaWiwz8Cg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
@@ -521,9 +521,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-01-04T16:08:55Z",
+      "created": "2023-01-05T10:33:07Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..lVd6wzlHx001cHcpML1_XcNqTiXj5WNspgoFHt29S9hREYSbu80LreVCqG_1-BMeBFk-9kpUhBGH1KN8DgJZBQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..hUSB0RzvkXmavMP-U_J-k9qZSkLH7V0Qlsyy-sTM1qX5c0abLnveeK4mQv0Hc9TQOZfseb972vShak_MaJ0HBQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
@@ -507,9 +507,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-01-04T16:08:59Z",
+      "created": "2023-01-05T10:33:10Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..jIrB0cjzADR674XmKIfAOqrvWU-A0avoWuQCCh2-gUcmkrJlu57C2V_jsdXhOU1U10Tw6DNKy87lSpRIjmo7BQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..qj_OdQvKexqUSAmEgML__u57606pC9zoj7FPzMmCvC-plw1_vv2n_ME99k5J1qwHPCYkAjTX9BjQcosAjTSoBg"
     }
   }


### PR DESCRIPTION
This fixes https://github.com/w3c-ccg/traceability-vocab/issues/574

@rhofvendahl  and @mkhraisha, I just did a full removal of the `www` removal from schema.org refs. The majority touched "your" schemas (as indicated on the issue). Please double check this. 