### PR TITLE
Simplify USMCA credential

### DIFF
--- a/docs/credentials-with-issuer-dependent-terms.json
+++ b/docs/credentials-with-issuer-dependent-terms.json
@@ -13,7 +13,7 @@
   },
   {
     "type": "USMCACertificationOfOrigin",
-    "count": 0
+    "count": 6
   },
   {
     "type": "ThingCredential",

--- a/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
@@ -44,20 +44,20 @@ properties:
         - USMCACertificationOfOrigin
   id:
     type: string
-
+    format: uri
   issuanceDate:
     type: string
     description: >-
       The date upon which the certification becomes applicable to the good
       covered by the blanket Certification (it may be prior to the date of
-      signing this certification).
+      signing this certification). In most cases this is Jan 01 of a given year.
   expirationDate:
     type: string
     description: >-
       The date upon which the blanket period expires. In no instance should that
       certification exceed a 12-month period, and any information provided
       should be updated in the event any previously-issued certification no
-      longer applies.
+      longer applies. In most cases this should be Dec 31 of the specified year.
   issuer:
     $ref: ../snippets/IssuerOrganization.yml
   credentialSchema:
@@ -76,7 +76,459 @@ properties:
         description: The type of validation to be run against the defined schema
         const: OpenApiSpecificationValidator2022
   credentialSubject:
