### PR TITLE
MTR minor tweaks

### DIFF
--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -220,7 +220,6 @@ properties:
                   streetAddress:
                     title: Street Address
                     description: >-
-                      The street address expressed as free form text. The street address is
                       printed on paper as the first lines below the name. For example, the name
                       of the street and the number in the street or the name of a building.
                     type: string
@@ -383,10 +382,7 @@ properties:
           grade:
             title: Grade
             description: Material grade.
-            type: array
-            minItems: 1
-            items: 
-              type: string
+            type: string
           heatTreatment:
             title: Heat Treatment
             description: Special heat treatments, depending on product specification. 
@@ -395,10 +391,15 @@ properties:
             title: Surface Treatment
             description: Surface treatments, if applicable. 
             type: string
+          productDescription: 
+            title: Product Description
+            description: Descriptive product name. 
+            type: string
         required:
           - type
           - standard
           - grade
+          - productDescription
       remarks:
         title: Remarks
         description: Additional attestation remarks. 
@@ -427,10 +428,6 @@ properties:
             productIdentifier: 
               title: Product Identifier
               description: Product identifier such as lot, part, coil, or serial number.
-              type: string
-            productName: 
-              title: Product Name
-              description: Descriptive product name. 
               type: string
             productDimensions: 
               title: Product Dimensions
@@ -466,9 +463,7 @@ properties:
                           - MeasuredValue
                     value:
                       title: Measurement Value
-                      description: >-
-                        A floating-point numeric value that is qualified by the corresponding
-                        measurement unit code - see gs1:unitCode.
+                      description: The measured value of an observation.
                       type: string
                     unitCode:
                       title: Measurement Unit
@@ -496,9 +491,7 @@ properties:
                           - MeasuredValue
                     value:
                       title: Measurement Value
-                      description: >-
-                        A floating-point numeric value that is qualified by the corresponding
-                        measurement unit code - see gs1:unitCode.
+                      description: The measured value of an observation.
                       type: string
                     unitCode:
                       title: Measurement Unit
@@ -526,9 +519,7 @@ properties:
                           - MeasuredValue
                     value:
                       title: Measurement Value
-                      description: >-
-                        A floating-point numeric value that is qualified by the corresponding
-                        measurement unit code - see gs1:unitCode.
+                      description: The measured value of an observation.
                       type: string
                     unitCode:
                       title: Measurement Unit
@@ -556,9 +547,7 @@ properties:
                           - MeasuredValue
                     value:
                       title: Measurement Value
-                      description: >-
-                        A floating-point numeric value that is qualified by the corresponding
-                        measurement unit code - see gs1:unitCode.
+                      description: The measured value of an observation.
                       type: string
                     unitCode:
                       title: Measurement Unit
@@ -593,9 +582,7 @@ properties:
                       - MeasuredValue
                 value:
                   title: Measurement Value
-                  description: >-
-                    A floating-point numeric value that is qualified by the corresponding
-                    measurement unit code - see gs1:unitCode.
+                  description: The measured value of an observation.
                   type: string
                 unitCode:
                   title: Measurement Unit
@@ -623,9 +610,7 @@ properties:
                       - MeasuredValue
                 value:
                   title: Measurement Value
-                  description: >-
-                    A floating-point numeric value that is qualified by the corresponding
-                    measurement unit code - see gs1:unitCode.
+                  description: The measured value of an observation.
                   type: string
                 unitCode:
                   title: Measurement Unit
@@ -783,6 +768,20 @@ properties:
                   $linkedData:
                     term: ca
                     "@id": https://w3id.org/traceability#ca
+                pb:
+                  title: Pb
+                  description: Lead percentage content.
+                  type: number
+                  $linkedData:
+                    term: pb
+                    "@id": https://w3id.org/traceability#pb
+                ce:
+                  title: C.E.
+                  description: Carbon Equivalent percentage content.
+                  type: number
+                  $linkedData:
+                    term: ce
+                    "@id": https://w3id.org/traceability#ce
               additionalProperties: false
               required:
                 - type
@@ -820,9 +819,7 @@ properties:
                           - MeasuredValue
                     value:
                       title: Measurement Value
