### PR TITLE
CBP Entry forms refactoring

### DIFF
--- a/docs/openapi/components/schemas/common/CBPEntry.yml
+++ b/docs/openapi/components/schemas/common/CBPEntry.yml
@@ -1,21 +1,21 @@
 $linkedData:
-  term: ImmediateDelivery
-  '@id': https://w3id.org/traceability#ImmediateDelivery
-title: Immediate Delivery
-description: CBP Form 3461 for Immediate Delivery (https://www.cbp.gov/sites/default/files/assets/documents/2016-Jun/CBP%20Form%203461%20-%20ACE%20Fillable.pdf and https://www.cbp.gov/sites/default/files/assets/documents/2016-Jun/CBP%203461%20Instructions_0.pdf).
+  term: CBPEntry
+  '@id': https://w3id.org/traceability#CBPEntry
+title: CBP Entry
+description: CBP Form 3461 for Entry/Immediate Delivery (https://www.cbp.gov/sites/default/files/assets/documents/2016-Jun/CBP%20Form%203461%20-%20ACE%20Fillable.pdf and https://www.cbp.gov/sites/default/files/assets/documents/2016-Jun/CBP%203461%20Instructions_0.pdf).
 type: object
 properties:
   type:
     type: array
     readOnly: true
     const:
-      - ImmediateDelivery
+      - CBPEntry
     default:
-      - ImmediateDelivery
+      - CBPEntry
     items:
       type: string
       enum:
-        - ImmediateDelivery
+        - CBPEntry
   portOfEntry:
     title: Port Of Entry
     $ref: ./Place.yml
@@ -31,28 +31,18 @@ properties:
       '@id': https://w3id.org/traceability#bondType
   importer:
     title: Importer
-    description: Importer of Record
+    description: Importer Organization
     $ref: ./Organization.yml
     $linkedData:
       term: importer
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#importerParty
-  assignedIdentifier: 
-    title: Assigned Identifier
-    description: Assigned Identifier
-    type: string
+  importerOfRecord: 
+    title: Importer Of Record
+    description: US CBP importer of record.
+    $ref: ./CBPImporterOfRecord.yml
     $linkedData:
-      term: assignedIdentifier
-      '@id': https://schema.org/identifier
-  assignedIdentifierType:
-    title: Assigned Identifier Type
-    description: IRS, SSN, or CBP Assigned number.
-    enum:
-      - IRS
-      - SSN
-      - CBP
-    $linkedData:
-      term: assignedIdentifierType
-      '@id': https://w3id.org/traceability#assignedIdentifierType
+      term: importerOfRecord
+      '@id': https://w3id.org/traceability#importerOfRecord
   entryNumber:
     title: Entry Number
     description: The 11 digit alphanumeric code. The entry number is comprised of the three-digit filer code, followed by the seven-digit entry number, and completed with the one-digit check digit. The Entry Filer Code represents the three-character alphanumeric filer code assigned to the filer or importer by CBP. The Entry Number represents the seven-digit number assigned by the filer. The number may be assigned in any manner convenient, provided that the same number is not assigned to more than one CBP Form 3461. Leading zeros must be shown. The check digit is computed on the previous 10 characters. The formula for calculating the check digit can be found in Appendix 1.
@@ -178,7 +168,7 @@ properties:
     description: Select the Header Party Type from the available options. Use a separate line for each Header Party Type. The Header Parties must apply to the entire entry.  If not, skip to line information (Block 24).
     type: array
     items: 
-      $ref: ./ImmediateDeliveryEntity.yml 
+      $ref: ./CBPEntryEntity.yml 
     $linkedData:
       term: headerParties
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#Party
@@ -186,7 +176,7 @@ properties:
     title: Line Items
     type: array
     items: 
-      $ref: ./ImmediateDeliveryLineItem.yml 
+      $ref: ./CBPEntryLineItem.yml 
     $linkedData:
       term: lineItems
       '@id': https://w3id.org/traceability#lineItems
@@ -264,15 +254,14 @@ required:
   - type
   - portOfEntry
   - importer
-  - assignedIdentifier
-  - assignedIdentifierType
+  - importerOfRecord
   - entryNumber
   - entryType
   - transportMode
   - arrivalDate
 example: |-
   {
-    "type": ["ImmediateDelivery"],
+    "type": ["CBPEntry"],
     "portOfEntry": {
       "type": ["Place"],
       "unLocode": "USLBC"
@@ -292,8 +281,11 @@ example: |-
         }
       }
     },
-    "assignedIdentifier": "12345678",
-    "assignedIdentifierType": "CBP",
+    "importerOfRecord":   {
+      "type": ["CBPImporterOfRecord"],
+      "number": "10025672",
+      "identifierType": "CBP"
+    },
     "entryNumber": "12345123456",
     "bondValue": 12000,
     "entryValue": 12000,
@@ -316,7 +308,7 @@ example: |-
     "referenceIDNumber": "EX123456",
     "lineItems": [
       {
-        "type": ["ImmediateDeliveryLineItem"],
+        "type": ["CBPEntryLineItem"],
         "commodity": {
           "type": ["Commodity"],
           "commodityCode": "9403 7000 00",
@@ -325,7 +317,7 @@ example: |-
         "productDescription": "Mobility assistance equipment",
         "itemCount": 400,
         "itemParty": {
-          "type": ["ImmediateDeliveryEntity"],
+          "type": ["CBPEntryEntity"],
           "consignee": {
             "type": ["Organization"],
             "name": "Future Mobility, Inc.",
@@ -340,8 +332,11 @@ example: |-
               }
             }
           },
-          "assignedIdentifier": "12345678",
-          "assignedIdentifierType": "CBP"
+          "importerOfRecord":   {
+            "type": ["CBPImporterOfRecord"],
+            "number": "10025672",
+            "identifierType": "CBP"
+          }
         },
         "freeTradeZoneFilingDate": "2022-02-25",
         "freeTradeZoneStatus": "N",

--- a/docs/openapi/components/schemas/common/CBPEntryEntity.yml
+++ b/docs/openapi/components/schemas/common/CBPEntryEntity.yml
@@ -1,21 +1,21 @@
 $linkedData:
-  term: ImmediateDeliveryEntity
-  '@id': https://w3id.org/traceability#ImmediateDeliveryEntity
-title: Immediate Delivery Entity
-description: Entity identifier used on CBP 3461 Immediate Delivery Form.
+  term: CBPEntryEntity
+  '@id': https://w3id.org/traceability#CBPEntryEntity
+title: Entry Entity
+description: Entity identifier used on CBP 3461 Entry/Immediate Delivery Form.
 type: object
 properties:
   type:
     type: array
     readOnly: true
     const:
-      - ImmediateDeliveryEntity
+      - CBPEntryEntity
     default:
-      - ImmediateDeliveryEntity
+      - CBPEntryEntity
     items:
       type: string
       enum:
-        - ImmediateDeliveryEntity
+        - CBPEntryEntity
   manufacturer:
     title: Manufacturer
     description: A manufacturer party.
@@ -44,31 +44,20 @@ properties:
     $linkedData:
       term: buyer
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#buyerParty
-  assignedIdentifier: 
-    title: Assigned Identifier
-    description: Assigned Identifier
-    type: string
+  importerOfRecord: 
+    title: Importer Of Record
+    description: US CBP importer of record.
+    $ref: ./CBPImporterOfRecord.yml
     $linkedData:
-      term: assignedIdentifier
-      '@id': https://schema.org/identifier
-  assignedIdentifierType:
-    title: Assigned Identifier Type
-    description: IRS, SSN, or CBP Assigned number.
-    enum:
-      - IRS
-      - SSN
-      - CBP
-    $linkedData:
-      term: assignedIdentifierType
-      '@id': https://w3id.org/traceability#assignedIdentifierType
+      term: importerOfRecord
+      '@id': https://w3id.org/traceability#importerOfRecord
 additionalProperties: false
 required:
   - type
-  - assignedIdentifier
-  - assignedIdentifierType
+  - importerOfRecord
 example: |-
   {
-    "type": ["ImmediateDeliveryEntity"],
+    "type": ["CBPEntryEntity"],
     "consignee": {
       "type": ["Organization"],
       "name": "Future Mobility, Inc.",
@@ -83,6 +72,9 @@ example: |-
         }
       }
     },
-    "assignedIdentifier": "12345678",
-    "assignedIdentifierType": "CBP"
+    "importerOfRecord":   {
+      "type": ["CBPImporterOfRecord"],
+      "number": "10025672",
+      "identifierType": "CBP"
+    }
   }

