### PR TITLE
fix: excess references

### DIFF
--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -371,33 +371,13 @@ properties:
         title: Certificate Number
         description: Mill test report certificate number.
         type: string
-      certificateType:
-        title: Certification Type
+      certification:
+        title: Certification
         description: The type of certification conducted. 
-        type: string
-      customerNumber:
-        title: Customer Number
-        description: Customer number.
         type: string
       purchaseOrderNumber:
         title: Purchase Order Number
         description: Purchase order number. 
-        type: string
-      invoiceNumber:
-        title: Invoice Number
-        description: Invoice number.
-        type: string
-      manufacturingOrder:
-        title: Manufacturing Order
-        description: Manufactoring order number. 
-        type: string
-      billOfLadingNumber:
-        title: Bill Of Lading Number
-        description: Bill of Lading number.
-        type: string
-      customerReferenceNumber:
-        title: Customer Reference Number
-        description: Customer's reference.
         type: string
       productSpecification:
         title: Product Specification
@@ -417,7 +397,7 @@ properties:
                 - SteelProduct
           standard:
             title: Standard
-            description: Required product standard.
+            description: Grading system standard.
             type: string
           grade:
             title: Grade
@@ -1150,24 +1130,17 @@ example: |-
         }
       },
       "certificateNumber": "202304215088",
-      "certificateType": "EN 10204.3.1",
-      "customerNumber": "10288",
+      "certification": "EN 10204.3.1",
       "purchaseOrderNumber": "PO992765413",
-      "invoiceNumber": "INV1988211-1254",
-      "manufacturingOrder": "12994661/23",
-      "billOfLadingNumber": "CCTR91822452",
-      "customerReferenceNumber": "8911190",
       "productSpecification": {
         "type": [
           "SteelProduct"
         ],
-        "specification": "ASTM- A615-01a",
+        "standard": "AISI/SAE",
         "grade": [
-          "60",
-          "420"
+          "316"
         ],
-        "standard": "API 5 CT",
-        "heatTreatment": "Min. 1040 Celcius, Quenched",
+        "heatTreatment": "Min. 1900F, Quenched",
         "surfaceTreatment": "Varnished"
       },
       "remarks": "No Mercury, Lead or Sulfor. Free from radioactive contamination.",
@@ -1297,9 +1270,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-04-25T19:19:05Z",
+      "created": "2023-04-26T08:23:53Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..tuVajExDilR8qOztibM48XMLajYIEPW8EkrcOtAE3nb4EjSqFs7Jhj-PkX5bS1p2xx26O_8PvvULLeqzov7ICA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..Gq_4I8eTxstpe1kffGrGFPTVSeZ9j3nQufZqw6gYo95OCDxnUsHBGBdUyxgW_wAACXI5UE2bnnaIbXgY0m8hDA"
     }
   }


### PR DESCRIPTION
This commit was supposed to have been part of https://github.com/w3c-ccg/traceability-vocab/pull/748. Taking the liberty of sneaking it in. 