### PR TITLE
Update Syntax for credential Schema

### DIFF
--- a/docs/openapi/components/schemas/credentials/AgricultureCanineCard.yml
+++ b/docs/openapi/components/schemas/credentials/AgricultureCanineCard.yml
@@ -139,7 +139,9 @@ properties:
         description: The url of the schema file to validate the shape of the json object
         type: string
         format: uri
-        example: https://schema.example/Type.yml
+        example: https://w3id.org/traceability/openapi/components/schemas/common/AgricultureActivity.yml
+		default: https://w3id.org/traceability/openapi/components/schemas/common/AgricultureActivity.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/AgricultureCanineCard.yml
+++ b/docs/openapi/components/schemas/credentials/AgricultureCanineCard.yml
@@ -140,8 +140,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/AgricultureCanineCard.yml
-		default: https://w3id.org/traceability/openapi/components/schemas/credentials/AgricultureCanineCard.yml
-		readonly: true
+		    default: https://w3id.org/traceability/openapi/components/schemas/credentials/AgricultureCanineCard.yml
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/AgricultureCanineCard.yml
+++ b/docs/openapi/components/schemas/credentials/AgricultureCanineCard.yml
@@ -139,8 +139,8 @@ properties:
         description: The url of the schema file to validate the shape of the json object
         type: string
         format: uri
-        example: https://w3id.org/traceability/openapi/components/schemas/common/AgricultureActivity.yml
-		default: https://w3id.org/traceability/openapi/components/schemas/common/AgricultureActivity.yml
+        example: https://w3id.org/traceability/openapi/components/schemas/credentials/AgricultureCanineCard.yml
+		default: https://w3id.org/traceability/openapi/components/schemas/credentials/AgricultureCanineCard.yml
 		readonly: true
       type:
         title: Type

