### PR TITLE
remove 3 letter country and migrate HS to HTS code examples

### DIFF
--- a/docs/openapi/components/schemas/common/OilAndGasDeliveryTicket.yml
+++ b/docs/openapi/components/schemas/common/OilAndGasDeliveryTicket.yml
@@ -321,7 +321,7 @@ example: |-
              "postalCode": "",
              "addressRegion": "IL",
              "streetAddress": "",
-             "addressCountry": "USA",
+             "addressCountry": "US",
              "addressLocality": "Chicago"
          }
      },
@@ -355,8 +355,8 @@ example: |-
       "sku":"391864383008",
       "commodity": {
         "type": ["Commodity"],
-        "commodityCode": "270900",
-        "commodityCodeType": "HS"
+        "commodityCode":"2714.10.00.00",
+        "commodityCodeType": "HTS"
       }
     },
      "observation": [
@@ -487,7 +487,7 @@ example: |-
              "postalCode": "",
              "addressRegion": "IL",
              "streetAddress": "",
-             "addressCountry": "USA",
+             "addressCountry": "US",
              "addressLocality": "Chicago"
          }
      },

--- a/docs/openapi/components/schemas/common/OilAndGasProduct.yml
+++ b/docs/openapi/components/schemas/common/OilAndGasProduct.yml
@@ -2,7 +2,7 @@ $linkedData:
   term: OilAndGasProduct
   '@id': https://w3id.org/traceability#OilAndGasProduct
 title: Crude Oil and Natural Gas Product
-description: Information regarding a crude oil or natural gas product 
+description: Information regarding a crude oil or natural gas product
 type: object
 properties:
   type:
@@ -184,8 +184,8 @@ example: |-
       "sku":"391864383008",
       "commodity": {
         "type": ["Commodity"],
-        "commodityCode": "270900",
-        "commodityCodeType": "HS"
+        "commodityCode":"2714.10.00.00",
+        "commodityCodeType": "HTS"
       }
     }
   }

--- a/docs/openapi/components/schemas/credentials/OilAndGasDeliveryTicketCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OilAndGasDeliveryTicketCredential.yml
@@ -140,8 +140,8 @@ example: |-
           "type": [
             "Commodity"
           ],
-          "commodityCode": "270900",
-          "commodityCodeType": "HS"
+          "commodityCode": "2714.10.00.00",
+          "commodityCodeType": "HTS"
         }
       },
       "observation": [
@@ -272,7 +272,7 @@ example: |-
           "postalCode": "",
           "addressRegion": "IL",
           "streetAddress": "",
-          "addressCountry": "USA",
+          "addressCountry": "US",
           "addressLocality": "Chicago"
         }
       },
@@ -327,9 +327,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-05-11T17:35:16Z",
+      "created": "2023-05-17T19:55:05Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..UVggQ6FAewnwqnaPMJ1OhHyGDCV9JWuvLihS6Vtl2HWznxYnNxQv278ixs_9ZAFwKY5HWFBvQqqbr70RTZCbCQ"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..pq-TYFa16TNB3f-HKrpCJ1Q6u0FTERg-HWChuwNn47n2P5xjUU3RHGxaBgk-SJ4Ez3__q9IG_ECSBVws3kYlAA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OilAndGasProductCredential.yml
@@ -219,16 +219,16 @@ example: |-
           "type": [
             "Commodity"
           ],
-          "commodityCode": "270900",
-          "commodityCodeType": "HS"
+          "commodityCode": "2714.10.00.00",
+          "commodityCodeType": "HTS"
         }
       }
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-05-11T17:40:17Z",
+      "created": "2023-05-17T19:55:06Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..rSq77qtknS5vhyYFdqoPWw8eM4xRbRnlns9snqSxWy0RFxjPYjOMWm-duB9WsYldJCpwGsvf3IXYwfnod3OxDA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..22IBWSwqt2LElhPyNBb-DFt_IvY-l2Bnh35tAN2VRCfaT3pVbV0ANUC7BAmFWoOS5zSfMX-quGc1sshNMALUAQ"
     }
   }


### PR DESCRIPTION
Fixes Examples using HS instead of HTS codes, fixes 3 letter country usage.