### PR TITLE
fix: proper GS1 contexts

### DIFF
--- a/docs/credentials-with-undefined-terms.json
+++ b/docs/credentials-with-undefined-terms.json
@@ -129,7 +129,7 @@
   },
   {
     "type": "GS1DataCredential",
-    "count": 18
+    "count": 0
   },
   {
     "type": "GS1CompanyPrefixLicenceCredential",

--- a/docs/openapi/components/schemas/credentials/GS1DataCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1DataCredential.yml
@@ -16,17 +16,20 @@ properties:
     readOnly: true
     const:
       - https://www.w3.org/2018/credentials/v1
-      - https://w3id.org/traceability/v1
+      - https://ref.gs1.org/gs1/vc/trade-item-context/
+      - https://ref.gs1.org/gs1/vc/declaration-context/
       - https://w3id.org/vc/status-list/2021/v1
     default:
       - https://www.w3.org/2018/credentials/v1
-      - https://w3id.org/traceability/v1
+      - https://ref.gs1.org/gs1/vc/trade-item-context/
+      - https://ref.gs1.org/gs1/vc/declaration-context/
       - https://w3id.org/vc/status-list/2021/v1
     items:
       type: string
       enum:
         - https://www.w3.org/2018/credentials/v1
-        - https://w3id.org/traceability/v1
+        - https://ref.gs1.org/gs1/vc/trade-item-context/
+        - https://ref.gs1.org/gs1/vc/declaration-context/
         - https://w3id.org/vc/status-list/2021/v1
   type:
     type: array
@@ -111,7 +114,8 @@ example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/traceability/v1",
+      "https://ref.gs1.org/gs1/vc/trade-item-context/",
+      "https://ref.gs1.org/gs1/vc/declaration-context/",
       "https://w3id.org/vc/status-list/2021/v1"
     ],
     "id": "did:example:4e24b35d-de87-49d4-a26b-70490c62ec25",
@@ -123,7 +127,7 @@ example: |-
     "issuanceDate": "2020-12-03T03:14:59Z",
     "credentialSubject": {
       "id": "https://id.gs1.org/01/07541234555551",
-      "keyAuthorisation": "did:example:60cda318-a0a7-4e39-b600-ea38bf68a31f",
+      "keyAuthorization": "did:example:60cda318-a0a7-4e39-b600-ea38bf68a31f",
       "brandOwner": "The Best Example",
       "tradeItemDescription": "Never Give Up NRG Drink",
       "tradeItemImageURL": "https://www.example.com/assets/7541234555551.png",
@@ -141,9 +145,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-01-27T12:59:41Z",
+      "created": "2023-03-13T14:13:48Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..a1LaEeEzSo8PwzJXL_4C5gDggoi1UvfSxikbe_GaKbqCJ3XYmPVjYfpMgXzQeVXEQnCU5j-mogX9GmG98SGuAA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..6qcSQcEnJnU7IA54OASek_f_cDYp1H_HP5PXtzZ0TD5zqY5FdD_6xF-XMoUILZQpbG2KL1pcEZaHy9m5VNfcDg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/GS1KeyCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1KeyCredential.yml
@@ -14,16 +14,19 @@ properties:
     readOnly: true
     const:
       - https://www.w3.org/2018/credentials/v1
+      - https://ref.gs1.org/gs1/vc/declaration-context/
       - https://ref.gs1.org/gs1/vc/licence-context/
       - https://w3id.org/vc/status-list/2021/v1
     default:
       - https://www.w3.org/2018/credentials/v1
+      - https://ref.gs1.org/gs1/vc/declaration-context/
       - https://ref.gs1.org/gs1/vc/licence-context/
       - https://w3id.org/vc/status-list/2021/v1
     items:
       type: string
       enum:
         - https://www.w3.org/2018/credentials/v1
+        - https://ref.gs1.org/gs1/vc/declaration-context/
         - https://ref.gs1.org/gs1/vc/licence-context/
         - https://w3id.org/vc/status-list/2021/v1
   type:
@@ -89,6 +92,7 @@ example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
+      "https://ref.gs1.org/gs1/vc/declaration-context/",
       "https://ref.gs1.org/gs1/vc/licence-context/",
       "https://w3id.org/vc/status-list/2021/v1"
     ],
@@ -109,9 +113,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-01-03T11:29:14Z",
+      "created": "2023-03-13T12:17:31Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..HZtoLHUCGXalQH8VPClh0TcsQeNKS5i9KWLyASTQYfPIUPDMnLnjgjPJ5TVCn7S4CV7i45aTsUWkfs6cBNntBQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YLyxVJP1qEh2bJO5l5SMr4HfShfiTVhklfzNTQ39G4fc0GGcFpJYp-mS12Ci7SUtZoqj01siegP-XU8seo5KDA"
     }
   }

--- a/packages/traceability-schemas/services/contexts.js
+++ b/packages/traceability-schemas/services/contexts.js
@@ -126,7 +126,78 @@ const contexts = {
       },
     },
   },
-
+  'https://ref.gs1.org/gs1/vc/declaration-context/': {
+    '@context': {
+      '@version': 1.1,
+      rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+      rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
+      owl: 'http://www.w3.org/2002/07/owl#',
+      skos: 'http://www.w3.org/2004/02/skos/core#',
+      gs1: 'https://gs1.org/voc/',
+      language: '@language',
+      value: '@value',
+      GS1KeyCredential: {
+        '@id': 'gs1:GS1KeyCredential',
+      },
+      GS1DataCredential: {
+        '@id': 'gs1:GS1DataCredential',
+      },
+      GS1DelegationCredential: {
+        '@id': 'gs1:GS1DelegationCredential',
+      },
+      sameAs: {
+        '@id': 'gs1:sameAs',
+      },
+      keyAuthorization: {
+        '@id': 'gs1:keyAuthorization',
+      },
+      dataCertification: {
+        '@id': 'gs1:dataCertification',
+      },
+      delegation: {
+        '@id': 'gs1:delegation',
+      },
+      dataCredentialType: {
+        '@id': 'gs1:dataCredentialType',
+      },
+    },
+  },
+  'https://ref.gs1.org/gs1/vc/trade-item-context/': {
+    '@context': {
+      '@version': 1.1,
+      rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+      rdfs: 'http://www.w3.org/2000/01/rdf-schema#',
+      owl: 'http://www.w3.org/2002/07/owl#',
+      skos: 'http://www.w3.org/2004/02/skos/core#',
+      gs1: 'https://gs1.org/voc/',
+      language: '@language',
+      value: '@value',
+      GS1VerifiedByGS1TradeItemDataCredential: {
+        '@id': 'gs1:GS1VerifiedByGS1TradeItemDataCredential',
+      },
+      brandOwner: {
+        '@id': 'gs1:brandOwner',
+      },
+      tradeItemDescription: {
+        '@id': 'gs1:tradeItemDescription',
+      },
+      tradeItemImageURL: {
+        '@id': 'gs1:tradeItemImageURL',
+      },
+      gpcCode: {
+        '@id': 'gs1:gpcCode',
+      },
+      netContent: {
+        '@id': 'gs1:netContent',
+      },
+      netContentUOM: {
+        '@id': 'gs1:netContentUOM',
+      },
+      targetMarketCountryCode: {
+        '@id': 'gs1:targetMarketCountryCode',
+      },
+    },
+  },
   'https://w3id.org/traceability/v1': JSON.parse(
     fs
       .readFileSync(


### PR DESCRIPTION
Using `https://ref.gs1.org/gs1/vc/trade-item-context/`and `https://ref.gs1.org/gs1/vc/declaration-context`, fixing undefined terms. 