--- a/docs/openapi/components/schemas/common/CBPEntryLineItem.yml
+++ b/docs/openapi/components/schemas/common/CBPEntryLineItem.yml
@@ -1,21 +1,21 @@
 $linkedData:
-  term: ImmediateDeliveryLineItem
-  '@id': https://w3id.org/traceability#ImmediateDeliveryLineItem
-title: Immediate Delivery Line Item
-description: Line Item identifier used on CBP 3461 Immediate Delivery Form.
+  term: CBPEntryLineItem
+  '@id': https://w3id.org/traceability#CBPEntryLineItem
+title: CBP Entry Line Item
+description: Line Item identifier used on CBP 3461 Entry/Immediate Delivery Form.
 type: object
 properties:
   type:
     type: array
     readOnly: true
     const:
-      - ImmediateDeliveryLineItem
+      - CBPEntryLineItem
     default:
-      - ImmediateDeliveryLineItem
+      - CBPEntryLineItem
     items:
       type: string
       enum:
-        - ImmediateDeliveryLineItem
+        - CBPEntryLineItem
   commodity: 
     title: Commodity
     description: Commodity classification based on either WCO HS or USITS HTS codification.
@@ -38,7 +38,7 @@ properties:
         https://service.unece.org/trade/uncefact/vocabulary/uncefact/#despatchedQuantity
   itemParty:
     title: Item Party