-    $ref: ../common/USMCAProductSpecifier.yml
+    title: USMCA Product Specifier
+    description: USMCA product origin specifier
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - USMCAProductSpecifier
+        default:
+          - USMCAProductSpecifier
+        items:
+          type: string
+          enum:
+            - USMCAProductSpecifier
+      product:
+        title: Product
+        description: >-
+          Product details. USMCA mandatory elements include: part/SKU number,
+          description, and minimum 6-digit HS classification
+        type: array
+        minItems: 1
+        items:
+          type: object
+          required:
+            - originCriterion
+            - type
+            - countryOfOrigin
+          properties:
+            type:
+              type: array
+              readOnly: true
+              const:
+                - Product
+              default:
+                - Product
+              items:
+                type: string
+                enum:
+                  - Product
+            id:
+              title: Product Identifier
+              description: The product identifier, such as ISBN.
+              type: string
+            gtin:
+              title: Global Trade Item Number (GTIN)
+              type: string
+            name:
+              title: Name
+              description: Name of the shipment item(s)
+              type: string
+            description:
+              title: Description
+              description: Description of the shipment.
+              type: string
+            commodity:
+              title: Commodity
+              description: Product commodity code, codification system and description
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - Commodity
+                  default:
+                    - Commodity
+                  items:
+                    type: string
+                    enum:
+                      - Commodity
+                commodityCode:
+                  title: Commodity Code
+                  description: >-
+                    The commodity code at a given granularity, commonly a 6-digit HS or a
+                    10-digit HTS code.
+                  type: string
+                commodityCodeType:
+                  title: Commodity Code Type
+                  description: Commodity code type
+                  enum:
+                    - HS
+                    - HTS
+                  default:
+                    - HTS
+            originCriterion:
+              title: Origin Criterion
+              description: >-
+                Specify the Origin Criterion under which the good qualifies, as set out in
+                Chapter 4, Article 4.2 (Originating Goods) of the USMCA/T-MEC/CUSMA
+                agreement
+                (https://ustr.gov/sites/default/files/files/agreements/FTA/USMCA/Text/04-Rules-of-Origin.pdf).
+                Criterion A: The good is wholly obtained or produced entirely in the
+                territory of one or more of the USMCA/T-MEC/CUSMA countries, as defined in
+                Article 4.3 of the Agreement; Criterion B: The good is produced entirely
+                in the territory of one or more of the USMCA/T-MEC/CUSMA countries using
+                non-originating materials, provided the good satisfies all applicable
+                requirements of product-specific rules of origin; Criterion C: The good is
+                produced entirely in the territory of one or more of the USMCA/T-MEC/CUSMA
+                countries exclusively from originating materials; or Criterion D: The good
+                is produced entirely in the territory of one or more of the
+                USMCA/T-MEC/CUSMA countries. It is classified with its materials, or
+                satisfies the 'unassembled goods' requirement, and meets a regional value
+                content threshold of not less than 60% if the transaction value method is
+                used, or not less than 50% if the net cost method is used (not including
+                RVC for autos); except for goods in Chapter 61-63 of the HTS.
+              enum:
+                - A
+                - B
+                - C
+                - D
+            countryOfOrigin:
+              title: Country of Origin
+              description: >-
+                Identify the 2-digit ISO country code of the country of production for
+                each good listed in this certification.
+              enum:
+                - CA
+                - MX
+                - US
+      producerConfidential:
+        title: Producer Confidential
+        description: >-
+          A person that wants the producer information to remain confidential may
+          state 'Available upon request by the importing authorities.'
+        type: boolean
+      producerDetails:
+        title: Producer's Details
+        description: >-
+          Producer’s name, address (including country), email address, and telephone
+          number, if different than the certifier or exporter, or, if there are
+          multiple producers, state 'Various' or provide a list of producers. A
+          person that wants this information to remain confidential may state
+          'Available upon request by the importing authorities.' The address of a
+          producer shall be the place of production of the good in a Party's
+          territory.
+        type: array
+        maxItems: 1
+        items:
+          type: object
+          properties:
+            type:
+              type: array
+              readOnly: true
+              const:
+                - Organization
+              default:
+                - Organization
+              items:
+                type: string
+                enum:
+                  - Organization
+            id: 
+              title: Identifier
+              description: Organization identifier.
+              type: string
+              format: uri
+            name:
+              title: Name
+              description: Name of the organization.
+              type: string
+            email:
+              title: Email Address
+              description: Organization's primary email address.
+              type: string
+            phoneNumber:
+              title: Phone Number
+              description: Organization's contact phone number.
+              type: string
+            location:
+              title: Location
+              description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - Place
+                  default:
+                    - Place
+                  items:
+                    type: string
+                    enum:
+                      - Place
+                address:
+                  title: Postal Address
+                  description: The postal address for an organization or place.
+                  type: object
+                  properties:
+                    type:
+                      type: array
+                      readOnly: true
+                      const:
+                        - PostalAddress
+                      default:
+                        - PostalAddress
+                      items:
+                        type: string
+                        enum:
+                          - PostalAddress
+                    streetAddress:
+                      title: Street Address
+                      description: >-
+                        The street address expressed as free form text. The street address is
+                        printed on paper as the first lines below the name. For example, the name
+                        of the street and the number in the street, or the name of a building.
+                      type: string
+                    addressLocality:
+                      title: Address Locality
+                      description: Text specifying the name of the locality; for example, a city.
+                      type: string
+                    addressRegion:
+                      title: Address Region
+                      description: >-
+                        Text specifying a province or state in abbreviated format; for example,
+                        NJ.
+                      type: string
+                    addressCountry:
+                      title: Address Country
+                      description: >-
+                        The two-letter ISO 3166-1 alpha-2 country code.
+                      type: string
+                    postalCode:
+                      title: Postal Code
+                      description: Text specifying the postal code for an address.
+                      type: string
+                  additionalProperties: false
+                  required:
+                    - type
+          additionalProperties: false
+          required:
+            - type
+      importerUnknown:
+        title: Importer Unknown
+        description: >-
+          If the identity of the importer is unknown, or there are various
+          importers, please check this appropriate box.
+        type: boolean
+      importerDetails:
+        title: Importer's Details
+        description: >-
+          Importer’s name, address, email address, and telephone number (if known).
+          The address of the importer shall be in a Party's territory. If the
+          identity of the importer is unknown, or there are various importers,
+          please check the appropriate box.
+        type: array
+        maxItems: 1
+        items:
+          type: object
+          properties:
+            type:
+              type: array
+              readOnly: true
+              const:
+                - Organization
+              default:
+                - Organization
+              items:
+                type: string
+                enum:
+                  - Organization
+            id: 
+              title: Identifier
+              description: Organization identifier.
+              type: string
+              format: uri
+            name:
+              title: Name
+              description: Name of the organization.
+              type: string
+            email:
+              title: Email Address
+              description: Organization's primary email address.
+              type: string
+            phoneNumber:
+              title: Phone Number
+              description: Organization's contact phone number.
+              type: string
+            location:
+              title: Location
+              description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - Place
+                  default:
+                    - Place
+                  items:
+                    type: string
+                    enum:
+                      - Place
+                address:
+                  title: Postal Address
+                  description: The postal address for an organization or place.
+                  type: object
+                  properties:
+                    type:
+                      type: array
+                      readOnly: true
+                      const:
+                        - PostalAddress
+                      default:
+                        - PostalAddress
+                      items:
+                        type: string
+                        enum:
+                          - PostalAddress
+                    streetAddress:
+                      title: Street Address
+                      description: >-
+                        The street address expressed as free form text. The street address is
+                        printed on paper as the first lines below the name. For example, the name
+                        of the street and the number in the street, or the name of a building.
+                      type: string
+                    addressLocality:
+                      title: Address Locality
+                      description: Text specifying the name of the locality; for example, a city.
+                      type: string
+                    addressRegion:
+                      title: Address Region
+                      description: >-
+                        Text specifying a province or state in abbreviated format; for example,
+                        NJ.
+                      type: string
+                    addressCountry:
+                      title: Address Country
+                      description: >-
+                        The two-letter ISO 3166-1 alpha-2 country code.
+                      type: string
+                    postalCode:
+                      title: Postal Code
+                      description: Text specifying the postal code for an address.
+                      type: string
+                  additionalProperties: false
+                  required:
+                    - type
+          additionalProperties: false
+          required:
+            - type
+      exporterDetails:
+        title: Exporter's Details
+        description: >-
+          Exporter’s name, address (including country), email address, and telephone
+          number, if different than the certifier. This information is not required
+          if the producer is completing the Certification of Origin and does not
+          know the identity of the exporter. The address of the exporter shall be
+          the place of export of the good in a Party’s territory.
+        type: array
+        maxItems: 1
+        items:
+          type: object
+          properties:
+            type:
+              type: array
+              readOnly: true
+              const:
+                - Organization
+              default:
+                - Organization
+              items:
+                type: string
+                enum:
+                  - Organization
+            id: 
+              title: Identifier
+              description: Organization identifier.
+              type: string
+              format: uri
+            name:
+              title: Name
+              description: Name of the organization.
+              type: string
+            email:
+              title: Email Address
+              description: Organization's primary email address.
+              type: string
+            phoneNumber:
+              title: Phone Number
+              description: Organization's contact phone number.
+              type: string
+            location:
+              title: Location
+              description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - Place
+                  default:
+                    - Place
+                  items:
+                    type: string
+                    enum:
+                      - Place
+                address:
+                  title: Postal Address
+                  description: The postal address for an organization or place.
+                  type: object
+                  properties:
+                    type:
+                      type: array
+                      readOnly: true
+                      const:
+                        - PostalAddress
+                      default:
+                        - PostalAddress
+                      items:
+                        type: string
+                        enum:
+                          - PostalAddress
+                    streetAddress:
+                      title: Street Address
+                      description: >-
+                        The street address expressed as free form text. The street address is
+                        printed on paper as the first lines below the name. For example, the name
+                        of the street and the number in the street, or the name of a building.
+                      type: string
+                    addressLocality:
+                      title: Address Locality
+                      description: Text specifying the name of the locality; for example, a city.
+                      type: string
+                    addressRegion:
+                      title: Address Region
+                      description: >-
+                        Text specifying a province or state in abbreviated format; for example,
+                        NJ.
+                      type: string
+                    addressCountry:
+                      title: Address Country
+                      description: >-
+                        The two-letter ISO 3166-1 alpha-2 country code.
+                      type: string
+                    postalCode:
+                      title: Postal Code
+                      description: Text specifying the postal code for an address.
+                      type: string
+                  additionalProperties: false
+                  required:
+                    - type
+          additionalProperties: false
+          required:
+            - type
+    additionalProperties: false  
+    required:
+      - type
+      - product
+      - exporterDetails
   proof:
     $ref: ../snippets/proof.yml
 additionalProperties: false
@@ -96,8 +548,8 @@ example: |-
       "VerifiableCredential",
       "USMCACertificationOfOrigin"
     ],
