### PR TITLE
MTR shipto optionality

### DIFF
--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -353,20 +353,8 @@ properties:
                     description: Text specifying the postal code for an address.
                     type: string
                 additionalProperties: false
-                required:
-                  - type
-                  - streetAddress
-                  - addressLocality
-                  - addressCountry
             additionalProperties: false
-            required:
-              - type
-              - address
         additionalProperties: false
-        required:
-          - type
-          - name
-          - location
       certificateNumber:
         title: Certificate Number
         description: Mill test report certificate number.

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -105,11 +105,11 @@ properties:
                   of the street and the number in the street, or the name of a building.
                 type: string
               addressLocality:
-                title: Address Locality
+                title: City
                 description: Text specifying the name of the locality; for example, a city.
                 type: string
               addressRegion:
-                title: Address Region
+                title: State
                 description: >-
                   Text specifying a province or state in abbreviated format; for example,
                   NJ.
@@ -119,7 +119,7 @@ properties:
                 description: Text specifying the postal code for an address.
                 type: string
               addressCountry:
-                title: Address Country
+                title: Country
                 description: >-
                   The two-letter ISO 3166-1 alpha-2 country code.
                 type: string
@@ -223,30 +223,23 @@ properties:
                       of the street and the number in the street or the name of a building.
                     type: string
                   addressLocality:
-                    title: Address Locality
+                    title: City
                     description: Text specifying the name of the locality; for example, a city.
                     type: string
                   addressRegion:
-                    title: Address Region
+                    title: State
                     description: >-
                       Text specifying a province or state in abbreviated format; for example,
                       NJ.
                     type: string
-                  addressCountry:
-                    title: Address Country
-                    description: >-
-                      The two-letter ISO 3166-1 alpha-2 country code.
-                    type: string
-                  countyCode:
-                    title: County Code
-                    description: >-
-                      A code that identifies a county. A county is a territorial division in
-                      some countries, forming the chief unit of local administration. In the US,
-                      a county is a political and administrative division of a state.
-                    type: string
                   postalCode:
                     title: Postal Code
                     description: Text specifying the postal code for an address.
+                    type: string
+                  addressCountry:
+                    title: Country
+                    description: >-
+                      The two-letter ISO 3166-1 alpha-2 country code.
                     type: string
                 additionalProperties: false
                 required:
@@ -285,7 +278,7 @@ properties:
             type: string
           name:
             title: Name
-            description: Ship to organization's name.
+            description: Ship to organization's name. Conditionally mandatory if the ship to party is included. 
             type: string
           location:
             title: Location
@@ -325,32 +318,29 @@ properties:
                       The street address expressed as free form text. The street address is
                       printed on paper as the first lines below the name. For example, the name
                       of the street and the number in the street or the name of a building.
+                      Conditionally mandatory if the ship to party is included. 
                     type: string
                   addressLocality:
-                    title: Address Locality
-                    description: Text specifying the name of the locality; for example, a city.
+                    title: City
+                    description: >-
+                      Text specifying the name of the locality; for example, a city.
+                      Conditionally mandatory if the ship to party is included. 
                     type: string
                   addressRegion:
-                    title: Address Region
+                    title: State
                     description: >-
                       Text specifying a province or state in abbreviated format; for example,
-                      NJ.
-                    type: string
-                  addressCountry:
-                    title: Address Country
-                    description: >-
-                      The two-letter ISO 3166-1 alpha-2 country code.
-                    type: string
-                  countyCode:
-                    title: County Code
-                    description: >-
-                      A code that identifies a county. A county is a territorial division in
-                      some countries, forming the chief unit of local administration. In the US,
-                      a county is a political and administrative division of a state.
+                      NJ. 
                     type: string
                   postalCode:
                     title: Postal Code
                     description: Text specifying the postal code for an address.
+                    type: string
+                  addressCountry:
+                    title: Country
+                    description: >-
+                      The two-letter ISO 3166-1 alpha-2 country code.
+                      Conditionally mandatory if the ship to party is included. 
                     type: string
                 additionalProperties: false
             additionalProperties: false


### PR DESCRIPTION
Optional elements should not contain mandatory child elements. 