### PR TITLE
Add workflow dispatch to CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release-unstable:


### PR DESCRIPTION
Trace-vocab seems to hit a limit when we mass-merge a bunch of PR's on a call. This is a PR to be able to run CD as a dispatch to be able to run the CD workflow without having to push to main. 