-    "issuanceDate": "2021-06-22T20:29:37+00:00",
-    "expirationDate": "2022-06-22T20:29:37+00:00",
+    "issuanceDate": "2023-01-01T20:29:37+00:00",
+    "expirationDate": "2023-12-31T20:29:37+00:00",
     "issuer": {
       "type": [
         "Organization"
@@ -124,41 +576,37 @@ example: |-
       "type": [
         "USMCAProductSpecifier"
       ],
-      "product": {
-        "type": [
-          "Product"
-        ],
-        "sku": "323050346937",
-        "description": "Non-alloy steel rolls",
-        "commodity": {
+      "product": [
+        {
           "type": [
-            "Commodity"
+            "Product"
           ],
-          "commodityCode": "721320",
-          "commodityCodeType": "HS",
-          "description": "Steel Coils"
+          "sku": "323050346937",
+          "description": "Non-alloy steel rolls",
+          "originCriterion": "A",
+          "countryOfOrigin": "MX",
+          "commodity": {
+            "type": [
+              "Commodity"
+            ],
+            "commodityCode": "721320",
+            "commodityCodeType": "HS"
+          }
         }
-      },
-      "originCriterion": "A",
-      "countryOfOrigin": "MX",
+      ],
+      "importerUnknown": false,
       "importerDetails": [
         {
           "type": [
             "Organization"
           ],
           "name": "Maxi Acero Mexicano",
-          "description": "Fusión y fabricación de acero sólido",
+          "email": "info@example.net",
+          "phoneNumber": "+1-144-555-9857",
           "location": {
             "type": [
               "Place"
             ],
-            "geo": {
-              "type": [
-                "GeoCoordinates"
-              ],
-              "latitude": "25.682338876065607",
-              "longitude": "-100.31373788104028"
-            },
             "address": {
               "type": [
                 "PostalAddress"
@@ -169,42 +617,35 @@ example: |-
               "postalCode": "32200",
               "addressCountry": "Mexico"
             }
-          },
-          "email": "info@example.net",
-          "phoneNumber": "+1-144-555-9857"
+          }
         }
       ],
-      "exporterDetails": {
-        "type": [
-          "Organization"
-        ],
-        "name": "American Prime Steel Inc.",
-        "description": "Quality Steel since 1952",
-        "location": {
+      "exporterDetails": [
+        {
           "type": [
-            "Place"
+            "Organization"
           ],
-          "geo": {
+          "name": "American Prime Steel Inc.",
+          "email": "contact@example.net",
+          "phoneNumber": "+1-271-555-5546",
+          "location": {
             "type": [
-              "GeoCoordinates"
+              "Place"
             ],
-            "latitude": "43.655585429184434",
-            "longitude": "-120.33634354756568"
-          },
-          "address": {
-            "type": [
-              "PostalAddress"
-            ],
-            "streetAddress": "1551 Keebler Knoll",
-            "addressLocality": "Vivianeburgh",
-            "addressRegion": "Oregon",
-            "postalCode": "47090",
-            "addressCountry": "US"
+            "address": {
+              "type": [
+                "PostalAddress"
+              ],
+              "streetAddress": "1551 Keebler Knoll",
+              "addressLocality": "Vivianeburgh",
+              "addressRegion": "Oregon",
+              "postalCode": "47090",
+              "addressCountry": "US"
+            }
           }
-        },
-        "email": "contact@example.net",
-        "phoneNumber": "+1-271-555-5546"
-      },
+        }
+      ],
+      "producerConfidential": false,
       "producerDetails": [
         {
           "type": [
@@ -216,13 +657,6 @@ example: |-
             "type": [
               "Place"
             ],
-            "geo": {
-              "type": [
-                "GeoCoordinates"
-              ],
-              "latitude": "30.893066748785927",
-              "longitude": "-93.80232474809726"
-            },
             "address": {
               "type": [
                 "PostalAddress"
@@ -238,9 +672,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-05-17T20:22:03Z",
+      "created": "2023-06-12T18:28:19Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..1Q4U0EhuoV9JoHLWuJ7FdwI0E7xil4jx1KfeG0_Gb2NMFjSupjyVFRHHZaoMY4HnVxjyrMwYqLV9_nXdtxW8CA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..7MIUzG2DupUd1tuyKBCXbas5dnBvqmEWbE7C3ql9WoRQ1t7Lmz_A-JF_LMic1LD7--YJGKLu-zlyZePCQr_vAw"
     }
   }


### PR DESCRIPTION
We got feedback that our USMCA credential didn't look anything like the form that it intends to replication. This PR inlines the schema to make the credential reference-able from a single file. And greatly reduces the number of unused fields pulled from `$ref`. 