### PR TITLE
Issuer Organization narrowing

### DIFF
--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -3,11 +3,7 @@ $linkedData:
   '@id': https://w3id.org/traceability#CTPATCertificate
 title: CTPAT Certificate
 tags:
-  - Steel
   - eCommerce
-  - Agriculture
-  - Oil and Gas
-  - Other
 description: >-
   Customs Trade Partnership Against Terrorism (CTPAT) is but one layer in U.S.
   Customs and Border Protection’s (CBP) multi-layered cargo enforcement

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -3,7 +3,11 @@ $linkedData:
   '@id': https://w3id.org/traceability#CTPATCertificate
 title: CTPAT Certificate
 tags:
+  - Steel
   - eCommerce
+  - Agriculture
+  - Oil and Gas
+  - Other
 description: >-
   Customs Trade Partnership Against Terrorism (CTPAT) is but one layer in U.S.
   Customs and Border Protection’s (CBP) multi-layered cargo enforcement
@@ -60,7 +64,7 @@ properties:
   expirationDate:
     type: string
   issuer:
-    $ref: ../common/Organization.yml
+    $ref: ../snippets/IssuerOrganization.yml
   credentialSubject:
     $ref: ../common/CTPAT.yml
   credentialStatus:
@@ -111,7 +115,8 @@ example: |-
         "Organization"
       ],
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "CTPAT"
+      "name": "CTPAT",
+      "description": "Customs Trade Partnership Against Terrorism"
     },
     "issuanceDate": "2022-01-13T09:16:46Z",
     "expirationDate": "2122-01-13T09:16:46Z",
@@ -174,9 +179,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-03-20T11:20:11Z",
+      "created": "2023-03-28T11:39:05Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Kw5V5ujAxGmizCbP6GHFb830-chr45_FSIGFwKoXWFquPkBX9rQhlzxY2dsivEraxvtovLdLwhw_mdMt3QiXAQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Hes-MaX6pvAtuwA2n2PsUegKMl-26buLxeH2xLpa5xMw0J1TRcOuJVmKxC76H8UBvMJKUihA0ypTdiUy7ESEAQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -3,7 +3,11 @@ $linkedData:
   '@id': https://w3id.org/traceability#CertificationOfOrigin
 title: Certification Of Origin
 tags:
+  - Steel
   - eCommerce
+  - Agriculture
+  - Oil and Gas
+  - Other
 description: >- 
   A document attesting to the country of origin of the goods. A certificate of origin is often required by customs authorities of a country as part of the entry process. Such certificates are usually through an official organization in the country of origin such as the local chamber of commerce or a consular office. The goods description must coincide with that provided in the commercial invoice and in the packing list (number, goods description, name of the consignor and of the consignee, trademarks, etc.). If the certificate of origin is not shown, the import customs may, if it deems it necessary, accept the dispatching of goods. In this case, the corresponding tariff would be applied to third countries (non preferential origin), without any tariff discount. Although the World Customs Organization and the World Trade Organization have tried to create a single set of origin criteria in worldwide use, none exists at this time. Some countries and free-trade zones (such as NAFTA) require that origin be certified in terms of special criteria such as tariff shift or percentage value. Traders are well advised to assure that any applicable origin rules are understood and any required documentation is obtainable before concluding sales contracts. (Source: Olegario Llamazares: Dictionary Of International Trade, Key definitions of 2000 trade terms and acronyms.)
 type: object
@@ -47,7 +51,7 @@ properties:
   expirationDate:
     type: string
   issuer:
-    $ref: ../common/Organization.yml
+    $ref: ../snippets/IssuerOrganization.yml
   credentialSubject:
     type: object
     properties:
@@ -63,6 +67,7 @@ properties:
         title: Date of Export
         description: The date, time, date time, or other date time value when the subject line item(s) will exit, or has(have) exited from the last port, airport, or border post of the country of export.
         type: string
+        format: date
     additionalProperties: false
     required:
       - items
