### PR TITLE
MMBOL inlining and updates

### DIFF
--- a/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
@@ -163,14 +163,14 @@ properties:
     $linkedData:
       term: transportEquipmentQuantity
       '@id': https://vocabulary.uncefact.org/transportEquipmentQuantity
-  includedConsignmentItems:
-    title: Included Consignment Items
-    description: A consignment item included in the consignment.
+  particulars:
+    title: Consignment item particulars
+    description: Consignment item particular listing.
     type: array
     items: 
       $ref: ./ConsignmentItem.yml
     $linkedData:
-      term: includedConsignmentItems
+      term: particulars
       '@id': https://vocabulary.uncefact.org/includedConsignmentItem
   utilizedTransportEquipment:
     title: Utilized Transport Equipment
@@ -222,7 +222,7 @@ required:
   - carrier
   - portOfLoading
   - portOfDischarge
-  - includedConsignmentItems
+  - particulars
   - termsAndConditions
 example: |-
   {
@@ -337,7 +337,7 @@ example: |-
         ]
       }
     ],
-    "includedConsignmentItems": [
+    "particulars": [
       {
         "type": ["ConsignmentItem"],
         "marksAndNumbers": "Espresso Italiano",

--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
@@ -50,7 +50,110 @@ properties:
   expirationDate:
     type: string
   issuer:
-    $ref: ../snippets/IssuerOrganization.yml
+    title: Issuer Carrier
+    description: The carrier organization issueing the Bill of Lading
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - Organization
+        default:
+          - Organization
+        items:
+          type: string
+          enum:
+            - Organization
+      id: 
+        title: Identifier
+        description: Carrier identifier.
+        type: string
+        format: uri
+      name:
+        title: Name
+        description: Name of carrier.
+        type: string
+      scac:
+        title: SCAC
+        description: >-
+          For maritime shipments, this code qualifies a Standard Alpha Carrier Code
+          (SCAC) as issued by the United Stated National Motor Traffic Association
+          Inc.
+        type: string
+        $linkedData:
+          term: scac
+          '@id': >-
+            https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Standard_Carrier_Alpha_Code_(SCAC)_number
+      location:
+        title: Location
+        description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Place
+            default:
+              - Place
+            items:
+              type: string
+              enum:
+                - Place
+          address:
+            title: Postal Address
+            description: The postal address for an organization or place.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - PostalAddress
+                default:
+                  - PostalAddress
+                items:
+                  type: string
+                  enum:
+                    - PostalAddress
+              name:
+                title: Name
+                description: The name of the entity in text.
+                type: string
+              streetAddress:
+                title: Street Address
+                description: >-
+                  The street address expressed as free form text. The street address is
+                  printed on paper as the first lines below the name. For example, the name
+                  of the street and the number in the street, or the name of a building.
+                type: string
+              addressLocality:
+                title: Address Locality
+                description: Text specifying the name of the locality; for example, a city.
+                type: string
+              addressRegion:
+                title: Address Region
+                description: >-
+                  Text specifying a province or state in abbreviated format; for example,
+                  NJ.
+                type: string
+              addressCountry:
+                title: Address Country
+                description: >-
+                  The two-letter ISO 3166-1 alpha-2 country code.
+                type: string
+              postalCode:
+                title: Postal Code
+                description: Text specifying the postal code for an address.
+                type: string
+            additionalProperties: false
+            required:
+              - type
+    additionalProperties: false
+    required:
+      - type
+      - id
   credentialSchema:
     type: object
     properties:
@@ -67,9 +170,968 @@ properties:
         description: The type of validation to be run against the defined schema
         const: OpenApiSpecificationValidator2022
   credentialSubject:
-    $ref: ../common/MultiModalBillOfLading.yml
+    title: Multi-Modal Bill Of Lading
+    description: A separately identifiable collection of goods items to be transported or available to be transported from one consignor to one consignee via one or more modes of transport where each consignment is the subject of one single transport contract.
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - MultiModalBillOfLading
+        default:
+          - MultiModalBillOfLading
+        items:
+          type: string
+          enum:
+            - MultiModalBillOfLading
+      billOfLadingNumber:
+        title: Bill Of Lading Number
+        description: >-
+          A unique number allocated by the shipping line to the transport document
+          and the main number used for the tracking of the status of the shipment.
+        type: string
+      bookingNumber:
+        title: Booking Number
+        description:  A unique identifier assigned by the carrier to the consignment, such as a booking reference number when cargo space is reserved prior to loading.
+        type: array
+        items: 
+          type: string
+      shippersReferences:
+        title: Shipper's References
+        description: A number that identifies the SID (shipper's identification) number for a shipment.
+        type: array
+        items: 
+          type: string
+      freightForwardersReferences:
+        title: Freight Forwarder's References
+        description: Reference number assigned by the freight forwarder to identify a particular consignment.
+        type: array
+        items: 
+          type: string
+      shipper: 
+        title: Shipper
+        description: Consignor party.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Organization
+            default:
+              - Organization
+            items:
+              type: string
+              enum:
+                - Organization
+          id:
+            title: Identifier
+            description: Decentralized identifier of the consignor.
+            type: string
+          name:
+            title: Name
+            description: Name of the consignor.
+            type: string
+          url:
+            title: URL
+            description: URL of the consignor.
+            type: string
+          description:
+            title: Description
+            description: Description of the consignor.
+            type: string
+          email:
+            title: Email Address
+            description: Consignor's primary email address.
+            type: string
+          phoneNumber:
+            title: Phone Number
+            description: Consignor's contact phone number.
+            type: string
+          location:
+            title: Location
+            description: Consignor's physical address.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - Place
+                default:
+                  - Place
+                items:
+                  type: string
+                  enum:
+                    - Place
+              address:
+                title: Postal Address
+                description: The postal address for an organization or place.
+                $ref: ../common/PostalAddress.yml
+        additionalProperties: false
+        required:
+          - type
+          - name
+      consignee:
+        title: Consignee
+        description: Consignee party.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Organization
+            default:
+              - Organization
+            items:
+              type: string
+              enum:
+                - Organization
+          id:
+            title: Identifier
+            description: Decentralized identifier for the consignee
+            type: string
+          name:
+            title: Name
+            description: Name of the consignee.
+            type: string
+          url:
+            title: URL
+            description: URL of the consignee.
+            type: string
+          description:
+            title: Description
+            description: Description of the consignee.
+            type: string
+          email:
+            title: Email Address
+            description: Consignee's primary email address.
+            type: string
+          phoneNumber:
+            title: Phone Number
+            description: Consignee's contact phone number.
+            type: string
+          location:
+            title: Location
+            description: Consignee's physical address.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - Place
+                default:
+                  - Place
+                items:
+                  type: string
+                  enum:
+                    - Place
+              address:
+                title: Postal Address
+                description: The postal address for an organization or place.
+                $ref: ../common/PostalAddress.yml
+        additionalProperties: false
+        required:
+          - type
+          - name
+      forwardingAgent: 
+        title: Forwarding Agent
+        description: The freight forwarder party for this supply chain consignment.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Organization
+            default:
+              - Organization
+            items:
+              type: string
+              enum:
+                - Organization
+          id:
+            title: Identifier
+            description: Decentralized identifier for the freight forwarder
+            type: string
+          name:
+            title: Name
+            description: Name of the freight forwarder.
+            type: string
+          url:
+            title: URL
+            description: URL of the freight forwarder.
+            type: string
+          description:
+            title: Description
+            description: Description of the freight forwarder.
+            type: string
+          email:
+            title: Email Address
+            description: Freight forwarder's primary email address.
+            type: string
+          phoneNumber:
+            title: Phone Number
+            description: Freight forwarder's contact phone number.
+            type: string
+          location:
+            title: Location
+            description: Freight forwarder's physical location, such as address or coordinates.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - Place
+                default:
+                  - Place
+                items:
+                  type: string
+                  enum:
+                    - Place
+              address:
+                title: Postal Address
+                description: The postal address for an organization or place.
+                $ref: ../common/PostalAddress.yml
+        additionalProperties: false
+        required:
+          - type
+          - name
+      notifyParty:
+        title: Notify Party
+        description: The freight forwarder party for this supply chain consignment.
+        type: array 
+        items: 
+          title: Notify Party
+          description: The freight forwarder party for this supply chain consignment.
+          type: object
+          properties:
+            type:
+              type: array
+              readOnly: true
+              const:
+                - Organization
+              default:
+                - Organization
+              items:
+                type: string
+                enum:
+                  - Organization
+            id:
+              title: Identifier
+              description: Decentralized identifier for the notify party
+              type: string
+            name:
+              title: Name
+              description: Name of the notify party.
+              type: string
+            url:
+              title: URL
+              description: URL of the notify party.
+              type: string
+            description:
+              title: Description
+              description: Description of the notify party.
+              type: string
+            email:
+              title: Email Address
+              description: notify party's primary email address.
+              type: string
+            phoneNumber:
+              title: Phone Number
+              description: notify party's contact phone number.
+              type: string
+            location:
+              title: Location
+              description: Notify party's physical location, such as address or coordinates.
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - Place
+                  default:
+                    - Place
+                  items:
+                    type: string
+                    enum:
+                      - Place
+                address:
+                  title: Postal Address
+                  description: The postal address for an organization or place.
+                  $ref: ../common/PostalAddress.yml
+          additionalProperties: false
+          required:
+            - type
+            - name
+      preCarriageTransportMovement:
+        title: Pre-carriage Transport Movement
+        description: A pre-carriage logistics transport movement for the consignment.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Transport
+            default:
+              - Transport
+            items:
+              type: string
+              enum:
+                - Transport
+          vesselNumber:
+            title: Vessel Number
+            description: The unique reference for a registered vessel.
+            type: string
+          voyageNumber:
+            title: Voyage Number
+            description: The vessel operator-specific identifier of the Voyage.
+            type: string
+        additionalProperties: false
+        required:
+          - type
+      mainCarriageTransportMovement:
+        title: Main Carriage Transport Movement
+        description: A main carriage logistics transport movement for this supply chain consignment.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Transport
+            default:
+              - Transport
+            items:
+              type: string
+              enum:
+                - Transport
+          vesselNumber:
+            title: Vessel Number
+            description: The unique reference for a registered vessel.
+            type: string
+          voyageNumber:
+            title: Voyage Number
+            description: The vessel operator-specific identifier of the Voyage.
+            type: string
+        additionalProperties: false
+        required:
+          - type
+      onCarriageTransportMovement:
+        title: On-carriage Transport Movement
+        description: An on-carriage logistics transport movement for this supply chain consignment.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Transport
+            default:
+              - Transport
+            items:
+              type: string
+              enum:
+                - Transport
+          vesselNumber:
+            title: Vessel Number
+            description: The unique reference for a registered vessel.
+            type: string
+          voyageNumber:
+            title: Voyage Number
+            description: The vessel operator-specific identifier of the Voyage.
+            type: string
+        additionalProperties: false
+        required:
+          - type
+      placeOfReceipt:
+        title: Place of Receipt
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Place
+            default:
+              - Place
+            items:
+              type: string
+              enum:
+                - Place
+          unLocode:
+            title: UN Locode
+            description: LOCODE
+            type: string
+          iataAirportCode:
+            title: IATA Airport Code
+            description: IATA airport code (3 letter)
+            type: string
+        additionalProperties: false
+        required:
+          - type
+      portOfLoading:
+        title: Port of Loading
+        description: The logistics location where the supply chain consignment is loaded.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Place
+            default:
+              - Place
+            items:
+              type: string
+              enum:
+                - Place
+          unLocode:
+            title: UN Locode
+            description: LOCODE
+            type: string
+          iataAirportCode:
+            title: IATA Airport Code
+            description: IATA airport code (3 letter)
+            type: string
+        additionalProperties: false
+        required:
+          - type
+      transshipmentLocation:
+        title: Transshipment Location
+        description: A transshipment location for this supply chain consignment.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Place
+            default:
+              - Place
+            items:
+              type: string
+              enum:
+                - Place
+          unLocode:
+            title: UN Locode
+            description: LOCODE
+            type: string
+          iataAirportCode:
+            title: IATA Airport Code
+            description: IATA airport code (3 letter)
+            type: string
+        additionalProperties: false
+        required:
+          - type
+      portOfDischarge:
+        title: Port of Discharge
+        description: The logistics location where the supply chain consignment is unloaded.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Place
+            default:
+              - Place
+            items:
+              type: string
+              enum:
+                - Place
+          unLocode:
+            title: UN Locode
+            description: LOCODE
+            type: string
+          iataAirportCode:
+            title: IATA Airport Code
+            description: IATA airport code (3 letter)
+            type: string
+        additionalProperties: false
+        required:
+          - type
+      placeOfDelivery:
+        title: Place of Delivery
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Place
+            default:
+              - Place
+            items:
+              type: string
+              enum:
+                - Place
+          unLocode:
+            title: UN Locode
+            description: LOCODE
+            type: string
+          iataAirportCode:
+            title: IATA Airport Code
+            description: IATA airport code (3 letter)
+            type: string
+        additionalProperties: false
+        required:
+          - type
+      totalNumberOfPackages: 
+        title: Total Number of Packages
+        description: A number of packages.
+        type: number
+      transportEquipmentQuantity: 
+        title: Transport Equipment Quantity
+        description: A number of pieces of transport equipment for the consignment or transport movement.
+        type: number
+      particulars:
+        title: Consignment item particulars
+        description: A consignment item included in the consignment.
+        type: array
+        items: 
+          title: Consignment Item
+          description: A separately identifiable collection of goods items to be transported or available to be transported from one consignor to one consignee via one or more modes of transport where each consignment is the subject of one single transport contract.
+          type: object
+          properties:
+            type:
+              type: array
+              readOnly: true
+              const:
+                - ConsignmentItem
+              default:
+                - ConsignmentItem
+              items:
+                type: string
+                enum:
+                  - ConsignmentItem
+            marksAndNumbers: 
+              title: Marks and Numbers
+              description: Physical markings or labels on individual packages or transport units for shipping purposes.
+              type: string
+            descriptionOfPackagesAndGoods: 
+              title: Description of Packages and Goods
+              description: Transport cargo details of the consignment or consignment item sufficient to identify its nature for customs, statistical, or transport purposes.
+              type: string
+            commodity: 
+              title: Commodity
+              description: Commodity classification based on either WCO HS or USITS HTS codification.
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - Commodity
+                  default:
+                    - Commodity
+                  items:
+                    type: string
+                    enum:
+                      - Commodity
+                commodityCode:
+                  title: Commodity Code
+                  description: >-
+                    The commodity code at a given granularity, commonly a 6-digit HS or a
+                    10-digit HTS code.
+                  type: string
+                commodityCodeType:
+                  title: Commodity Code Type
+                  description: Commodity code type
+                  enum:
+                    - HS
+                    - HTS
+                description:
+                  title: Commodity Description
+                  description: Description of the commodity.
+                  type: string
+              additionalProperties: false
+              required:
+                - type
+            packageQuantity: 
+              title: Number of Packages
+              description: A number of packages.
+              type: number
+            netWeight: 
+              title: Net Weight
+              description: Net weight of the product.
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - QuantitativeValue
+                  default:
+                    - QuantitativeValue
+                  items:
+                    type: string
+                    enum:
+                      - QuantitativeValue
+                unitCode:
+                  title: Unit Code
+                  description: Unit of measurement.
+                  type: string
+                value:
+                  title: Value
+                  description: Value or amount.
+                  type: string
+              additionalProperties: false
+              required:
+                - type
+            grossWeight:   
+              title: Gross Weight
+              description: Gross weight of the product.
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - QuantitativeValue
+                  default:
+                    - QuantitativeValue
+                  items:
+                    type: string
+                    enum:
+                      - QuantitativeValue
+                unitCode:
+                  title: Unit Code
+                  description: Unit of measurement.
+                  type: string
+                value:
+                  title: Value
+                  description: Value or amount.
+                  type: string
+              additionalProperties: false
+              required:
+                - type
+            grossVolume:   
+              title: Gross Volume
+              description: A measure of the gross volume, normally calculated by multiplying the maximum length, width and height.
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - QuantitativeValue
+                  default:
+                    - QuantitativeValue
+                  items:
+                    type: string
+                    enum:
+                      - QuantitativeValue
+                unitCode:
+                  title: Unit Code
+                  description: Unit of measurement.
+                  type: string
+                value:
+                  title: Value
+                  description: Value or amount.
+                  type: string
+              additionalProperties: false
+              required:
+                - type
+            countryOfOrigin: 
+              title: Country of Origin
+              description: A country of origin for the consignment, consignment item, or product. The two-letter ISO 3166-1 alpha-2 country code is recommended.
+              type: string
+      utilizedTransportEquipment:
+        title: Utilized Transport Equipment
+        description: A piece of transport equipment utilized for the consignment or trade delivery.
+        type: array
+        items: 
+          type: object
+          properties:
+            type:
+              type: array
+              readOnly: true
+              const:
+                - TransportEquipment
+              default:
+                - TransportEquipment
+              items:
+                type: string
+                enum:
+                  - TransportEquipment
+            id:
+              title: Identifier
+              description: Transport equipment identifier.
+              type: string
+            equipmentReference:
+              title: Equipment Reference
+              description: >-
+                The unique identifier for the equipment, which should follow the BIC ISO
+                Container Identification Number where possible. According to ISO 6346, a
+                container identification code consists of a 4-letter prefix and a 7-digit
+                number (composed of a 3-letter owner code, a category identifier, a serial
+                number, and a check-digit). If a container does not comply with ISO 6346,
+                it is suggested to follow Recommendation #2 “Container with non-ISO
+                identification” from SMDG.
+              type: string
+            ISOEquipmentCode:
+              title: ISO Equipment Code
+              description: >-
+                Unique code for the different equipment size/type used for transporting
+                commodities. The code is a concatenation of ISO Equipment Size Code and
+                ISO Equipment Type Code A and follows the ISO 6346 standard.
+              type: string
+            tareWeight:
+              title: Tare Weight
+              description: The weight of an empty container (gross container weight).
+              type: number
+            tareWeightUnit:
+              title: Weight Unit
+              description: The unit of measure which can be expressed in imperial or metric terms
+              type: number
+            cargoGrossWeight:
+              title: Tare Weight
+              description: The weight of an empty container (gross container weight).
+              type: number
+            cargoGrossWeightUnit:
+              title: Weight Unit
+              description: The unit of measure which can be expressed in imperial or metric terms
+              type: number
+            seals:
+              title: Seals
+              description: >-
+                A seal affixed to this piece of logistics or referenced logistics
+                transport equipment.
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: array
+                    readOnly: true
+                    const:
+                      - Seal
+                    default:
+                      - Seal
+                    items:
+                      type: string
+                      enum:
+                        - Seal
+                  sealNumber:
+                    title: Seal Number
+                    description: Identifies a seal affixed to the container.
+                    type: string
+                  sealSource:
+                    title: Seal Source
+                    description: >-
+                      The source of the seal, namely who has affixed the seal. This attribute
+                      links to the Seal Source ID defined in the Seal Source reference data
+                      entity. CAR (Carrier), SHI (Shipper), PHY (Phytosanitary), VET
+                      (Veterinary), CUS (Customs)
+                    enum:
+                      - CAR
+                      - SHI
+                      - PHY
+                      - VET
+                      - CUS
+                  sealType:
+                    title: Tare Weight
+                    description: >-
+                      The type of seal. This attribute links to the Seal Type ID defined in the
+                      Seal Type reference data entity. KLP (Keyless padlock), BLT (Bolt), WIR
+                      (Wire)
+                    enum:
+                      - KLP
+                      - BLT
+                      - WIR
+                additionalProperties: false
+                required:
+                  - type
+          additionalProperties: false  
+          required:
+            - type
+      freightAndCharges: 
+        title: Freight and Charges
+        description: A logistics service charge, such as freight or insurance charges, applicable to this supply chain consignment, supply chain consignment item, piece of logistics transport equipment, logistics means of transport or logistics transport movement.
+        type: array
+        items: 
+          type: object
+          properties:
+            type:
+              type: array
+              readOnly: true
+              const:
+                - ServiceCharge
+              default:
+                - ServiceCharge
+              items:
+                type: string
+                enum:
+                  - ServiceCharge
+            chargeCode:
+              description: The unique identifier for this logistics service charge.
+              type: string
+              enum:
+                - allCharges
+                - additionalCharges
+                - basicFreight
+                - destinationHaulageCharges
+                - destinationPortCharges
+                - originPortCharges
+                - originHaulageCharges
+                - otherCharges
+            paymentTerm:
+              description: Charge payment term.
+              type: string
+              enum:
+                - prepaid
+                - collect
+                - prepaidElsewhere
+            chargeText:
+              title: Charge Text
+              description: A textual description of this logistics service charge.
+              type: string
+            rate:
+              title: Rate
+              description: Per unit rate.
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - PriceSpecification
+                  default:
+                    - PriceSpecification
+                  items:
+                    type: string
+                    enum:
+                      - PriceSpecification
+                price:
+                  title: Price
+                  description: >-
+                    The offer price of a product, or of a price component when attached to
+                    PriceSpecification and its subtypes.
+                  type: number
+                priceCurrency:
+                  title: Price Currency
+                  description: >-
+                    The currency of the price, or a price component when attached to
+                    PriceSpecification and its subtypes.
+                  type: string
+              additionalProperties: false
+              required:
+                - type
+            calculationBasis:
+              description: The code specifying a basis on which this service charge is to be calculated such as by volume or per unit.
+              type: string
+            appliedAmount:
+              description: A monetary value applied to this logistics service charge.
+              type: object
+              properties:
+                type:
+                  type: array
+                  readOnly: true
+                  const:
+                    - PriceSpecification
+                  default:
+                    - PriceSpecification
+                  items:
+                    type: string
+                    enum:
+                      - PriceSpecification
+                price:
+                  title: Price
+                  description: >-
+                    The offer price of a product, or of a price component when attached to
+                    PriceSpecification and its subtypes.
+                  type: number
+                priceCurrency:
+                  title: Price Currency
+                  description: >-
+                    The currency of the price, or a price component when attached to
+                    PriceSpecification and its subtypes.
+                  type: string
+              additionalProperties: false
+              required:
+                - type
+          additionalProperties: false  
+          required:
+            - type
+      declaredValue:
+        title: Declared Value
+        description: The monetary value of the consignment or consignment item as declared by the shipper or his agent for the purpose of varying the carrier's level of liability from that provided in the contract of carriage, in case of loss or damage to goods or delayed delivery.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - PriceSpecification
+            default:
+              - PriceSpecification
+            items:
+              type: string
+              enum:
+                - PriceSpecification
+          price:
+            title: Price
+            description: >-
+              The offer price of a product, or of a price component when attached to
+              PriceSpecification and its subtypes.
+            type: number
+          priceCurrency:
+            title: Price Currency
+            description: >-
+              The currency of the price, or a price component when attached to
+              PriceSpecification and its subtypes.
+            type: string
+        additionalProperties: false
+        required:
+          - type
+      shippedOnBoardDate:
+        title: Shipped On Board Date
+        description: >-
+          Date when the last container that is linked to the transport document is physically loaded onboard the vessel indicated on the transport document.
+        type: string
+      termsAndConditions:
+        title: Terms And Conditions
+        description: Carrier general terms and conditions for this transport document.
+        type: string
+    additionalProperties: false
+    required:
+      - type
+      - billOfLadingNumber
+      - shipper
+      - consignee
+      - portOfLoading
+      - portOfDischarge
+      - particulars
+      - termsAndConditions
   proof:
-    $ref: ../snippets/proof.yml
+    title: proof
+    description: A JSON Web Signature proof for a credential as defined by the VC data model 
+    type: object
+    properties:
+      type:
+        type: string
+        description: Signature suite for the proof
+        enum:
+          - Ed25519Signature2018
+      created:
+        description: Creation timestamp for the proof in the form of an XML datestring
+        type: string
+      verificationMethod:
+        description: The fragment from which the public key can be de-referenced, in the form of a URI
+        type: string
+      proofPurpose:
+        description: In the case of credentials, the proof should be the constant, 'assertionMethod'
+        const: assertionMethod
+      jws:
+        description: The JSON Web Signature for the proof
+        type: string
 additionalProperties: false
 required:
   - '@context'
@@ -95,6 +1157,7 @@ example: |-
       ],
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "name": "MULTI CONTAINER LINE",
+      "scac": "MCLI",
       "location": {
         "type": [
           "Place"
@@ -188,28 +1251,6 @@ example: |-
           }
         }
       ],
-      "carrier": {
-        "type": [
-          "Organization"
-        ],
-        "id": "did:key:z6Mku6sNEit2qhNyaKDoj6ozURx5ApD85Za5g6dmnpYi6Auv",
-        "name": "MULTI CONTAINER LINE",
-        "location": {
-          "type": [
-            "Place"
-          ],
-          "address": {
-            "type": [
-              "PostalAddress"
-            ],
-            "name": "MCL Multi Container Line LTD.",
-            "streetAddress": "Rm. 3501, 35/F Manhatten Place, 23 Wang Tai Road",
-            "addressLocality": "Kowloon Bay",
-            "addressRegion": "Hong Kong",
-            "addressCountry": "Hong Kong SAR"
-          }
-        }
-      },
       "mainCarriageTransportMovement": {
         "type": [
           "Transport"
@@ -263,7 +1304,7 @@ example: |-
           ]
         }
       ],
-      "includedConsignmentItems": [
+      "particulars": [
         {
           "type": [
             "ConsignmentItem"
@@ -337,9 +1378,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-06-15T07:48:16Z",
+      "created": "2023-06-15T09:01:17Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..zeQCzz-CTYlcLx2jxcLh-64MwodtYeCqFasOoues1bqC_cyFz_TP4d6xKecChmIxUQwV0jfKGCaw-OSuDlcWCA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..VjDnk1mTrvL1119VnAqwcejcmlvRmzgIaotVpW62LJTkLjjGnF6JajN8FhONsVcvEC8ezs6O4t77mKxKs8IyDA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
@@ -273,7 +273,7 @@ example: |-
             "type": [
               "Commodity"
             ],
-            "commodityCode": "851671",
+            "commodityCode": "8516.71",
             "commodityCodeType": "HS"
           },
           "packageQuantity": 2200,
@@ -337,9 +337,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-06-05T15:55:01Z",
+      "created": "2023-06-15T07:48:16Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..c1ZEKMXS-wKvZQ6xsg6LYUx_fliNDeO0Ux8xmfbtQ_7Q36eFIWxFPayYO1jHILAtfJlhj13YClfCe7LEoUo_CA"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..zeQCzz-CTYlcLx2jxcLh-64MwodtYeCqFasOoues1bqC_cyFz_TP4d6xKecChmIxUQwV0jfKGCaw-OSuDlcWCA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
@@ -9,7 +9,7 @@ tags:
   - Oil and Gas
   - Other
 description: >- 
-  A receipt for the cargo and a contract for transportation between a shipper and the ocean carrier. It may also be used as instrument of ownership (negotiable bill of lading) which can be bought, sold or traded while the goods are in transit. To be used in this manner, it must be a negotiable "order bill of lading". 
+  A receipt for the cargo and a contract for transportation between a shipper and the carrier. It may also be used as instrument of ownership (negotiable bill of lading) which can be bought, sold or traded while the goods are in transit. To be used in this manner, it must be a negotiable "order bill of lading". 
   (source: Olegario Llamazares: Dictionary Of International Trade, Key definitions of 2000 trade terms and acronyms).
   Model based on https://service.unece.org/trade/uncefact/publication/Transport%20and%20Logistics/MaritimeBill/HTML/001.htm
 type: object


### PR DESCRIPTION
This first and foremost inlines the Multi modal BL. 

Also includes a few tweaks: 
- Removing "ocean" from the descriptino, multimodal BLs are not limited to ocean carriers
- Changes "includedConsignmentItems" to "particulars", which is how it is labeled printing on BL forms
- Removes `carrier` because the carrier is always the issuer. 
- Indication that issuer is carrier, incl adding SCAC identifier. 