-    $ref: ./ImmediateDeliveryEntity.yml
+    $ref: ./CBPEntryEntity.yml
     $linkedData:
       term: itemParty
       '@id': https://w3id.org/traceability#itemParty
@@ -78,7 +78,7 @@ required:
   - countryOfOrigin
 example: |-
   {
-    "type": ["ImmediateDeliveryLineItem"],
+    "type": ["CBPEntryLineItem"],
     "commodity": {
       "type": ["Commodity"],
       "commodityCode": "9403 7000 00",
@@ -87,7 +87,7 @@ example: |-
     "productDescription": "Mobility assistance equipment",
     "itemCount": 400,
     "itemParty": {
-      "type": ["ImmediateDeliveryEntity"],
+      "type": ["CBPEntryEntity"],
       "consignee": {
         "type": ["Organization"],
         "name": "Future Mobility, Inc.",
@@ -102,8 +102,13 @@ example: |-
           }
         }
       },
-      "assignedIdentifier": "12345678",
-      "assignedIdentifierType": "CBP"
+      "importerOfRecord": {
+        "type": [
+          "CBPImporterOfRecord"
+        ],
+        "number": "10025672",
+        "identifierType": "CBP"
+      }
     },
     "freeTradeZoneFilingDate": "2022-02-25",
     "freeTradeZoneStatus": "N",

--- a/docs/openapi/components/schemas/common/CBPEntrySummary.yml
+++ b/docs/openapi/components/schemas/common/CBPEntrySummary.yml
@@ -1,6 +1,6 @@
 $linkedData:
