### PR TITLE
Intent to import tightening

### DIFF
--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -9,7 +9,7 @@ tags:
   - Oil and Gas
   - Other
 description: >-
-  A basic indication to US CBP that the issuing organization wishes to start digital importing procedures of goods entering the United States. 
+  A basic indication to US CBP that the issuing organization wishes to start digital importing procedures for goods entering the United States. 
 
   An Intent To Import Credential should be included in the first submission of Traceable Presentations. 
 

--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -51,7 +51,7 @@ properties:
   description:
     type: string
   issuanceDate:
-    description: Date at which the import intention is declared.
+    description: Date on which the import intention is declared.
     type: string
   expirationDate:
     type: string

--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -251,7 +251,7 @@ example: |-
       "type": [
         "IntentToImport"
       ],
-      "importIntent": "By issuing this Intent to Import Verifiable Credential and presenting it in a Traceable Presentation to US CBP, the issuing organization initiates a digital procedure of importing goods into the United States."
+      "importIntent": "By issuing this Intent to Import Verifiable Credential and presenting it in a Traceable Presentation to US CBP, the issuing organization initiates a digital procedure for importing goods into the United States."
     },
     "proof": {
       "type": "Ed25519Signature2018",

--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -178,8 +178,8 @@ properties:
         title: Import Intent
         type: string
         readOnly: true
-        const: By issuing this Intent to Import Verifiable Credential and presenting it in a Traceable Presentation to US CBP, the issuing organization initiates a digital procedure of importing goods into the United States. 
-        default: By issuing this Intent to Import Verifiable Credential and presenting it in a Traceable Presentation to US CBP, the issuing organization initiates a digital procedure of importing goods into the United States.
+        const: By issuing this Intent to Import Verifiable Credential and presenting it in a Traceable Presentation to US CBP, the issuing organization initiates a digital procedure for importing goods into the United States. 
+        default: By issuing this Intent to Import Verifiable Credential and presenting it in a Traceable Presentation to US CBP, the issuing organization initiates a digital procedure for importing goods into the United States.
     additionalProperties: false
     required:
       - type

--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -9,15 +9,11 @@ tags:
   - Oil and Gas
   - Other
 description: >-
-  A simple case where an entity (person or organization) wishes to notify some
-  third party that they intend to import some product, likely into a different
-  geographic region than that of its origin. This can be used to identify and 
-  declare intent earlier in the process than would be possible otherwise. This 
-  object may be easily subclassed for extension with other data for cases 
-  where additional regulatory data may be required.
+  A basic indication to US CBP that the issuing organization wishes to start digital importing procedures of goods entering the United States. 
 
-  An Intent To Import Credential should be included in the first submission of 
-  Traceable Presentations. 
+  An Intent To Import Credential should be included in the first submission of Traceable Presentations. 
+
+  Additional Verifiable Credentials to be presented depends on the workflow definition(s) indicated on the presentation. 
 type: object
 properties:
   '@context':
@@ -55,11 +51,102 @@ properties:
   description:
     type: string
   issuanceDate:
+    description: Date at which the import intention is declared.
     type: string
   expirationDate:
     type: string
   issuer:
-    $ref: ../snippets/IssuerOrganization.yml
+    title: Issuer Organization
+    description: The organization indicating intent to import, thereby initiating the corresponding import workflow. 
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - Organization
+        default:
+          - Organization
+        items:
+          type: string
+          enum:
+            - Organization
+      id: 
+        title: Issuer's Identifier
+        description: Issuing organization identifier, typically a Decentralized Identifier (DID).
+        type: string
+      name:
+        title: Name
+        description: Issuing organization name.
+        type: string
+      location:
+        title: Location
+        description: Issuing organization's location of business.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Place
+            default:
+              - Place
+            items:
+              type: string
+              enum:
+                - Place
+          address:
+            title: Postal Address
+            description: Issuing organization's postal address.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - PostalAddress
+                default:
+                  - PostalAddress
+                items:
+                  type: string
+                  enum:
+                    - PostalAddress
+              streetAddress:
+                title: Street Address
+                description: >-
+                  The street address expressed as free form text. The street address is
+                  printed on paper as the first lines below the name. For example, the name
+                  of the street and the number in the street, or the name of a building.
+                type: string
+              addressLocality:
+                title: City
+                description: Text specifying the name of the locality; for example, a city.
+                type: string
+              addressRegion:
+                title: State
+                description: >-
+                  Text specifying a province or state in abbreviated format; for example,
+                  NJ.
+                type: string
+              postalCode:
+                title: Postal Code
+                description: Text specifying the postal code for an address.
+                type: string
+              addressCountry:
+                title: Country
+                description: >-
+                  The two-letter ISO 3166-1 alpha-2 country code.
+                type: string
+            additionalProperties: false
+            required:
+              - type
+              - streetAddress
+              - addressLocality
+              - addressCountry
+    additionalProperties: false
+    required:
+      - type
+      - id
   credentialSchema:
     type: object
     properties:
@@ -74,15 +161,51 @@ properties:
         description: The type of validation to be run against the defined schema
         const: OpenApiSpecificationValidator2022
   credentialSubject:
-    $ref: ../common/IntentToImport.yml
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - IntentToImport
+        default:
+          - IntentToImport
+        items:
+          type: string
+          enum:
+            - IntentToImport
+      importIntent:
+        title: Import Intent
+        type: string
+        readOnly: true
+        const: By issuing this Intent to Import Verifiable Credential and presenting it in a Traceable Presentation to US CBP, the issuing organization initiates a digital procedure of importing goods into the United States. 
+        default: By issuing this Intent to Import Verifiable Credential and presenting it in a Traceable Presentation to US CBP, the issuing organization initiates a digital procedure of importing goods into the United States.
+    additionalProperties: false
+    required:
+      - type
+      - importIntent
   proof:
-    $ref: ../snippets/proof.yml
-  relatedLink:
-    title: Related Link
-    description: Links related to this verifiable credential
-    type: array
-    items:
-      $ref: ../common/LinkRole.yml
+    title: proof
+    description: A JSON Web Signature proof for a credential as defined by the VC data model 
+    type: object
+    properties:
+      type:
+        type: string
+        description: Signature suite for the proof
+        enum:
+          - Ed25519Signature2018
+      created:
+        description: Creation timestamp for the proof in the form of an XML datestring
+        type: string
+      verificationMethod:
+        description: The fragment from which the public key can be de-referenced, in the form of a URI
+        type: string
+      proofPurpose:
+        description: In the case of credentials, the proof should be the constant, 'assertionMethod'
+        const: assertionMethod
+      jws:
+        description: The JSON Web Signature for the proof
+        type: string
 additionalProperties: false
 required:
   - '@context'
@@ -106,6 +229,7 @@ example: |-
         "Organization"
       ],
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "name": "Generic Motors of America",
       "location": {
         "type": [
           "Place"
@@ -114,7 +238,6 @@ example: |-
           "type": [
             "PostalAddress"
           ],
-          "name": "Generic Motors of America",
           "streetAddress": "12 Generic Motors Dr",
           "addressLocality": "Detroit",
           "addressRegion": "Michigan",
@@ -128,96 +251,13 @@ example: |-
       "type": [
         "IntentToImport"
       ],
-      "exporter": {
-        "type": [
-          "Organization"
-        ],
-        "name": "Maxi Acero Mexicano",
-        "description": "Fusion y fabricacion de acero solido",
-        "location": {
-          "type": [
-            "Place"
-          ],
-          "address": {
-            "type": [
-              "PostalAddress"
-            ],
-            "streetAddress": "Avenida Carlos 100",
-            "addressLocality": "Hernádez de Mara",
-            "addressRegion": "Nuevo Leon",
-            "postalCode": "32200",
-            "addressCountry": "Mexico"
-          }
-        },
-        "email": "info@example.net",
-        "phoneNumber": "555-127-7813"
-      },
-      "importer": {
-        "type": [
-          "Organization"
-        ],
-        "id": "did:web:generic-motor-company.example.com",
-        "location": {
-          "type": [
-            "Place"
-          ],
-          "address": {
-            "type": [
-              "PostalAddress"
-            ],
-            "name": "Generic Motors of America",
-            "streetAddress": "12 Generic Motors Dr",
-            "addressLocality": "Detroit",
-            "addressRegion": "Michigan",
-            "postalCode": "48232-5170",
-            "addressCountry": "USA"
-          }
-        }
-      },
-      "product": {
-        "type": [
-          "Product"
-        ],
-        "manufacturer": {
-          "type": [
-            "Organization"
-          ],
-          "name": "Maxi Acero Mexicano",
-          "description": "Fusion y fabricacion de acero solido",
-          "location": {
-            "type": [
-              "Place"
-            ],
-            "address": {
-              "type": [
-                "PostalAddress"
-              ],
-              "streetAddress": "Avenida Carlos 100",
-              "addressLocality": "Hernádez de Mara",
-              "addressRegion": "Nuevo Leon",
-              "postalCode": "32200",
-              "addressCountry": "Mexico"
-            }
-          },
-          "email": "info@example.net",
-          "phoneNumber": "555-127-7813"
-        },
-        "description": "UNS S30400 chromium-nickel stainless steel rolls.",
-        "weight": {
-          "type": [
-            "QuantitativeValue"
-          ],
-          "unitCode": "lbs",
-          "value": "16500"
-        }
-      },
-      "declarationDate": "2022-03-21"
+      "importIntent": "By issuing this Intent to Import Verifiable Credential and presenting it in a Traceable Presentation to US CBP, the issuing organization initiates a digital procedure of importing goods into the United States."
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-04-04T21:39:05Z",
+      "created": "2023-05-02T07:40:13Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..h2O1TTn5EkasnshQMyQVEzs7CCvP1Xswks58sB45ClCzN8GXB0xS3cHne3uh85if7FjZOm39DEEKY-_ZXv3hCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..5yNPoHBA0nXNw-0oe7myLhnhIhlUNGW5yYOw-9pEuBVLREAJVUQBDMgRsyZlMxKbfmDfPklNHB3tXr7671FeBQ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -13,7 +13,7 @@ description: >-
 
   An Intent To Import Credential should be included in the first submission of Traceable Presentations. 
 
-  Additional Verifiable Credentials to be presented depends on the workflow definition(s) indicated on the presentation. 
+  Any additional Verifiable Credentials to be presented depend on the workflow definition(s) indicated on the presentation. 
 type: object
 properties:
   '@context':


### PR DESCRIPTION
This removes the excess party and product requirements on the intent to import schema, trimming it down to the requirement of establishing the importer's identity. 

All remaining data will be captured in other credential schemas, required by associated workflow definitions.