### PR TITLE
chore: adding missing required fields to example

### DIFF
--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -4,7 +4,7 @@ $linkedData:
 title: Bill of Lading Credential
 tags:
   - eCommerce
-description: >- 
+description: >-
   A transport document issued or signed by a carrier evidencing
   a contract of carriage acknowledging receipt of cargo. This term is normally reserved
   for carriage by vessel (marine or ocean bill of lading) or multimodal transport. All
@@ -258,6 +258,24 @@ example: |-
           }
         }
       },
+      "freightForwarder": {
+        "type": ["Organization"],
+        "name": "Florida Contact Org",
+        "email": "Florida91@example.net",
+        "phoneNumber": "+1-555-104-1126",
+        "location": {
+          "type": ["Place"],
+          "address": {
+            "type": ["PostalAddress"],
+            "name": "Hahn LLC",
+            "streetAddress": "786 Pfeffer Plains",
+            "addressLocality": "West Ottilie",
+            "addressRegion": "Nebraska",
+            "postalCode": "50878-0870",
+            "addressCountry": "Cook Islands"
+          }
+        }
+      },
       "freight": {
         "type": [
           "ParcelDelivery"
@@ -293,6 +311,234 @@ example: |-
             "postalCode": "78251-3640",
             "addressCountry": "Paraguay"
           }
+        },
+        "partOfOrder": {
+          "type": [
+            "Order"
+          ],
+          "orderedItems": [
+            {
+              "type": [
+                "OrderItem"
+              ],
+              "marketplace": {
+                "type": [
+                  "Organization"
+                ],
+                "location": {
+                  "type": [
+                    "Place"
+                  ],
+                  "geo": {
+                    "type": [
+                      "GeoCoordinates"
+                    ]
+                  },
+                  "address": {
+                    "type": [
+                      "PostalAddress"
+                    ]
+                  }
+                },
+                "brand": {},
+                "contactPoint": {
+                  "type": [
+                    "ContactPoint"
+                  ],
+                  "place": {
+                    "type": [
+                      "Place"
+                    ],
+                    "geo": {
+                      "type": [
+                        "GeoCoordinates"
+                      ]
+                    },
+                    "address": {
+                      "type": [
+                        "PostalAddress"
+                      ]
+                    }
+                  }
+                }
+              },
+              "fulfillmentCenter": {
+                "type": [
+                  "Organization"
+                ],
+                "location": {
+                  "type": [
+                    "Place"
+                  ],
+                  "geo": {
+                    "type": [
+                      "GeoCoordinates"
+                    ]
+                  },
+                  "address": {
+                    "type": [
+                      "PostalAddress"
+                    ]
+                  }
+                },
+                "brand": {},
+                "contactPoint": {
+                  "type": [
+                    "ContactPoint"
+                  ],
+                  "place": {
+                    "type": [
+                      "Place"
+                    ],
+                    "geo": {
+                      "type": [
+                        "GeoCoordinates"
+                      ]
+                    },
+                    "address": {
+                      "type": [
+                        "PostalAddress"
+                      ]
+                    }
+                  }
+                }
+              },
+              "orderedItem": {
+                "type": [
+                  "Product"
+                ],
+                "manufacturer": {
+                  "type": [
+                    "Organization"
+                  ],
+                  "location": {
+                    "type": [
+                      "Place"
+                    ],
+                    "geo": {
+                      "type": [
+                        "GeoCoordinates"
+                      ]
+                    },
+                    "address": {
+                      "type": [
+                        "PostalAddress"
+                      ]
+                    }
+                  },
+                  "brand": {},
+                  "contactPoint": {
+                    "type": [
+                      "ContactPoint"
+                    ],
+                    "place": {
+                      "type": [
+                        "Place"
+                      ],
+                      "geo": {
+                        "type": [
+                          "GeoCoordinates"
+                        ]
+                      },
+                      "address": {
+                        "type": [
+                          "PostalAddress"
+                        ]
+                      }
+                    }
+                  }
+                },
+                "sizeOrAmount": {
+                  "type": [
+                    "QuantitativeValue"
+                  ],
+                  "unitCode": "1",
+                  "value": "1"
+                },
+                "weight": {
+                  "type": [
+                    "QuantitativeValue"
+                  ],
+                  "unitCode": "1",
+                  "value": "1"
+                },
+                "depth": {
+                  "type": [
+                    "QuantitativeValue"
+                  ],
+                  "unitCode": "1",
+                  "value": "1"
+                },
+                "width": {
+                  "type": [
+                    "QuantitativeValue"
+                  ],
+                  "unitCode": "1",
+                  "value": "1"
+                },
+                "height": {
+                  "type": [
+                    "QuantitativeValue"
+                  ],
+                  "unitCode": "1",
+                  "value": "1"
+                },
+                "productPrice": {
+                  "type": [
+                    "PriceSpecification"
+                  ]
+                },
+                "commodity": {
+                  "type": [
+                    "Commodity"
+                  ]
+                },
+                "seller": {
+                  "type": [
+                    "Organization"
+                  ],
+                  "location": {
+                    "type": [
+                      "Place"
+                    ],
+                    "geo": {
+                      "type": [
+                        "GeoCoordinates"
+                      ]
+                    },
+                    "address": {
+                      "type": [
+                        "PostalAddress"
+                      ]
+                    }
+                  },
+                  "brand": {},
+                  "contactPoint": {
+                    "type": [
+                      "ContactPoint"
+                    ],
+                    "place": {
+                      "type": [
+                        "Place"
+                      ],
+                      "geo": {
+                        "type": [
+                          "GeoCoordinates"
+                        ]
+                      },
+                      "address": {
+                        "type": [
+                          "PostalAddress"
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              "orderedQuantity": 1
+            }
+          ],
+          "orderNumber": "121"
         },
         "deliveryMethod": "Ocean transport",
         "trackingNumber": "178380801954"


### PR DESCRIPTION
freight forward was missing from the example and freight -> part of order too, but were required in the BoL schema