-  term: EntrySummary
-  '@id': https://w3id.org/traceability#EntrySummary
+  term: CBPEntrySummary
+  '@id': https://w3id.org/traceability#CBPEntrySummary
 title: Entry Summary
 description: CBP Form 7501 for Entry Summary (https://www.cbp.gov/sites/default/files/assets/documents/2021-Sep/CBP%20Form%207501.pdf).
 type: object
@@ -9,13 +9,13 @@ properties:
     type: array
     readOnly: true
     const:
-      - EntrySummary
+      - CBPEntrySummary
     default:
-      - EntrySummary
+      - CBPEntrySummary
     items:
       type: string
       enum:
-        - EntrySummary
+        - CBPEntrySummary
   entryNumber:
     title: Entry Number
     description: The 11 digit alphanumeric code. The entry number is comprised of the three-digit filer code, followed by the seven-digit entry number, and completed with the one-digit check digit. The Entry Filer Code represents the three-character alphanumeric filer code assigned to the filer or importer by CBP. The Entry Number represents the seven-digit number assigned by the filer. The number may be assigned in any manner convenient, provided that the same number is not assigned to more than one CBP Form 3461. Leading zeros must be shown. The check digit is computed on the previous 10 characters. The formula for calculating the check digit can be found in Appendix 1.
@@ -229,7 +229,7 @@ properties:
     description: A description of the articles in sufficient detail to permit the classification thereof under the proper statistical reporting number in the HTS should be reported at the top of column 28. The standard definitions from the CBP HTS database are acceptable for this requirement. 
     type: array 
     items: 
-      $ref: ./EntrySummaryLineItem.yml
+      $ref: ./CBPEntrySummaryLineItem.yml
     $linkedData:
       term: descriptionOfMerchandise
       '@id': https://w3id.org/traceability#descriptionOfMerchandise
@@ -296,7 +296,7 @@ required:
   - descriptionOfMerchandise
 example: |-
   {
-    "type": ["EntrySummary"],
+    "type": ["CBPEntrySummary"],
     "entryNumber": "73461882610",
     "entryType": "01",
     "summaryDate": "2022-03-01T12:54Z",
@@ -363,7 +363,7 @@ example: |-
     },
     "descriptionOfMerchandise": [
       {
-        "type": ["EntrySummaryLineItem"],
+        "type": ["CBPEntrySummaryLineItem"],
         "commodity": {
           "type": ["Commodity"],
           "commodityCode": "2204.21.60 00",

--- a/docs/openapi/components/schemas/common/CBPEntrySummaryLineItem.yml
+++ b/docs/openapi/components/schemas/common/CBPEntrySummaryLineItem.yml
@@ -1,6 +1,6 @@
 $linkedData:
-  term: EntrySummaryLineItem
-  '@id': https://w3id.org/traceability#EntrySummaryLineItem
+  term: CBPEntrySummaryLineItem
+  '@id': https://w3id.org/traceability#CBPEntrySummaryLineItem
 title: Entry Summary Line Item
 description: A description of the articles in sufficient detail to permit the classification thereof under the proper statistical reporting number in the HTS should be reported at the top of column 28. The standard definitions from the CBP HTS database are acceptable for this requirement. 
 type: object
@@ -9,13 +9,13 @@ properties:
     type: array
     readOnly: true
     const:
-      - EntrySummaryLineItem
+      - CBPEntrySummaryLineItem
     default:
-      - EntrySummaryLineItem
+      - CBPEntrySummaryLineItem
     items:
       type: string
       enum:
-        - EntrySummaryLineItem
+        - CBPEntrySummaryLineItem
   commodity:
     title: Commodity
     description: Product commodity code, codification system and description
@@ -171,7 +171,7 @@ required:
   - type
 example: |-
   {
-    "type": ["EntrySummaryLineItem"],
+    "type": ["CBPEntrySummaryLineItem"],
     "commodity": {
       "type": ["Commodity"],
       "commodityCode": "2204.21.60 00",

--- a/docs/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: CBP3461ImmediateDeliveryCredential
-  '@id': https://w3id.org/traceability#CBP3461ImmediateDeliveryCredential
-title: CBP Form 3461 - Immediate Delivery Credential
+  term: CBP3461EntryCredential
+  '@id': https://w3id.org/traceability#CBP3461EntryCredential
+title: CBP Form 3461 - Entry/Immediate Delivery Credential
 tags:
   - eCommerce
 description: Customs and Border Protection Form 3461 Immediate Delivery Certification (https://www.cbp.gov/sites/default/files/assets/documents/2016-Jun/CBP%20Form%203461%20-%20ACE%20Fillable.pdf and https://www.cbp.gov/sites/default/files/assets/documents/2016-Jun/CBP%203461%20Instructions_0.pdf).
@@ -19,15 +19,15 @@ properties:
     readOnly: true
     const:
       - VerifiableCredential
-      - CBP3461ImmediateDeliveryCredential
+      - CBP3461EntryCredential
     default:
       - VerifiableCredential
-      - CBP3461ImmediateDeliveryCredential
+      - CBP3461EntryCredential
     items:
       type: string
       enum:
         - VerifiableCredential
-        - CBP3461ImmediateDeliveryCredential
+        - CBP3461EntryCredential
   id:
     type: string
   name:
@@ -41,7 +41,7 @@ properties:
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:
-    $ref: ../common/ImmediateDelivery.yml
+    $ref: ../common/CBPEntry.yml
   proof:
     $ref: ../snippets/proof.yml
   relatedLink:
@@ -66,7 +66,7 @@ example: |-
     "id": "did:key:z6MkhrVRiPmbS48dKC39L65XtJaGqWFSykfUgRepcXzBwBqS",
     "type": [
       "VerifiableCredential",
-      "CBP3461ImmediateDeliveryCredential"
+      "CBP3461EntryCredential"
     ],
     "issuanceDate": "2022-02-25T14:34:00Z",
     "issuer": {
@@ -92,7 +92,7 @@ example: |-
     },
     "credentialSubject": {
       "type": [
-        "ImmediateDelivery"
+        "CBPEntry"
       ],
       "portOfEntry": {
         "type": [
@@ -121,8 +121,13 @@ example: |-
           }
         }
       },
-      "assignedIdentifier": "12345678",
-      "assignedIdentifierType": "CBP",
+      "importerOfRecord": {
+        "type": [
+          "CBPImporterOfRecord"
+        ],
+        "number": "10025672",
+        "identifierType": "CBP"
+      },
       "entryNumber": "A123456",
       "bondValue": 12000,
       "entryValue": 12000,
@@ -150,7 +155,7 @@ example: |-
       "lineItems": [
         {
           "type": [
-            "ImmediateDeliveryLineItem"
+            "CBPEntryLineItem"
           ],
           "commodity": {
             "type": [
@@ -163,7 +168,7 @@ example: |-
           "itemCount": 400,
           "itemParty": {
             "type": [
-              "ImmediateDeliveryEntity"
+              "CBPEntryEntity"
             ],
             "consignee": {
               "type": [
@@ -185,8 +190,13 @@ example: |-
                 }
               }
             },
-            "assignedIdentifier": "12345678",
-            "assignedIdentifierType": "CBP"
+            "importerOfRecord": {
+              "type": [
+                "CBPImporterOfRecord"
+              ],
+              "number": "10025672",
+              "identifierType": "CBP"
+            }
           },
           "freeTradeZoneFilingDate": "2022-02-25",
           "freeTradeZoneStatus": "N",
@@ -212,9 +222,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-01-05T10:32:34Z",
+      "created": "2023-03-24T11:50:32Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..u4dGZaXQPX6rpwYn5sPhx_RbqaYSOlokoJ2w8vLazS4TMcZA5ovGTa73WMrxuiSgv8YU2cL8PgKwcJLCZ1WPBQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..S-HFQpNkO7DWPixX1D9oNdYnj51ucvncb4lkFs4o3fEgcs1U5C6-HljVGc-1gesNHJQGkSCTshCO1v4DBuFNAQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
@@ -41,7 +41,7 @@ properties:
   issuer:
     $ref: ../common/Organization.yml
   credentialSubject:
-    $ref: ../common/EntrySummary.yml
+    $ref: ../common/CBPEntrySummary.yml
   proof:
     $ref: ../snippets/proof.yml
   relatedLink:
@@ -92,7 +92,7 @@ example: |-
     "issuanceDate": "2022-03-03T15:20:00Z",
     "credentialSubject": {
       "type": [
-        "EntrySummary"
+        "CBPEntrySummary"
       ],
       "entryNumber": "73461882610",
       "entryType": "01",
@@ -181,7 +181,7 @@ example: |-
       "descriptionOfMerchandise": [
         {
           "type": [
-            "EntrySummaryLineItem"
+            "CBPEntrySummaryLineItem"
           ],
           "commodity": {
             "type": [
@@ -267,9 +267,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-11-10T05:34:17Z",
+      "created": "2023-03-24T11:26:39Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..tUukNXbfzN4RJC1ateqJD9MMdYAEPnyBVSDECF7M0IcPPdYqnK0l9U7dA9MEgfFzmekE3FPhUI1R69zMFLIFCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ZoxS4LlF-K--onTbY0MPkY8raVEk2qEuzf7KZ7SVBpYiLm0zC9O9IYKvk6aD2VJWrCGwg0IvpZlDlSGIKpkQAg"
     }
   }


### PR DESCRIPTION
This PR tightens up aspects of the 3461 and 7501 CBP forms: 

1. Properly names 3461 as "Entry" which is its main purpose (it also serves Immediate Delivery purposes in special cases).
2. Adds "CBP" to class naming. 
3. Wraps importerOfRecord identifier in a dedicated class (aligned with CTPAT).