@@ -112,7 +117,9 @@ example: |-
           "name": "Espresso Italiano",
           "description": "Premium Prosumer Espresso Makers - Model Dolce",
           "product": {
-            "type": ["Product"],
+            "type": [
+              "Product"
+            ],
             "commodity": {
               "type": [
                 "Commodity"
@@ -124,13 +131,13 @@ example: |-
         }
       ],
       "manufacturingCountry": "IT",
-      "dateOfExport": "2022-02-02T09:30:00Z"
+      "dateOfExport": "2022-02-02"
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-10-27T08:26:29Z",
+      "created": "2023-03-28T11:30:33Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..e1Ht4mqGCCTDV9jBkaEgyVOZDDQMhqrvjr8gx4zjKuDuBSbY0-r44_fHlgaHPF8PGQuECtlMfyY2K_IrUn8SBg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2uc4gcJQYbmqsf1C1vtkfGQP1vVzgJOkK0xg04QFNKZ5sNg_NGfFySopr_ahS8sUxKCNvnLSwM8c-HL2sNdPBA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -3,11 +3,7 @@ $linkedData:
   '@id': https://w3id.org/traceability#CertificationOfOrigin
 title: Certification Of Origin
 tags:
-  - Steel
   - eCommerce
-  - Agriculture
-  - Oil and Gas
-  - Other
 description: >- 
   A document attesting to the country of origin of the goods. A certificate of origin is often required by customs authorities of a country as part of the entry process. Such certificates are usually through an official organization in the country of origin such as the local chamber of commerce or a consular office. The goods description must coincide with that provided in the commercial invoice and in the packing list (number, goods description, name of the consignor and of the consignee, trademarks, etc.). If the certificate of origin is not shown, the import customs may, if it deems it necessary, accept the dispatching of goods. In this case, the corresponding tariff would be applied to third countries (non preferential origin), without any tariff discount. Although the World Customs Organization and the World Trade Organization have tried to create a single set of origin criteria in worldwide use, none exists at this time. Some countries and free-trade zones (such as NAFTA) require that origin be certified in terms of special criteria such as tariff shift or percentage value. Traders are well advised to assure that any applicable origin rules are understood and any required documentation is obtainable before concluding sales contracts. (Source: Olegario Llamazares: Dictionary Of International Trade, Key definitions of 2000 trade terms and acronyms.)
 type: object

--- a/docs/openapi/components/schemas/snippets/IssuerOrganization.yml
+++ b/docs/openapi/components/schemas/snippets/IssuerOrganization.yml
@@ -1,5 +1,5 @@
-title: Intent to Import Organization
-description: An organization such as a corporation, firm, club, etc.
+title: Issuer Organization
+description: Organization issuing a Verifiable Credential.
 type: object
 properties:
   type:
@@ -61,9 +61,6 @@ properties:
             title: Name
             description: The name of the entity in text.
             type: string
-            $linkedData:
-              term: name
-              '@id': https://schema.org/name
           streetAddress:
             title: Street Address
             description: >-
@@ -71,40 +68,25 @@ properties:
               printed on paper as the first lines below the name. For example, the name
               of the street and the number in the street or the name of a building.
             type: string
-            $linkedData:
-              term: streetAddress
-              '@id': https://schema.org/streetAddress
           addressLocality:
             title: Address Locality
             description: Text specifying the name of the locality; for example, a city.
             type: string
-            $linkedData:
-              term: addressLocality
-              '@id': https://schema.org/addressLocality
           addressRegion:
             title: Address Region
             description: >-
               Text specifying a province or state in abbreviated format; for example,
               NJ.
             type: string
-            $linkedData:
-              term: addressRegion
-              '@id': https://schema.org/addressRegion
           addressCountry:
             title: Address Country
             description: >-
               The two-letter ISO 3166-1 alpha-2 country code.
             type: string
-            $linkedData:
-              term: addressCountry
-              '@id': https://schema.org/addressCountry
           postalCode:
             title: Postal Code
             description: Text specifying the postal code for an address.
             type: string
-            $linkedData:
-              term: postalCode
-              '@id': https://schema.org/postalCode
         additionalProperties: false
         required:
           - type

--- a/docs/openapi/components/schemas/snippets/IssuerOrganization.yml
+++ b/docs/openapi/components/schemas/snippets/IssuerOrganization.yml
@@ -1,0 +1,130 @@
+title: Intent to Import Organization
+description: An organization such as a corporation, firm, club, etc.
+type: object
+properties:
+  type:
+    type: array
+    readOnly: true
+    const:
+      - Organization
+    default:
+      - Organization
+    items:
+      type: string
+      enum:
+        - Organization
+  id: 
+    title: Identifier
+    description: Organization identifier.
+    type: string
+  name:
+    title: Name
+    description: Name of the organization.
+    type: string
+  description:
+    title: Description
+    description: Description of the company.
+    type: string
+  location:
+    title: Location
+    description: The location of, for example, where an event is happening, where an organization is located, or where an action takes place.
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - Place
+        default:
+          - Place
+        items:
+          type: string
+          enum:
+            - Place
+      address:
+        title: Postal Address
+        description: The postal address for an organization or place.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - PostalAddress
+            default:
+              - PostalAddress
+            items:
+              type: string
+              enum:
+                - PostalAddress
+          name:
+            title: Name
+            description: The name of the entity in text.
+            type: string
+            $linkedData:
+              term: name
+              '@id': https://schema.org/name
+          streetAddress:
+            title: Street Address
+            description: >-
+              The street address expressed as free form text. The street address is
+              printed on paper as the first lines below the name. For example, the name
+              of the street and the number in the street or the name of a building.
+            type: string
+            $linkedData:
+              term: streetAddress
+              '@id': https://schema.org/streetAddress
+          addressLocality:
+            title: Address Locality
+            description: Text specifying the name of the locality; for example, a city.
+            type: string
+            $linkedData:
+              term: addressLocality
+              '@id': https://schema.org/addressLocality
+          addressRegion:
+            title: Address Region
+            description: >-
+              Text specifying a province or state in abbreviated format; for example,
+              NJ.
+            type: string
+            $linkedData:
+              term: addressRegion
+              '@id': https://schema.org/addressRegion
+          addressCountry:
+            title: Address Country
+            description: >-
+              The two-letter ISO 3166-1 alpha-2 country code.
+            type: string
+            $linkedData:
+              term: addressCountry
+              '@id': https://schema.org/addressCountry
+          postalCode:
+            title: Postal Code
+            description: Text specifying the postal code for an address.
+            type: string
+            $linkedData:
+              term: postalCode
+              '@id': https://schema.org/postalCode
+        additionalProperties: false
+        required:
+          - type
+additionalProperties: false
+required:
+  - type
+example: |-
+  {
+    "type": ["Organization"],
+    "name": "Maxi Acero Mexicano",
+    "description": "Fusion y fabricacion de acero solido",
+    "location": {
+      "type": ["Place"],
+      "address": {
+        "type": ["PostalAddress"],
+        "streetAddress": "Avenida Carlos 100",
+        "addressLocality": "Hernádez de Mara",
+        "addressRegion": "Nuevo Leon",
+        "postalCode": "32200",
+        "addressCountry": "Mexico"
+      }
+    }
+  }

--- a/docs/openapi/components/schemas/snippets/IssuerOrganization.yml
+++ b/docs/openapi/components/schemas/snippets/IssuerOrganization.yml
@@ -27,7 +27,7 @@ properties:
     type: string
   location:
     title: Location
-    description: The location of, for example, where an event is happening, where an organization is located, or where an action takes place.
+    description: The location where, for example, an event is happening, an organization is located, or an action takes place.
     type: object
     properties:
       type:

--- a/docs/openapi/components/schemas/snippets/IssuerOrganization.yml
+++ b/docs/openapi/components/schemas/snippets/IssuerOrganization.yml
@@ -66,7 +66,7 @@ properties:
             description: >-
               The street address expressed as free form text. The street address is
               printed on paper as the first lines below the name. For example, the name
-              of the street and the number in the street or the name of a building.
+              of the street and the number in the street, or the name of a building.
             type: string
           addressLocality:
             title: Address Locality


### PR DESCRIPTION
This PR introduces a limited subset of Organization intended to be generically applicable for vc.issuer.

I only updated CTPAT and CertificateOfOrigin for now, but I would consider this (or another dedicated narrowing) anywhere where we currently use: 

```
  issuer:
    $ref: ../common/Organization.yml
```