### PR TITLE
Refactor Organization with external IDs

### DIFF
--- a/docs/openapi/components/schemas/common/AgricultureInspectionGeneric.yml
+++ b/docs/openapi/components/schemas/common/AgricultureInspectionGeneric.yml
@@ -293,7 +293,13 @@ example: |-
       "broker": {
         "type": ["Organization"],
         "name": "Cole United",
-        "leiCode": "54321351219389121979"
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ]
       }
     },
     "inspectionType": "Contamination",

--- a/docs/openapi/components/schemas/common/AgricultureParcelDelivery.yml
+++ b/docs/openapi/components/schemas/common/AgricultureParcelDelivery.yml
@@ -308,6 +308,12 @@ example: |-
     "broker": {
       "type": ["Organization"],
       "name": "Koch LLC",
-      "leiCode": "54321351219389121979"
+      "externalIdentifiers": [
+        {
+          "type": ["ExternalIdentifier"],
+          "name": "LEI Code",
+          "value": "OHVJ56TBUFWT9XWMBEJ9"
+        }
+      ]
     }
   }

--- a/docs/openapi/components/schemas/common/ExternalIdentifier.yml
+++ b/docs/openapi/components/schemas/common/ExternalIdentifier.yml
@@ -1,0 +1,49 @@
+$linkedData:
+  term: ExternalIdentifier
+  '@id': https://w3id.org/traceability#ExternalIdentifier
+title: External Identifier
+description: Information to recognize & verify an external identifier.
+type: object
+properties:
+  type:
+    type: array
+    readOnly: true
+    const:
+      - ExternalIdentifier
+    default:
+      - ExternalIdentifier
+    items:
+      type: string
+      enum:
+        - ExternalIdentifier
+  name:
+    title: URI
+    description: Name of identifier.
+    type: string
+    $linkedData:
+      term: uri
+      '@id': https://schema.org/name
+  value:
+    title: URI
+    description: Value of identifier.
+    type: string
+    $linkedData:
+      term: uri
+      '@id': https://schema.org/value
+  uri:
+    title: URI
+    description: URI (Universal Resource Identifier) for identifier.
+    type: string
+    $linkedData:
+      term: uri
+      '@id': https://schema.org/url
+additionalProperties: false  
+required:
+  - type
+example: |-
+  {
+    "type": ["ExternalIdentifier"],
+    "name": "IOR_Number",
+    "value": "SOMIDNUM123",
+    "uri": "http://example.gov/ior/"
+  }

--- a/docs/openapi/components/schemas/common/ExternalIdentifier.yml
+++ b/docs/openapi/components/schemas/common/ExternalIdentifier.yml
@@ -43,7 +43,7 @@ required:
 example: |-
   {
     "type": ["ExternalIdentifier"],
-    "name": "IOR_Number",
-    "value": "SOMIDNUM123",
-    "uri": "http://example.gov/ior/"
+    "name": "leiCode",
+    "value": "2594007XIACKNMUAW223",
+    "uri": "http://example.gov/lei/"
   }

--- a/docs/openapi/components/schemas/common/ExternalIdentifier.yml
+++ b/docs/openapi/components/schemas/common/ExternalIdentifier.yml
@@ -40,6 +40,8 @@ properties:
 additionalProperties: false  
 required:
   - type
+  - name
+  - value
 example: |-
   {
     "type": ["ExternalIdentifier"],

--- a/docs/openapi/components/schemas/common/ExternalResource.yml
+++ b/docs/openapi/components/schemas/common/ExternalResource.yml
@@ -1,6 +1,6 @@
 $linkedData:
   term: ExternalResource
-  '@id': https://w3id.org/traceability#ExternalResource
+  '@id': https://schema.org/identifier
 title: External Resource
 description: Information to access & verify an external resource.
 type: object

--- a/docs/openapi/components/schemas/common/FoodGradeInspection.yml
+++ b/docs/openapi/components/schemas/common/FoodGradeInspection.yml
@@ -312,7 +312,13 @@ example: |-
       "broker": {
         "type": ["Organization"],
         "name": "Cole United",
-        "leiCode": "54321351219389121979"
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ]
       }
     },
     "loadingStatus": "UL",

