### PR TITLE
CTPAT schema updates based on feedback

### DIFF
--- a/docs/openapi/components/schemas/common/CTPAT.yml
+++ b/docs/openapi/components/schemas/common/CTPAT.yml
@@ -140,7 +140,7 @@ properties:
                   description: >-
                     The street address expressed as free form text. The street address is
                     printed on paper as the first lines below the name. For example, the name
-                    of the street and the number in the street or the name of a building.
+                    of the street and the number on the street, or the name of a building.
                   type: string
                   $linkedData:
                     term: streetAddress

--- a/docs/openapi/components/schemas/common/CTPAT.yml
+++ b/docs/openapi/components/schemas/common/CTPAT.yml
@@ -16,7 +16,7 @@ properties:
       type: string
       enum:
         - CTPAT
-  ctpatMember:
+  member:
     title: CTPAT Member Organization
     description: CTPAT members are considered to be of low risk, and are therefore less likely to be examined at a U.S. port of entry.
     type: object
@@ -272,14 +272,14 @@ properties:
 additionalProperties: false
 required:
   - type
-  - ctpatMember
+  - member
   - tradeSector
   - tier
   - issuingCountry
 example: |-
   {
     "type": ["CTPAT"],
-    "ctpatMember": {
+    "member": {
       "type": ["CTPATMember"],
       "name": "Quality Metals Inc",
       "id": "did:web:quality-metals.example.com",

--- a/docs/openapi/components/schemas/common/CTPAT.yml
+++ b/docs/openapi/components/schemas/common/CTPAT.yml
@@ -97,7 +97,7 @@ properties:
           '@id': https://schema.org/logo
       location:
         title: Location
-        description: The location of, for example, where an event is happening, where an organization is located, or where an action takes place.
+        description: The location where, for example, an event is happening, an organization is located, or an action takes place.
         type: array
         items:
           type: object

--- a/docs/openapi/components/schemas/common/CTPAT.yml
+++ b/docs/openapi/components/schemas/common/CTPAT.yml
@@ -19,7 +19,7 @@ properties:
   ctpatMember:
     title: CTPAT Member
     description: CTPAT member organization.
-    $ref: ./Organization.yml
+    $ref: ./CTPATMember.yml
     $linkedData:
       term: ctpatMember
       '@id': https://schema.org/member
@@ -60,6 +60,15 @@ properties:
     $linkedData:
       term: tradeSector
       '@id': https://schema.org/industry
+  tier:
+    title: CTPAT Tier
+    enum:
+      - Certified
+      - Validated
+      - Exceeding
+    $linkedData:
+      term: tier
+      '@id': https://w3id.org/traceability#ctpatTier
   dateOfLastValidation:
     title: Date of Last Validation
     description: >-
@@ -81,29 +90,32 @@ required:
   - type
   - ctpatMember
   - tradeSector
+  - tier
   - issuingCountry
 example: |-
   {
     "type": ["CTPAT"],
     "ctpatMember": {
-      "type": [
-        "Organization"
-      ],
-      "id": "did:key:z6MkhfZ7sNYEJ8vFSpwJaeyN7zNUaTxS4TBxW3y6R9ZKRaQ4",
-      "name": "Trans-Atlantic Shipping Co. Ltd.",
-      "location": {
-        "type": ["Place"],
-        "address": {
-          "type": [
-            "PostalAddress"
-          ],
-          "name": "Trans-Atlantic Shipping Co. Ltd.",
-          "streetAddress": "82 Whitchurch Road",
-          "addressLocality": "Elsworth",
-          "postalCode": "CB3 8NW",
-          "addressCountry": "UK"
+      "type": ["Organization"],
+      "name": "Quality Metals Inc",
+      "id": "did:web:quality-metals.example.com",
+      "importerOfRecordNumber": "10025672",
+      "importerOfRecordNumberType": "CBP",
+      "url": "https://quality-metals.example.com",
+      "location" : [
+        {
+          "type": ["Place"],
+          "address": {
+            "type": ["PostalAddress"],
+            "name": "Quality Metals",
+            "streetAddress": "1040 Newland Drive",
+            "addressLocality": "Yellowville",
+            "addressRegion": "Texas",
+            "postalCode": "28101",
+            "addressCountry": "US"
+          }
         }
-      }
+      ]
     },
     "sviNumber": "57118961",
     "ctpatAccountNumber": "12008",

--- a/docs/openapi/components/schemas/common/CTPAT.yml
+++ b/docs/openapi/components/schemas/common/CTPAT.yml
@@ -17,12 +17,196 @@ properties:
       enum:
         - CTPAT
   ctpatMember:
-    title: CTPAT Member
-    description: CTPAT member organization.
-    $ref: ./CTPATMember.yml
-    $linkedData:
-      term: ctpatMember
-      '@id': https://schema.org/member
+    title: CTPAT Member Organization
+    description: CTPAT members are considered to be of low risk, and are therefore less likely to be examined at a U.S. port of entry.
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - CTPATMember
+        default:
+          - CTPATMember
+        items:
+          type: string
+          enum:
+            - CTPATMember
+      name:
+        title: Name
+        description: Name of the organization.
+        type: string
+        $linkedData:
+          term: name
+          '@id': https://schema.org/name
+      id: 
+        title: Identifier
+        description: Organization identifier.
+        type: string
+        $linkedData:
+          term: name
+          '@id': https://schema.org/identifier
+      scac:
+        title: SCAC
+        description: >-
+          For maritime shipments, this code qualifies a Standard Alpha Carrier Code
+          (SCAC) as issued by the United Stated National Motor Traffic Association
+          Inc.
+        type: string
+        $linkedData:
+          term: scac
+          '@id': >-
+            https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Standard_Carrier_Alpha_Code_(SCAC)_number
+      iataCarrierCode:
+        title: IATA Carrier Code
+        description: Carrier's three-digit IATA airline code number
+        type: string
+        $linkedData:
+          term: iataCarrierCode
+          '@id': https://onerecord.iata.org/cargo/Company#airlineCode
+      importerOfRecordNumber: 
+        title: importerOfRecordNumber
+        description: Importer Of Record Number
+        type: string
+        $linkedData:
+          term: importerOfRecordNumber
+          '@id': https://schema.org/identifier
+      importerOfRecordNumberType:
+        title: Assigned Identifier Type
+        description: IRS, SSN, or CBP Assigned number.
+        enum:
+          - IRS
+          - SSN
+          - CBP
+        $linkedData:
+          term: importerOfRecordNumberType
+          '@id': https://w3id.org/traceability#assignedIdentifierType
+      url:
+        title: URL
+        description: URL of the organization.
+        type: string
+        $linkedData:
+          term: url
+          '@id': https://schema.org/url
+      logo: 
+        title: Logo
+        description: An associated logo.
+        type: string
+        $linkedData:
+          term: logo
+          '@id': https://schema.org/logo
+      location:
+        title: Location
+        description: The location of, for example, where an event is happening, where an organization is located, or where an action takes place.
+        type: array
+        items:
+          type: object
+          properties:
+            type:
+              type: array
+              readOnly: true
+              const:
+                - Place
+              default:
+                - Place
+              items:
+                type: string
+                enum:
+                  - Place
+            address:
+              title: Postal Address
+              description: The postal address for an organization or place.
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - PostalAddress
+                  default:
+                    - PostalAddress
+                  items:
+                    type: string
+                    enum:
+                      - PostalAddress
+                name:
+                  title: Name
+                  description: The name of the entity in text.
+                  type: string
+                  $linkedData:
+                    term: name
+                    '@id': https://schema.org/name
+                streetAddress:
+                  title: Street Address
+                  description: >-
+                    The street address expressed as free form text. The street address is
+                    printed on paper as the first lines below the name. For example, the name
+                    of the street and the number in the street or the name of a building.
+                  type: string
+                  $linkedData:
+                    term: streetAddress
+                    '@id': https://schema.org/streetAddress
+                addressLocality:
+                  title: Address Locality
+                  description: Text specifying the name of the locality; for example, a city.
+                  type: string
+                  $linkedData:
+                    term: addressLocality
+                    '@id': https://schema.org/addressLocality
+                addressRegion:
+                  title: Address Region
+                  description: >-
+                    Text specifying a province or state in abbreviated format; for example,
+                    NJ.
+                  type: string
+                  $linkedData:
+                    term: addressRegion
+                    '@id': https://schema.org/addressRegion
+                addressCountry:
+                  title: Address Country
+                  description: >-
+                    The two-letter ISO 3166-1 alpha-2 country code.
+                  type: string
+                  $linkedData:
+                    term: addressCountry
+                    '@id': https://schema.org/addressCountry
+                countyCode:
+                  title: County Code
+                  description: >-
+                    A code that identifies a county. A county is a territorial division in
+                    some countries, forming the chief unit of local administration. In the US,
+                    a county is a political and administrative division of a state.
+                  type: string
+                  $linkedData:
+                    term: countyCode
+                    '@id': https://gs1.org/voc/countyCode
+                postalCode:
+                  title: Postal Code
+                  description: Text specifying the postal code for an address.
+                  type: string
+                  $linkedData:
+                    term: postalCode
+                    '@id': https://schema.org/postalCode
+                postOfficeBoxNumber:
+                  title: Post Office Box Number
+                  description: >-
+                    The number that identifies a PO box. A PO box is a box in a post office or
+                    other postal service location assigned to an organization where postal
+                    items may be kept.
+                  type: string
+                  $linkedData:
+                    term: postOfficeBoxNumber
+                    '@id': https://schema.org/postOfficeBoxNumber
+              additionalProperties: false
+              required:
+                - type
+          additionalProperties: false
+          required:
+            - type
+            - address
+    additionalProperties: false
+    required:
+      - type
+      - location
   sviNumber:
     title: SVI Number
     description: >-
@@ -96,7 +280,7 @@ example: |-
   {
     "type": ["CTPAT"],
     "ctpatMember": {
-      "type": ["Organization"],
+      "type": ["CTPATMember"],
       "name": "Quality Metals Inc",
       "id": "did:web:quality-metals.example.com",
       "importerOfRecordNumber": "10025672",
@@ -120,6 +304,7 @@ example: |-
     "sviNumber": "57118961",
     "ctpatAccountNumber": "12008",
     "tradeSector": "Sea Carrier",
+    "tier": "Certified",
     "dateOfLastValidation": "2022-01-06T11:50:00Z",
     "issuingCountry": "US"
   }

--- a/docs/openapi/components/schemas/common/CTPATMember.yml
+++ b/docs/openapi/components/schemas/common/CTPATMember.yml
@@ -124,7 +124,7 @@ properties:
               description: >-
                 The street address expressed as free form text. The street address is
                 printed on paper as the first lines below the name. For example, the name
-                of the street and the number in the street or the name of a building.
+                of the street and the number in the street, or the name of a building.
               type: string
               $linkedData:
                 term: streetAddress

--- a/docs/openapi/components/schemas/common/CTPATMember.yml
+++ b/docs/openapi/components/schemas/common/CTPATMember.yml
@@ -193,7 +193,7 @@ required:
   - location
 example: |-
   {
-    "type": ["Organization"],
+    "type": ["CTPATMember"],
     "name": "Quality Metals Inc",
     "id": "did:web:quality-metals.example.com",
     "importerOfRecordNumber": "10025672",

--- a/docs/openapi/components/schemas/common/CTPATMember.yml
+++ b/docs/openapi/components/schemas/common/CTPATMember.yml
@@ -1,0 +1,216 @@
+$linkedData:
+  term: CTPATMember
+  '@id': https://schema.org/Organization
+title: CTPAT Member Organization
+description: CTPAT members are considered to be of low risk, and are therefore less likely to be examined at a U.S. port of entry.
+type: object
+properties:
+  type:
+    type: array
+    readOnly: true
+    const:
+      - Organization
+    default:
+      - Organization
+    items:
+      type: string
+      enum:
+        - Organization
+  name:
+    title: Name
+    description: Name of the organization.
+    type: string
+    $linkedData:
+      term: name
+      '@id': https://schema.org/name
+  id: 
+    title: Identifier
+    description: Organization identifier.
+    type: string
+    $linkedData:
+      term: name
+      '@id': https://schema.org/identifier
+  scac:
+    title: SCAC
+    description: >-
+      For maritime shipments, this code qualifies a Standard Alpha Carrier Code
+      (SCAC) as issued by the United Stated National Motor Traffic Association
+      Inc.
+    type: string
+    $linkedData:
+      term: scac
+      '@id': >-
+        https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Standard_Carrier_Alpha_Code_(SCAC)_number
+  iataCarrierCode:
+    title: IATA Carrier Code
+    description: Carrier's three-digit IATA airline code number
+    type: string
+    $linkedData:
+      term: iataCarrierCode
+      '@id': https://onerecord.iata.org/cargo/Company#airlineCode
+  importerOfRecordNumber: 
+    title: importerOfRecordNumber
+    description: Importer Of Record Number
+    type: string
+    $linkedData:
+      term: importerOfRecordNumber
+      '@id': https://schema.org/identifier
+  importerOfRecordNumberType:
+    title: Assigned Identifier Type
+    description: IRS, SSN, or CBP Assigned number.
+    enum:
+      - IRS
+      - SSN
+      - CBP
+    $linkedData:
+      term: importerOfRecordNumberType
+      '@id': https://w3id.org/traceability#assignedIdentifierType
+  url:
+    title: URL
+    description: URL of the organization.
+    type: string
+    $linkedData:
+      term: url
+      '@id': https://schema.org/url
+  logo: 
+    title: Logo
+    description: An associated logo.
+    type: string
+    $linkedData:
+      term: logo
+      '@id': https://schema.org/logo
+  location:
+    title: Location
+    description: The location of, for example, where an event is happening, where an organization is located, or where an action takes place.
+    type: array
+    items:
+      type: object
+      properties:
+        type:
+          type: array
+          readOnly: true
+          const:
+            - Place
+          default:
+            - Place
+          items:
+            type: string
+            enum:
+              - Place
+        address:
+          title: Postal Address
+          description: The postal address for an organization or place.
+          properties:
+            type:
+              type: array
+              readOnly: true
+              const:
+                - PostalAddress
+              default:
+                - PostalAddress
+              items:
+                type: string
+                enum:
+                  - PostalAddress
+            name:
+              title: Name
+              description: The name of the entity in text.
+              type: string
+              $linkedData:
+                term: name
+                '@id': https://schema.org/name
+            streetAddress:
+              title: Street Address
+              description: >-
+                The street address expressed as free form text. The street address is
+                printed on paper as the first lines below the name. For example, the name
+                of the street and the number in the street or the name of a building.
+              type: string
+              $linkedData:
+                term: streetAddress
+                '@id': https://schema.org/streetAddress
+            addressLocality:
+              title: Address Locality
+              description: Text specifying the name of the locality; for example, a city.
+              type: string
+              $linkedData:
+                term: addressLocality
+                '@id': https://schema.org/addressLocality
+            addressRegion:
+              title: Address Region
+              description: >-
+                Text specifying a province or state in abbreviated format; for example,
+                NJ.
+              type: string
+              $linkedData:
+                term: addressRegion
+                '@id': https://schema.org/addressRegion
+            addressCountry:
+              title: Address Country
+              description: >-
+                The two-letter ISO 3166-1 alpha-2 country code.
+              type: string
+              $linkedData:
+                term: addressCountry
+                '@id': https://schema.org/addressCountry
+            countyCode:
+              title: County Code
+              description: >-
+                A code that identifies a county. A county is a territorial division in
+                some countries, forming the chief unit of local administration. In the US,
+                a county is a political and administrative division of a state.
+              type: string
+              $linkedData:
+                term: countyCode
+                '@id': https://gs1.org/voc/countyCode
+            postalCode:
+              title: Postal Code
+              description: Text specifying the postal code for an address.
+              type: string
+              $linkedData:
+                term: postalCode
+                '@id': https://schema.org/postalCode
+            postOfficeBoxNumber:
+              title: Post Office Box Number
+              description: >-
+                The number that identifies a PO box. A PO box is a box in a post office or
+                other postal service location assigned to an organization where postal
+                items may be kept.
+              type: string
+              $linkedData:
+                term: postOfficeBoxNumber
+                '@id': https://schema.org/postOfficeBoxNumber
+          additionalProperties: false
+          required:
+            - type
+      additionalProperties: false
+      required:
+        - type
+        - address
+additionalProperties: false
+required:
+  - type
+  - location
+example: |-
+  {
+    "type": ["Organization"],
+    "name": "Quality Metals Inc",
+    "id": "did:web:quality-metals.example.com",
+    "importerOfRecordNumber": "10025672",
+    "importerOfRecordNumberType": "CBP",
+    "url": "https://quality-metals.example.com",
+    "location" : [
+      {
+        "type": ["Place"],
+        "address": {
+          "type": ["PostalAddress"],
+          "name": "Quality Metals",
+          "streetAddress": "1040 Newland Drive",
+          "addressLocality": "Yellowville",
+          "addressRegion": "Texas",
+          "postalCode": "28101",
+          "addressCountry": "US"
+        }
+      }
+    ]
+  }

--- a/docs/openapi/components/schemas/common/CTPATMember.yml
+++ b/docs/openapi/components/schemas/common/CTPATMember.yml
@@ -9,13 +9,13 @@ properties:
     type: array
     readOnly: true
     const:
-      - Organization
+      - CTPATMember
     default:
-      - Organization
+      - CTPATMember
     items:
       type: string
       enum:
-        - Organization
+        - CTPATMember
   name:
     title: Name
     description: Name of the organization.

--- a/docs/openapi/components/schemas/common/CTPATMember.yml
+++ b/docs/openapi/components/schemas/common/CTPATMember.yml
@@ -81,7 +81,7 @@ properties:
       '@id': https://schema.org/logo
   location:
     title: Location
-    description: The location of, for example, where an event is happening, where an organization is located, or where an action takes place.
+    description: The location where, for example, an event is happening, an organization is located, or an action takes place.
     type: array
     items:
       type: object

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -119,7 +119,7 @@ example: |-
       "type": [
         "CTPAT"
       ],
-      "ctpatMember": {
+      "member": {
         "type": [
           "CTPATMember"
         ],
@@ -162,9 +162,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-03-14T11:44:19Z",
+      "created": "2023-03-14T14:02:07Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DG586gtZaO-VurMJdUDl1e7Nyn4ig20m-vst5634mUkUlf2KS6Oke6QisDPYPkHJpF2j-cv3qE_gdkuD-xMfBg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..t0fhzEfyFZNgomOUTNfI8_yD6fFKslk8K2IUncCXv9Jwgro9GQ9_WsBq7idU2YF5X43hZv468nbjRmR9sGxpAg"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -88,6 +88,7 @@ additionalProperties: false
 required:
   - '@context'
   - type
+  - id
   - issuanceDate
   - issuer
   - credentialSubject
@@ -102,7 +103,7 @@ example: |-
       "https://w3id.org/traceability/v1",
       "https://w3id.org/vc/status-list/2021/v1"
     ],
-    "id": "did:key:z6LSpdSReUHCjYcQb1243aF1vS7sd9ArK585Mm4ktARQxatd",
+    "id": "urn:uuid:2385e117-8011-4n15-bcae-64e4e26856c8",
     "name": "CTPAT Certificate",
     "description": "In recognition of your commitment to partnership, and in appreciation for joining with us to secure the international supply chain and protect our country's security, the U.S. Customs Service is pleased to certify your membership in the Customs - Trade Partnership Against Terrorism.",
     "issuer": {

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -121,29 +121,36 @@ example: |-
       ],
       "ctpatMember": {
         "type": [
-          "Organization"
+          "CTPATMember"
         ],
-        "id": "did:key:z6MkhfZ7sNYEJ8vFSpwJaeyN7zNUaTxS4TBxW3y6R9ZKRaQ4",
-        "name": "Trans-Atlantic Shipping Co. Ltd.",
-        "location": {
-          "type": [
-            "Place"
-          ],
-          "address": {
+        "name": "Quality Metals Inc",
+        "id": "did:web:quality-metals.example.com",
+        "importerOfRecordNumber": "10025672",
+        "importerOfRecordNumberType": "CBP",
+        "url": "https://quality-metals.example.com",
+        "location": [
+          {
             "type": [
-              "PostalAddress"
+              "Place"
             ],
-            "name": "Trans-Atlantic Shipping Co. Ltd.",
-            "streetAddress": "82 Whitchurch Road",
-            "addressLocality": "Elsworth",
-            "postalCode": "CB3 8NW",
-            "addressCountry": "UK"
+            "address": {
+              "type": [
+                "PostalAddress"
+              ],
+              "name": "Quality Metals",
+              "streetAddress": "1040 Newland Drive",
+              "addressLocality": "Yellowville",
+              "addressRegion": "Texas",
+              "postalCode": "28101",
+              "addressCountry": "US"
+            }
           }
-        }
+        ]
       },
       "sviNumber": "57118961",
       "ctpatAccountNumber": "12008",
       "tradeSector": "Sea Carrier",
+      "tier": "Certified",
       "dateOfLastValidation": "2022-01-06T11:50:00Z",
       "issuingCountry": "US"
     },
@@ -155,9 +162,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-22T17:31:32Z",
+      "created": "2023-03-14T11:44:19Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..kSgKBKawfsh3qCPoTWfEyNhjJK4-LQEdyyL0zI9bdq7Hrbds1lPIkG8OWsCTTR-rYcXzLnTZkYTYbTnH5L-rCQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..DG586gtZaO-VurMJdUDl1e7Nyn4ig20m-vst5634mUkUlf2KS6Oke6QisDPYPkHJpF2j-cv3qE_gdkuD-xMfBg"
     }
   }

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -152,6 +152,18 @@ paths:
                 $ref: './components/schemas/common/CTPATEIPApplication.yml'
     
 
+  /schemas/common/CTPATMember.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CTPATMember.yml'
+    
+
   /schemas/common/CargoItem.yml:
     get:
       tags:


### PR DESCRIPTION
This PR: 
- Introduces a CTPATMember RDF class because of requirements to allow multiple addresses and SCAC code on the organization
- Restricts the parts of Organization not needed for CTPAT members
- Flattens the CTPAT-Member-Location for easier implementation