-                      description: >-
-                        A floating-point numeric value that is qualified by the corresponding
-                        measurement unit code - see gs1:unitCode.
+                      description: The measured value of an observation.
                       type: string
                     unitCode:
                       title: Measurement Unit
@@ -850,9 +847,7 @@ properties:
                           - MeasuredValue
                     value:
                       title: Measurement Value
-                      description: >-
-                        A floating-point numeric value that is qualified by the corresponding
-                        measurement unit code - see gs1:unitCode.
+                      description: The measured value of an observation.
                       type: string
                     unitCode:
                       title: Measurement Unit
@@ -880,9 +875,7 @@ properties:
                           - MeasuredValue
                     value:
                       title: Measurement Value
-                      description: >-
-                        A floating-point numeric value that is qualified by the corresponding
-                        measurement unit code - see gs1:unitCode.
+                      description: The measured value of an observation.
                       type: string
                     unitCode:
                       title: Measurement Unit
@@ -910,9 +903,7 @@ properties:
                           - MeasuredValue
                     value:
                       title: Measurement Value
-                      description: >-
-                        A floating-point numeric value that is qualified by the corresponding
-                        measurement unit code - see gs1:unitCode.
+                      description: The measured value of an observation.
                       type: string
                     unitCode:
                       title: Measurement Unit
@@ -940,9 +931,7 @@ properties:
                           - MeasuredValue
                     value:
                       title: Measurement Value
-                      description: >-
-                        A floating-point numeric value that is qualified by the corresponding
-                        measurement unit code - see gs1:unitCode.
+                      description: The measured value of an observation.
                       type: string
                     unitCode:
                       title: Measurement Unit
@@ -970,9 +959,7 @@ properties:
                           - MeasuredValue
                     value:
                       title: Measurement Value
-                      description: >-
-                        A floating-point numeric value that is qualified by the corresponding
-                        measurement unit code - see gs1:unitCode.
+                      description: The measured value of an observation.
                       type: string
                     unitCode:
                       title: Measurement Unit
@@ -989,7 +976,6 @@ properties:
           required:
             - type
             - productIdentifier
-            - productName
             - productDimensions
             - countryOfManufacture
             - countryOfMeltAndPour
@@ -1121,11 +1107,10 @@ example: |-
           "SteelProduct"
         ],
         "standard": "AISI/SAE",
-        "grade": [
-          "316"
-        ],
+        "grade": "316",
         "heatTreatment": "Min. 1900F, Quenched",
-        "surfaceTreatment": "Varnished"
+        "surfaceTreatment": "Varnished",
+        "productDescription": "Stainless Steel Plate"
       },
       "remarks": "No Mercury, Lead or Sulfor. Free from radioactive contamination.",
       "inspections": [
@@ -1134,7 +1119,6 @@ example: |-
             "Inspection"
           ],
           "productIdentifier": "212900-34",
-          "productName": "Stainless Steel Plate",
           "productDimensions": {
             "type": [
               "ProductDimensions"
@@ -1200,7 +1184,9 @@ example: |-
             "ti": 0.003,
             "b": 0.0014,
             "n": 0.0074,
-            "ca": 0.0018
+            "ca": 0.0018,
+            "pb": 0.001,
+            "ce": 0.3882
           },
           "mechanicalProperties": {
             "type": [
@@ -1254,9 +1240,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-05-02T10:24:41Z",
+      "created": "2023-05-04T21:02:39Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..heG66TwJr4XBZKdDS_dudzW8G7pzyqEN934zhjvTMpYBjzQ9ETJq_1FMqrPf4N9lacLlzCCtB-CdCgm4qU78DA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..AlDcSMe22eZbskLyhP2ogGQ1ZvXpWHSABXPggzDULrI2f_Zd34ZjqU3_srDMo6tPADEZtcWuNB8YYlRINTHIBA"
     }
   }


### PR DESCRIPTION
Based on review of more real life samples, this: 
1. Adds Lead and Carbon Equivalence chemical analysis
2. Moves product desc from inspection array to root 
3. Fixes a bad measured value description
4. Makes steel grade a string instead of array