--- a/docs/openapi/components/schemas/common/InspectionReport.yml
+++ b/docs/openapi/components/schemas/common/InspectionReport.yml
@@ -149,7 +149,13 @@ example: |-
         "phoneNumber": "555-615-9876",
         "worksFor": {
             "type": ["Organization"],
-            "globalLocationNumber": "3348622345363",
+            "externalIdentifiers": [
+              {
+                "type": ["ExternalIdentifier"],
+                "name": "LEI Code",
+                "value": "OHVJ56TBUFWT9XWMBEJ9"
+              }
+            ],
             "name": "IRON APPROVERS INC.",
             "description": "Inpsections for Iron Commodities",
             "location": {

--- a/docs/openapi/components/schemas/common/LEIentity.yml
+++ b/docs/openapi/components/schemas/common/LEIentity.yml
@@ -190,7 +190,13 @@ example: |-
     "legalForm": "CORPORATION",
     "associatedEntity": {
       "type": ["Organization"],
-      "leiCode": "OHVJ56TBUFWT9XWMBEJ9",
+      "externalIdentifiers": [
+        {
+          "type": ["ExternalIdentifier"],
+          "name": "LEI Code",
+          "value": "OHVJ56TBUFWT9XWMBEJ9"
+        }
+      ],
       "name": "Lemke LLC"
     },
     "status": "CONFIRMED",
@@ -198,7 +204,13 @@ example: |-
     "expirationReason": "synergize cross-media eyeballs",
     "successorEntity": {
       "type": ["Organization"],
-      "leiCode": "2T6Q7NQ863KK7JV6X2I2",
+      "externalIdentifiers": [
+        {
+          "type": ["ExternalIdentifier"],
+          "name": "LEI Code",
+          "value": "OHVJ56TBUFWT9XWMBEJ9"
+        }
+      ],
       "name": "Zemlak - Feest"
     },
     "otherAddresses": []

--- a/docs/openapi/components/schemas/common/LEIevidenceDocument.yml
+++ b/docs/openapi/components/schemas/common/LEIevidenceDocument.yml
@@ -106,7 +106,13 @@ example: |-
       "legalForm": "LLC",
       "associatedEntity": {
         "type": ["Organization"],
-        "leiCode": "GO6JI8JKTTQ1NM4CPAIE",
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ],
         "name": "Torphy Group"
       },
       "status": "IN PROGRESS",
@@ -114,7 +120,13 @@ example: |-
       "expirationReason": "whiteboard visionary web-readiness",
       "successorEntity": {
         "type": ["Organization"],
-        "leiCode": "XB3M42K0WGZB1FC975RO",
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ],
         "name": "Larkin - Carter"
       },
       "otherAddresses": []

--- a/docs/openapi/components/schemas/common/Organization.yml
+++ b/docs/openapi/components/schemas/common/Organization.yml
@@ -50,7 +50,7 @@ properties:
       '@id': https://schema.org/description
   location:
     title: Location
-    description: The location of, for example, where an event is happening, where an organization is located, or where an action takes place.
+    description: The location where, for example, an event happens, an organization is located, or an action takes place.
     $ref: ./Place.yml
     $linkedData:
       term: location

--- a/docs/openapi/components/schemas/common/Organization.yml
+++ b/docs/openapi/components/schemas/common/Organization.yml
@@ -34,13 +34,6 @@ properties:
     $linkedData:
       term: legalName
       '@id': https://schema.org/legalName
-  leiCode:
-    title: Legal Entity Identifier Code
-    description: Legal entity identifier code
-    type: string
-    $linkedData:
-      term: leiCode
-      '@id': https://schema.org/leiCode
   url:
     title: URL
     description: URL of the organization.
@@ -55,13 +48,6 @@ properties:
     $linkedData:
       term: description
       '@id': https://schema.org/description
-  globalLocationNumber:
-    title: Global Location Number
-    description: The GS1 GLN of the organization.
-    type: string
-    $linkedData:
-      term: globalLocationNumber
-      '@id': https://schema.org/globalLocationNumber
   location:
     title: Location
     description: The location of, for example, where an event is happening, where an organization is located, or where an action takes place.
@@ -104,15 +90,6 @@ properties:
     $linkedData:
       term: contactPoint
       '@id': https://schema.org/ContactPoint
