### PR TITLE
add monthly advance Manifest

### DIFF
--- a/docs/credentials-with-issuer-dependent-terms.json
+++ b/docs/credentials-with-issuer-dependent-terms.json
@@ -80,6 +80,10 @@
     "count": 0
   },
   {
+    "type": "MonthlyAdvanceManifestCredential",
+    "count": 20
+  },
+  {
     "type": "MillTestReportCredential",
     "count": 179
   },

--- a/docs/openapi/components/schemas/common/MonthlyAdvanceManifest.yml
+++ b/docs/openapi/components/schemas/common/MonthlyAdvanceManifest.yml
@@ -1,0 +1,81 @@
+$linkedData:
+  term: MonthlyAdvanceManifest
+  '@id': https://w3id.org/traceability#MonthlyAdvanceManifest
+title: Monthly Advance Manifest
+description: A manifest that contains the scheduled deliveries by location for the upcoming month.
+type: object
+properties:
+  type:
+    type: array
+    readOnly: true
+    const:
+      - MonthlyAdvanceManifest
+    default:
+      - MonthlyAdvanceManifest
+    items:
+      type: string
+      enum:
+        - MonthlyAdvanceManifest
+  date:
+    title: Date
+    description: A date time value when the manifest is created
+    type: string
+    $linkedData:
+      term: date
+      '@id': https://schema.org/Date
+  scheduledDeliveries:
+    title: scheduledDeliveries
+    description: Scheduled deliveries for the upcoming month
+    type: array
+    items:
+      scheduledDelivery:
+        title: ScheduledDelivery
+        description: sum of all deliveries scheduled for a given location
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - ScheduledDelivery
+            default:
+              - ScheduledDelivery
+            items:
+              type: string
+              enum:
+                - ScheduledDelivery
+          deliveryLocation:
+            type: string
+            title: deliveryLocation
+            description: name of the delivery location
+          sumOfScheduledDeliveries:
+            type: string
+            title: Sum of Scheduled Deliveries
+            description: sum of volumes delivered to the delivery location in one month     
+          numberOfBatches:
+            type: string
+            title: Number of Batches
+            description: Number of batches scheduled for the delivery location in one month       
+
+ 
+additionalProperties: false
+required:
+  - type
+example: |-
+  {
+    "type": [
+        "MonthlyAdvanceManifest"
+    ],
+    "date": "2019-12-11T03:50:55Z",
+    "scheduledDeliveries": [
+        {
+            "deliveryLocation": "Enbridge Cushing",
+            "sumOfScheduledDelivires": "2000",
+            "numberOfBatches": "1"
+        },
+        {
+            "deliveryLocation": "Philips 66",
+            "sumOfScheduledDelivires": "2000",
+            "numberOfBatches": "1"
+        }
+    ]
+  }

--- a/docs/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
@@ -1,0 +1,118 @@
+$linkedData:
+  term: MonthlyAdvanceManifestCredential
+  '@id': https://w3id.org/traceability#MonthlyAdvanceManifestCredential
+title: Monthly Advance Manifest Credential
+tags:
+  - Oil and Gas
+description: A manifest that contains the scheduled deliveries by location for the upcoming month.
+type: object
+properties:
+  '@context':
+    type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    items:
+      type: string
+      enum:
+        - https://www.w3.org/2018/credentials/v1
+        - https://w3id.org/traceability/v1
+  type:
+    type: array
+    readOnly: true
+    const:
+      - VerifiableCredential
+      - MonthlyAdvanceManifestCredential
+    default:
+      - VerifiableCredential
+      - MonthlyAdvanceManifestCredential
+    items:
+      type: string
+      enum:
+        - VerifiableCredential
+        - MonthlyAdvanceManifestCredential
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  expirationDate:
+    type: string
+  issuer:
+    type: string
+  credentialSchema:
+    type: object
+    properties:
+      id:
+        title: Id
+        description: The url of the schema file to validate the shape of the json object
+        type: string
+        format: uri
+        example: https://w3id.org/traceability/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
+      type:
+        title: Type
+        description: The type of validation to be run against the defined schema
+        const: OpenApiSpecificationValidator2022
+  credentialSubject:
+    $ref: ../common/MonthlyAdvanceManifest.yml
+  proof:
+    $ref: ../snippets/proof.yml
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ../common/LinkRole.yml
+additionalProperties: false
+required:
+  - '@context'
+  - type
+  - issuanceDate
+  - issuer
+  - credentialSubject
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "http://example.org/credentials/",
+    "type": [
+      "VerifiableCredential",
+      "MonthlyAdvanceManifestCredential"
+    ],
+    "issuanceDate": "2021-02-04T20:29:37+00:00",
+    "issuer": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+    "credentialSubject": {
+      "type": [
+        "MonthlyAdvanceManifest"
+      ],
+      "date": "2019-12-11T03:50:55Z",
+      "scheduledDeliveries": [
+        {
+          "deliveryLocation": "Enbridge Cushing",
+          "sumOfScheduledDelivires": "2000",
+          "numberOfBatches": "1"
+        },
+        {
+          "deliveryLocation": "Philips 66",
+          "sumOfScheduledDelivires": "2000",
+          "numberOfBatches": "1"
+        }
+      ]
+    },
+    "proof": {
+      "type": "Ed25519Signature2018",
+      "created": "2023-05-02T17:06:28Z",
+      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..wCwul-wrxcOjjgD9aiBTqSBaKTNm3_y49MA_5dJXgfF89_K8gsM5j8JHFRkorSFQXJ24ryzUcsV7bE7wkFwtBg"
+    }
+  }

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -1064,6 +1064,18 @@ paths:
                 $ref: './components/schemas/common/MechanicalProperty.yml'
     
 
+  /schemas/common/MonthlyAdvanceManifest.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/MonthlyAdvanceManifest.yml'
+    
+
   /schemas/common/MonthlyDeliveryStatement.yml:
     get:
       tags:
@@ -2550,6 +2562,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/MillTestReportCredential.yml'
+    
+
+  /schemas/credentials/MonthlyAdvanceManifestCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/MonthlyAdvanceManifestCredential.yml'
     
 
   /schemas/credentials/MultiModalBillOfLadingCredential.yml:


### PR DESCRIPTION
Adds a monthly advance manifest, which is a document generated by a pipeline indicated their expected scheduled deliveries and volumes per location for the next month.