### PR TITLE
Mandatory MTR chemical compounds

### DIFF
--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -787,6 +787,11 @@ properties:
               additionalProperties: false
               required:
                 - type
+                - c
+                - mn
+                - p
+                - s
+                - si
             mechanicalProperties: 
               title: Mechanical Properties
               description: Mechanical property measurements. 


### PR DESCRIPTION
These five elements are required for all certification types.