-  taxId:
-    title: Tax Identification Number
-    description: >-
-      The Tax / Fiscal ID of the organization or person, e.g., the TIN in the US
-      or the CIF/NIF in Spain.
-    type: string
-    $linkedData:
-      term: taxId
-      '@id': https://schema.org/taxID
   iataCarrierCode:
     title: IATA Carrier Code
     description: Carrier's three-digit IATA airline code number
@@ -120,6 +97,14 @@ properties:
     $linkedData:
       term: iataCarrierCode
       '@id': https://onerecord.iata.org/cargo/Company#airlineCode
+  externalIdentifiers:
+    title: External Identifiers
+    description: External identifiers for this organization.
+    items:
+      $ref: ./ExternalIdentifier.yml
+    $linkedData:
+      term: externalIdentifiers
+      '@id': https://schema.org/identifier
 additionalProperties: false
 required:
   - type
@@ -148,6 +133,18 @@ example: |-
     "email": "contact@glover-gleason.example.net",
     "phoneNumber": "555-758-8926",
     "faxNumber": "555-248-4575",
-    "taxId": "789-56-123",
-    "url": "glover-gleason.example.net"
+    "url": "glover-gleason.example.net",
+    "externalIdentifiers": [
+      {
+        "type": ["ExternalIdentifier"],
+        "name": "LEI Code",
+        "value": "OHVJ56TBUFWT9XWMBEJ9"
+      },
+      {
+        "type": ["ExternalIdentifier"],
+        "name": "TIN",
+        "value": "39407884951871",
+        "uri": "http://example.gov/tin/"
+      }
+    ]
   }

--- a/docs/openapi/components/schemas/common/Phytosanitary.yml
+++ b/docs/openapi/components/schemas/common/Phytosanitary.yml
@@ -377,7 +377,13 @@ example: |-
       "broker": {
         "type": ["Organization"],
         "name": "Koch LLC",
-        "leiCode": "54321351219389121979"
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ]
       }
     },
     "applicant": {

--- a/docs/openapi/components/schemas/common/USDAPPQ203ForeignSiteInspection.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ203ForeignSiteInspection.yml
@@ -292,7 +292,13 @@ example: |-
       "broker": {
         "type": ["Organization"],
         "name": "Cole United",
-        "leiCode": "54321351219389121979"
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ]
       }
     },
     "signatureDate": "2021-02-27",

--- a/docs/openapi/components/schemas/common/USDAPPQ368NoticeOfArrival.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ368NoticeOfArrival.yml
@@ -221,7 +221,13 @@ example: |-
       "broker": {
         "type": ["Organization"],
         "name": "Cole United",
-        "leiCode": "54321351219389121979"
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ]
       }
     },
     "arrivalDate": "2020-01-24",

--- a/docs/openapi/components/schemas/common/USDAPPQ429FumigationRecord.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ429FumigationRecord.yml
@@ -515,7 +515,13 @@ example: |-
       "broker": {
         "type": ["Organization"],
         "name": "Cole United",
-        "leiCode": "54321351219389121979"
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ]
       }
     },
     "fumigationContractor": {

--- a/docs/openapi/components/schemas/common/USDAPPQ505PlantDeclaration.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ505PlantDeclaration.yml
@@ -181,7 +181,13 @@ example: |-
       "broker": {
         "type": ["Organization"],
         "name": "Cole United",
-        "leiCode": "54321351219389121979"
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ]
       }
     },
     "productDeclarations": [

--- a/docs/openapi/components/schemas/common/USDAPPQ587PlantImportPermit.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ587PlantImportPermit.yml
@@ -184,7 +184,13 @@ example: |-
       "broker": {
         "type": ["Organization"],
         "name": "Koch LLC",
-        "leiCode": "54321351219389121979"
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ]
       }
     },
     "signatureDate": "2021-02-16",

--- a/docs/openapi/components/schemas/common/UsdaSc6.yml
+++ b/docs/openapi/components/schemas/common/UsdaSc6.yml
@@ -327,7 +327,13 @@ example: |-
       "broker": {
         "type": ["Organization"],
         "name": "Cole United",
-        "leiCode": "54321351219389121979"
+        "externalIdentifiers": [
+          {
+            "type": ["ExternalIdentifier"],
+            "name": "LEI Code",
+            "value": "OHVJ56TBUFWT9XWMBEJ9"
+          }
+        ]
       }
     },
     "applicant": {

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
@@ -366,7 +366,15 @@ example: |-
             "Organization"
           ],
           "name": "Cole United",
