### PR TITLE
Fix type error in common/TradeLineItem.yml

### DIFF
--- a/docs/openapi/components/schemas/common/TradeLineItem.yml
+++ b/docs/openapi/components/schemas/common/TradeLineItem.yml
@@ -61,7 +61,7 @@ properties:
     type: string
   countryOfOrigin:
     title: Country of Origin
-    description: Identify the 2-digit ISO country code of the country of production.
+    description: Identify the 2-character ISO country code of the country of production.
     type: string
     $linkedData:
       term: countryOfOrigin

--- a/docs/openapi/components/schemas/common/TradeLineItem.yml
+++ b/docs/openapi/components/schemas/common/TradeLineItem.yml
@@ -62,6 +62,7 @@ properties:
   countryOfOrigin:
     title: Country of Origin
     description: Identify the 2-digit ISO country code of the country of production.
+    type: string
     $linkedData:
       term: countryOfOrigin
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncefact/#originCountry


### PR DESCRIPTION
This is fixing a small error in Tradeline item where there is no type (string, number, ect) defined for `countryOfOrigin`. 