--- a/docs/openapi/components/schemas/credentials/AgricultureCanineCard.yml
+++ b/docs/openapi/components/schemas/credentials/AgricultureCanineCard.yml
@@ -140,8 +140,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/AgricultureCanineCard.yml
-		    default: https://w3id.org/traceability/openapi/components/schemas/credentials/AgricultureCanineCard.yml
-		    readonly: true
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/AgricultureCanineCard.yml
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/BankAccountCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/BankAccountCredential.yml
-		readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
@@ -64,6 +64,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/BankAccountCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/BankAccountCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -68,6 +68,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -69,7 +69,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/BillOfLadingCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/BillOfLadingCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BillOfLadingCredential.yml
@@ -69,7 +69,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/BillOfLadingCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/BillOfLadingCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
@@ -53,6 +53,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
@@ -54,7 +54,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
@@ -54,7 +54,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP3461EntryCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
@@ -53,6 +53,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
@@ -54,7 +54,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
@@ -54,7 +54,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CBP7501EntrySummaryCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -75,7 +75,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATCertificate.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATCertificate.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -74,6 +74,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATCertificate.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATCertificate.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -75,7 +75,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATCertificate.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATCertificate.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
@@ -56,6 +56,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPApplicationCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPFulfillmentCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPMarketplaceCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/CTPATEIPSellerCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -62,7 +62,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CertificationOfOrigin.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CertificationOfOrigin.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -61,6 +61,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -62,7 +62,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CertificationOfOrigin.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CertificationOfOrigin.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
@@ -64,7 +64,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
@@ -63,6 +63,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
@@ -64,7 +64,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
@@ -66,6 +66,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
@@ -67,7 +67,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
@@ -67,7 +67,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSAShippingInstructionCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
@@ -64,6 +64,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/DCSATransportDocumentCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
@@ -56,6 +56,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/DeMinimisShipmentCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/EventCredential.yml
+++ b/docs/openapi/components/schemas/credentials/EventCredential.yml
@@ -60,6 +60,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/EventCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/EventCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/EventCredential.yml
+++ b/docs/openapi/components/schemas/credentials/EventCredential.yml
@@ -61,7 +61,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/EventCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/EventCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/EventCredential.yml
+++ b/docs/openapi/components/schemas/credentials/EventCredential.yml
@@ -61,7 +61,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/EventCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/EventCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
@@ -64,6 +64,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMACreatingCTECredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
@@ -64,6 +64,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAFirstReceiverDataCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
@@ -64,6 +64,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAGrowingCTECredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
@@ -64,6 +64,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAReceivingCTECredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
@@ -64,6 +64,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMAShippingCTECredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
@@ -64,6 +64,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
+++ b/docs/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FSMATransformingCTECredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
@@ -67,7 +67,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
@@ -66,6 +66,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
@@ -67,7 +67,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FoodDefenseInspectionCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FreightManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FreightManifestCredential.yml
@@ -65,6 +65,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FreightManifestCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/FreightManifestCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FreightManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FreightManifestCredential.yml
@@ -66,7 +66,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FreightManifestCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FreightManifestCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/FreightManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FreightManifestCredential.yml
@@ -66,7 +66,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/FreightManifestCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/FreightManifestCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GAPInspectionCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GAPInspectionCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
@@ -64,6 +64,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GAPInspectionCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/GAPInspectionCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
@@ -65,7 +65,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GAPInspectionCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GAPInspectionCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS18PrefixLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS18PrefixLicenseCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS18PrefixLicenceCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS18PrefixLicenceCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS18PrefixLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS18PrefixLicenseCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS18PrefixLicenceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS18PrefixLicenceCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS18PrefixLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS18PrefixLicenseCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS18PrefixLicenceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS18PrefixLicenceCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1CompanyPrefixLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1CompanyPrefixLicenseCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1CompanyPrefixLicenceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1CompanyPrefixLicenceCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1CompanyPrefixLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1CompanyPrefixLicenseCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1CompanyPrefixLicenceCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1CompanyPrefixLicenceCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1CompanyPrefixLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1CompanyPrefixLicenseCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1CompanyPrefixLicenceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1CompanyPrefixLicenceCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1DataCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1DataCredential.yml
@@ -64,7 +64,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DataCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DataCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1DataCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1DataCredential.yml
@@ -63,6 +63,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DataCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DataCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1DataCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1DataCredential.yml
@@ -64,7 +64,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DataCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DataCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1DelegationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1DelegationCredential.yml
@@ -58,7 +58,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DelegationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DelegationCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1DelegationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1DelegationCredential.yml
@@ -58,7 +58,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DelegationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DelegationCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1DelegationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1DelegationCredential.yml
@@ -57,6 +57,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DelegationCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1DelegationCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1IdentificationKeyLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1IdentificationKeyLicenseCredential.yml
@@ -58,6 +58,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1IdentificationKeyLicenceCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1IdentificationKeyLicenceCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1IdentificationKeyLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1IdentificationKeyLicenseCredential.yml
@@ -59,7 +59,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1IdentificationKeyLicenceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1IdentificationKeyLicenceCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1IdentificationKeyLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1IdentificationKeyLicenseCredential.yml
@@ -59,7 +59,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1IdentificationKeyLicenceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1IdentificationKeyLicenceCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1KeyCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1KeyCredential.yml
@@ -63,7 +63,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1KeyCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1KeyCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1KeyCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1KeyCredential.yml
@@ -62,6 +62,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1KeyCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1KeyCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1KeyCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1KeyCredential.yml
@@ -63,7 +63,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1KeyCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1KeyCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1PrefixLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1PrefixLicenseCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1PrefixLicenceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1PrefixLicenceCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1PrefixLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1PrefixLicenseCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1PrefixLicenceCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1PrefixLicenceCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/GS1PrefixLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GS1PrefixLicenseCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1PrefixLicenceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/GS1PrefixLicenceCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
@@ -62,6 +62,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
@@ -63,7 +63,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
@@ -63,7 +63,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/HouseBillOfLadingCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
@@ -62,6 +62,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
@@ -63,7 +63,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
@@ -63,7 +63,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/IATAAirWaybillCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
@@ -60,6 +60,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
@@ -61,7 +61,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
@@ -61,7 +61,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/ImporterSecurityFilingCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/IntellectualPropertyRightsCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -157,7 +157,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/IntentToImportCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/IntentToImportCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -157,7 +157,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/IntentToImportCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/IntentToImportCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntentToImportCredential.yml
@@ -156,6 +156,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/IntentToImportCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/IntentToImportCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/InventoryRegistrationCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
@@ -64,7 +64,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
@@ -63,6 +63,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
@@ -64,7 +64,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/MasterBillOfLadingCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -152,7 +152,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MillTestReportCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/MillTestReportCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -151,6 +151,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MillTestReportCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/MillTestReportCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -152,7 +152,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MillTestReportCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/MillTestReportCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
@@ -56,6 +56,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
@@ -64,7 +64,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
@@ -63,6 +63,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
@@ -64,7 +64,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
@@ -56,6 +56,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/OGDeliveryTicketCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
@@ -56,6 +56,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/OrderConfirmationCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
@@ -65,6 +65,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OrganicCertificationCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/OrganicCertificationCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
@@ -66,7 +66,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OrganicCertificationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/OrganicCertificationCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
@@ -66,7 +66,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/OrganicCertificationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/OrganicCertificationCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
@@ -61,7 +61,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
@@ -61,7 +61,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
@@ -60,6 +60,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/PGAShipmentStatusCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PackingListCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PackingListCredential.yml
@@ -60,7 +60,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PackingListCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/PackingListCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PackingListCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PackingListCredential.yml
@@ -60,7 +60,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PackingListCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/PackingListCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PackingListCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PackingListCredential.yml
@@ -59,6 +59,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PackingListCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/PackingListCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
@@ -65,6 +65,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
@@ -66,7 +66,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
@@ -66,7 +66,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/ProductRegistrationCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
@@ -64,7 +64,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
@@ -63,6 +63,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
@@ -64,7 +64,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/ProformaInvoiceCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
@@ -60,7 +60,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
@@ -59,6 +59,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
@@ -60,7 +60,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
@@ -58,6 +58,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
@@ -59,7 +59,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
@@ -59,7 +59,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
@@ -63,7 +63,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
@@ -63,7 +63,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
@@ -62,6 +62,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/SIMASteelImportLicenseCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
@@ -62,7 +62,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
@@ -62,7 +62,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
@@ -61,6 +61,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/SeaCargoManifestCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
@@ -55,6 +55,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
@@ -56,7 +56,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/SellerRegistrationCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
@@ -56,6 +56,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
@@ -57,7 +57,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/ShippingInstructionsCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
@@ -61,6 +61,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
@@ -62,7 +62,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
+++ b/docs/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
@@ -62,7 +62,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/SoftwareBillofMaterialsCredential.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
@@ -73,7 +73,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
@@ -73,7 +73,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
@@ -72,6 +72,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
@@ -304,6 +304,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
@@ -305,7 +305,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
@@ -305,7 +305,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableBusinessCard.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
@@ -50,6 +50,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
@@ -51,7 +51,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
@@ -51,7 +51,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiablePostmanCollection.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
@@ -53,7 +53,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableScorecard.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableScorecard.yml
-		readonly: true
+		    readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
@@ -52,6 +52,8 @@ properties:
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableScorecard.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableScorecard.yml
+		readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema

--- a/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
+++ b/docs/openapi/components/schemas/credentials/VerifiableScorecard.yml
@@ -53,7 +53,7 @@ properties:
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableScorecard.yml
         default: https://w3id.org/traceability/openapi/components/schemas/credentials/VerifiableScorecard.yml
-		    readonly: true
+        readonly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema


### PR DESCRIPTION
Syntax sugar updates to `credentialSchema`

- `example` is a placeholder
- `default` implies what the value should be
- `readonly` sets form input to readonly for form libraries that support it