-          "leiCode": "54321351219389121979"
+          "externalIdentifiers": [
+            {
+              "type": [
+                "ExternalIdentifier"
+              ],
+              "name": "LEI Code",
+              "value": "OHVJ56TBUFWT9XWMBEJ9"
+            }
+          ]
         }
       },
       "loadingStatus": "UL",
@@ -556,9 +564,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-01-05T10:32:48Z",
+      "created": "2023-01-30T04:51:14Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..CbqnPgKfgF-t-giDly4wR957kqBCNnzr3rGvmj00nJtfE1tEKS3_0WFOGJ1myned_K2BaHa-FhRJGcbDREYKBg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..IsWroEpQAenx3S-qQjfS_tpwzeynKBiHK4S6WPb4do3e7u2f0MMhZj8QgHzLOtufEVsgtkgXtliGNKP-_PJABA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -635,9 +635,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-01-27T11:35:42Z",
+      "created": "2023-01-30T04:51:21Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..lBEICfgnVwuVzDQC0R4V5dHnWrmLUxBZCSbiOVS352BwNYI_xTfwLrvCKWYambBl41FvAyoIe61z_xi2L87_Dg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fzujyiAXRSXUZ7--13NPkc_9RIMK8E7qQ1Ax6lXNiAVxWfnhtsdtxa9dzwJSCvWXVkuwFGn1F57yjFyWRX4JDA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
@@ -523,9 +523,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-01-26T15:27:18Z",
+      "created": "2023-01-30T04:51:28Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..jq302v25rMJa4PC8kSmXuRCTGsBuppDX_wyLa3x6305S_zBiqaOEJuSoa7ezcwfUT-CTU_kQ6rr6BGPgciGrBA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..IGPmVQ95c5eGmIDpvKUZTa7BuqRK8K9599OExoJW6Fd3IQZGC5E8uzuC7QTVQBFUFKDA0ZvPOBg_EQuIPsfNBg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
@@ -509,9 +509,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-01-26T15:37:18Z",
+      "created": "2023-01-30T04:51:30Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..yKalL9wOx5l52OOEVAtui28QkqZDd_n7OFvmrsFL33FoI5UcONOKb3QYv3jy1b_8UJbYOO0lTGDuW4WeCgBRDg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Rgn9uwu7DSXgF_eznIMURqgkGmI384S67xsONCUjooBuS4H_7pSlHRKLjsLzf7U4JxRf47L6wqt92cwG-KMnAg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
@@ -113,7 +113,6 @@ example: |-
       "email": "contact@glover-gleason.example.net",
       "phoneNumber": "555-758-8926",
       "faxNumber": "555-248-4575",
-      "taxId": "789-56-123",
       "url": "glover-gleason.example.net"
     },
     "credentialSubject": {
@@ -141,14 +140,13 @@ example: |-
       "email": "contact@glover-gleason.example.net",
       "phoneNumber": "555-758-8926",
       "faxNumber": "555-248-4575",
-      "taxId": "789-56-123",
       "url": "glover-gleason.example.net"
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-28T10:38:31Z",
+      "created": "2023-01-30T04:40:56Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..lawBpHbkXdJyxls2I5nOgvrrALhxwmbzFLS5T19nmnfHIml6MChoQp6mrgmQt4O3Z243X0kcLQu7y3uHEwj4Bw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..NzdZ_MKlB76kMpetJe360zmsnMggEIYsj9mnfRU5C_5WnhfZcvyx6SuGfRB2-pQKRL0t20xdmmbngVZRdXFdDA"
     }
   }

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -428,6 +428,18 @@ paths:
                 $ref: './components/schemas/common/Event.yml'
     
 
+  /schemas/common/ExternalIdentifier.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/ExternalIdentifier.yml'
+    
+
   /schemas/common/ExternalResource.yml:
     get:
       tags:


### PR DESCRIPTION
This PR creates a schema `ExternalIdentifier`, and refactors `Organization` to represent `leiCode`, `globalLocationNumber`, and `taxId` as external ID. This is done in order to keep `Organization` both succinct & flexible in the case of additional IDs which might become necessary.