### PR TITLE
Change the order of usmca from feedback

### DIFF
--- a/docs/credentials-with-issuer-dependent-terms.json
+++ b/docs/credentials-with-issuer-dependent-terms.json
@@ -12,10 +12,6 @@
     "count": 2
   },
   {
-    "type": "USMCACertificationOfOrigin",
-    "count": 6
-  },
-  {
     "type": "ThingCredential",
     "count": 0
   },

--- a/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
@@ -91,6 +91,329 @@ properties:
           type: string
           enum:
             - USMCAProductSpecifier
+      invoiceNumber:
+        title: Invoice Number
+        description: >-
+          An invoice in the case of a single shipment. When covering a shipment, the
+          issued USMCA credential should be indicated as revokable as to not allow the
+          credential to be double-spent for another shipment on delivery.
+        type: string
+      exporterDetails:
+        title: Exporter's Details
+        description: >-
+          Exporter’s name, address (including country), email address, and telephone
+          number, if different than the certifier. This information is not required
+          if the producer is completing the Certification of Origin and does not
+          know the identity of the exporter. The address of the exporter shall be
+          the place of export of the good in a Party’s territory.
+        type: object
+        required:
+          - type
+          - name
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Organization
+            default:
+              - Organization
+            items:
+              type: string
+              enum:
+                - Organization
+          id: 
+            title: Identifier
+            description: Organization identifier.
+            type: string
+            format: uri
+          name:
+            title: Name
+            description: Name of the organization.
+            type: string
+          email:
+            title: Email Address
+            description: Organization's primary email address.
+            type: string
+          phoneNumber:
+            title: Phone Number
+            description: Organization's contact phone number.
+            type: string
+          location:
+            title: Location
+            description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - Place
+                default:
+                  - Place
+                items:
+                  type: string
+                  enum:
+                    - Place
+              address:
+                title: Postal Address
+                description: The postal address for an organization or place.
+                type: object
+                properties:
+                  type:
+                    type: array
+                    readOnly: true
+                    const:
+                      - PostalAddress
+                    default:
+                      - PostalAddress
+                    items:
+                      type: string
+                      enum:
+                        - PostalAddress
+                  streetAddress:
+                    title: Street Address
+                    description: >-
+                      The street address expressed as free form text. The street address is
+                      printed on paper as the first lines below the name. For example, the name
+                      of the street and the number in the street, or the name of a building.
+                    type: string
+                  addressLocality:
+                    title: Address Locality
+                    description: Text specifying the name of the locality; for example, a city.
+                    type: string
+                  addressRegion:
+                    title: Address Region
+                    description: >-
+                      Text specifying a province or state in abbreviated format; for example,
+                      NJ.
+                    type: string
+                  addressCountry:
+                    title: Address Country
+                    description: >-
+                      The two-letter ISO 3166-1 alpha-2 country code.
+                    type: string
+                  postalCode:
+                    title: Postal Code
+                    description: Text specifying the postal code for an address.
+                    type: string
+                additionalProperties: false
+                required:
+                  - type
+        additionalProperties: false
+      producerDetails:
+        title: Producer's Details
+        description: >-
+          Producer’s name, address (including country), email address, and telephone
+          number, if different than the certifier or exporter, or, if there are
+          multiple producers, state 'Various' or provide a list of producers. A
+          person that wants this information to remain confidential may state
+          'Available upon request by the importing authorities.' The address of a
+          producer shall be the place of production of the good in a Party's
+          territory.
+        type: object
+        required:
+          - type
+          - name
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Organization
+            default:
+              - Organization
+            items:
+              type: string
+              enum:
+                - Organization
+          id: 
+            title: Identifier
+            description: Organization identifier.
+            type: string
+            format: uri
+          name:
+            title: Name
+            description: Name of the organization.
+            type: string
+          email:
+            title: Email Address
+            description: Organization's primary email address.
+            type: string
+          phoneNumber:
+            title: Phone Number
+            description: Organization's contact phone number.
+            type: string
+          location:
+            title: Location
+            description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - Place
+                default:
+                  - Place
+                items:
+                  type: string
+                  enum:
+                    - Place
+              address:
+                title: Postal Address
+                description: The postal address for an organization or place.
+                type: object
+                properties:
+                  type:
+                    type: array
+                    readOnly: true
+                    const:
+                      - PostalAddress
+                    default:
+                      - PostalAddress
+                    items:
+                      type: string
+                      enum:
+                        - PostalAddress
+                  streetAddress:
+                    title: Street Address
+                    description: >-
+                      The street address expressed as free form text. The street address is
+                      printed on paper as the first lines below the name. For example, the name
+                      of the street and the number in the street, or the name of a building.
+                    type: string
+                  addressLocality:
+                    title: Address Locality
+                    description: Text specifying the name of the locality; for example, a city.
+                    type: string
+                  addressRegion:
+                    title: Address Region
+                    description: >-
+                      Text specifying a province or state in abbreviated format; for example,
+                      NJ.
+                    type: string
+                  addressCountry:
+                    title: Address Country
+                    description: >-
+                      The two-letter ISO 3166-1 alpha-2 country code.
+                    type: string
+                  postalCode:
+                    title: Postal Code
+                    description: Text specifying the postal code for an address.
+                    type: string
+                additionalProperties: false
+                required:
+                  - type
+        additionalProperties: false
+        required:
+          - type
+      variousImporters:
+        title: Various Importer
+        description: >-
+          A flag to indicate there are multiple importers available on request
+        type: boolean
+      importerDetails:
+        title: Importer's Details
+        description: >-
+          Importer’s name, address, email address, and telephone number (if known).
+          The address of the importer shall be in a Party's territory. If the
+          identity of the importer is unknown, or there are various importers,
+          please check the appropriate box.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Organization
+            default:
+              - Organization
+            items:
+              type: string
+              enum:
+                - Organization
+          id: 
+            title: Identifier
+            description: Organization identifier.
+            type: string
+            format: uri
+          name:
+            title: Name
+            description: Name of the organization.
+            type: string
+          email:
+            title: Email Address
+            description: Organization's primary email address.
+            type: string
+          phoneNumber:
+            title: Phone Number
+            description: Organization's contact phone number.
+            type: string
+          location:
+            title: Location
+            description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - Place
+                default:
+                  - Place
+                items:
+                  type: string
+                  enum:
+                    - Place
+              address:
+                title: Postal Address
+                description: The postal address for an organization or place.
+                type: object
+                properties:
+                  type:
+                    type: array
+                    readOnly: true
+                    const:
+                      - PostalAddress
+                    default:
+                      - PostalAddress
+                    items:
+                      type: string
+                      enum:
+                        - PostalAddress
+                  streetAddress:
+                    title: Street Address
+                    description: >-
+                      The street address expressed as free form text. The street address is
+                      printed on paper as the first lines below the name. For example, the name
+                      of the street and the number in the street, or the name of a building.
+                    type: string
+                  addressLocality:
+                    title: Address Locality
+                    description: Text specifying the name of the locality; for example, a city.
+                    type: string
+                  addressRegion:
+                    title: Address Region
+                    description: >-
+                      Text specifying a province or state in abbreviated format; for example,
+                      NJ.
+                    type: string
+                  addressCountry:
+                    title: Address Country
+                    description: >-
+                      The two-letter ISO 3166-1 alpha-2 country code.
+                    type: string
+                  postalCode:
+                    title: Postal Code
+                    description: Text specifying the postal code for an address.
+                    type: string
+                additionalProperties: false
+                required:
+                  - type
+        additionalProperties: false
+        required:
+          - type
       product:
         title: Product
         description: >-
@@ -98,12 +421,17 @@ properties:
           description, and minimum 6-digit HS classification
         type: array
         minItems: 1
+        maxItems: 100
         items:
           type: object
-          required:
-            - originCriterion
+          required:            
             - type
+            - identifier
             - countryOfOrigin
+            - originCriterion
+            - name
+            - description
+            - commodity
           properties:
             type:
               type: array
@@ -116,12 +444,9 @@ properties:
                 type: string
                 enum:
                   - Product
-            id:
+            identifier:
               title: Product Identifier
               description: The product identifier, such as ISBN.
-              type: string
-            gtin:
-              title: Global Trade Item Number (GTIN)
               type: string
             name:
               title: Name
@@ -131,10 +456,17 @@ properties:
               title: Description
               description: Description of the shipment.
               type: string
+            gtin:
+              title: Global Trade Item Number (GTIN)
+              type: string
             commodity:
               title: Commodity
               description: Product commodity code, codification system and description
               type: object
+              required:
+                - type
+                - commodityCode
+                - commodityCodeType
               properties:
                 type:
                   type: array
@@ -156,6 +488,7 @@ properties:
                 commodityCodeType:
                   title: Commodity Code Type
                   description: Commodity code type
+                  type: string
                   enum:
                     - HS
                     - HTS
@@ -196,339 +529,12 @@ properties:
                 - CA
                 - MX
                 - US
-      producerConfidential:
-        title: Producer Confidential
-        description: >-
-          A person that wants the producer information to remain confidential may
-          state 'Available upon request by the importing authorities.'
-        type: boolean
-      producerDetails:
-        title: Producer's Details
-        description: >-
-          Producer’s name, address (including country), email address, and telephone
-          number, if different than the certifier or exporter, or, if there are
-          multiple producers, state 'Various' or provide a list of producers. A
-          person that wants this information to remain confidential may state
-          'Available upon request by the importing authorities.' The address of a
-          producer shall be the place of production of the good in a Party's
-          territory.
-        type: array
-        maxItems: 1
-        items:
-          type: object
-          properties:
-            type:
-              type: array
-              readOnly: true
-              const:
-                - Organization
-              default:
-                - Organization
-              items:
-                type: string
-                enum:
-                  - Organization
-            id: 
-              title: Identifier
-              description: Organization identifier.
-              type: string
-              format: uri
-            name:
-              title: Name
-              description: Name of the organization.
-              type: string
-            email:
-              title: Email Address
-              description: Organization's primary email address.
-              type: string
-            phoneNumber:
-              title: Phone Number
-              description: Organization's contact phone number.
-              type: string
-            location:
-              title: Location
-              description: The location where, for example, an event is happening, an organization is located, or an action takes place.
-              type: object
-              properties:
-                type:
-                  type: array
-                  readOnly: true
-                  const:
-                    - Place
-                  default:
-                    - Place
-                  items:
-                    type: string
-                    enum:
-                      - Place
-                address:
-                  title: Postal Address
-                  description: The postal address for an organization or place.
-                  type: object
-                  properties:
-                    type:
-                      type: array
-                      readOnly: true
-                      const:
-                        - PostalAddress
-                      default:
-                        - PostalAddress
-                      items:
-                        type: string
-                        enum:
-                          - PostalAddress
-                    streetAddress:
-                      title: Street Address
-                      description: >-
-                        The street address expressed as free form text. The street address is
-                        printed on paper as the first lines below the name. For example, the name
-                        of the street and the number in the street, or the name of a building.
-                      type: string
-                    addressLocality:
-                      title: Address Locality
-                      description: Text specifying the name of the locality; for example, a city.
-                      type: string
-                    addressRegion:
-                      title: Address Region
-                      description: >-
-                        Text specifying a province or state in abbreviated format; for example,
-                        NJ.
-                      type: string
-                    addressCountry:
-                      title: Address Country
-                      description: >-
-                        The two-letter ISO 3166-1 alpha-2 country code.
-                      type: string
-                    postalCode:
-                      title: Postal Code
-                      description: Text specifying the postal code for an address.
-                      type: string
-                  additionalProperties: false
-                  required:
-                    - type
-          additionalProperties: false
-          required:
-            - type
-      importerUnknown:
-        title: Importer Unknown
-        description: >-
-          If the identity of the importer is unknown, or there are various
-          importers, please check this appropriate box.
-        type: boolean
-      importerDetails:
-        title: Importer's Details
-        description: >-
-          Importer’s name, address, email address, and telephone number (if known).
-          The address of the importer shall be in a Party's territory. If the
-          identity of the importer is unknown, or there are various importers,
-          please check the appropriate box.
-        type: array
-        maxItems: 1
-        items:
-          type: object
-          properties:
-            type:
-              type: array
-              readOnly: true
-              const:
-                - Organization
-              default:
-                - Organization
-              items:
-                type: string
-                enum:
-                  - Organization
-            id: 
-              title: Identifier
-              description: Organization identifier.
-              type: string
-              format: uri
-            name:
-              title: Name
-              description: Name of the organization.
-              type: string
-            email:
-              title: Email Address
-              description: Organization's primary email address.
-              type: string
-            phoneNumber:
-              title: Phone Number
-              description: Organization's contact phone number.
-              type: string
-            location:
-              title: Location
-              description: The location where, for example, an event is happening, an organization is located, or an action takes place.
-              type: object
-              properties:
-                type:
-                  type: array
-                  readOnly: true
-                  const:
-                    - Place
-                  default:
-                    - Place
-                  items:
-                    type: string
-                    enum:
-                      - Place
-                address:
-                  title: Postal Address
-                  description: The postal address for an organization or place.
-                  type: object
-                  properties:
-                    type:
-                      type: array
-                      readOnly: true
-                      const:
-                        - PostalAddress
-                      default:
-                        - PostalAddress
-                      items:
-                        type: string
-                        enum:
-                          - PostalAddress
-                    streetAddress:
-                      title: Street Address
-                      description: >-
-                        The street address expressed as free form text. The street address is
-                        printed on paper as the first lines below the name. For example, the name
-                        of the street and the number in the street, or the name of a building.
-                      type: string
-                    addressLocality:
-                      title: Address Locality
-                      description: Text specifying the name of the locality; for example, a city.
-                      type: string
-                    addressRegion:
-                      title: Address Region
-                      description: >-
-                        Text specifying a province or state in abbreviated format; for example,
-                        NJ.
-                      type: string
-                    addressCountry:
-                      title: Address Country
-                      description: >-
-                        The two-letter ISO 3166-1 alpha-2 country code.
-                      type: string
-                    postalCode:
-                      title: Postal Code
-                      description: Text specifying the postal code for an address.
-                      type: string
-                  additionalProperties: false
-                  required:
-                    - type
-          additionalProperties: false
-          required:
-            - type
-      exporterDetails:
-        title: Exporter's Details
-        description: >-
-          Exporter’s name, address (including country), email address, and telephone
-          number, if different than the certifier. This information is not required
-          if the producer is completing the Certification of Origin and does not
-          know the identity of the exporter. The address of the exporter shall be
-          the place of export of the good in a Party’s territory.
-        type: array
-        maxItems: 1
-        items:
-          type: object
-          properties:
-            type:
-              type: array
-              readOnly: true
-              const:
-                - Organization
-              default:
-                - Organization
-              items:
-                type: string
-                enum:
-                  - Organization
-            id: 
-              title: Identifier
-              description: Organization identifier.
-              type: string
-              format: uri
-            name:
-              title: Name
-              description: Name of the organization.
-              type: string
-            email:
-              title: Email Address
-              description: Organization's primary email address.
-              type: string
-            phoneNumber:
-              title: Phone Number
-              description: Organization's contact phone number.
-              type: string
-            location:
-              title: Location
-              description: The location where, for example, an event is happening, an organization is located, or an action takes place.
-              type: object
-              properties:
-                type:
-                  type: array
-                  readOnly: true
-                  const:
-                    - Place
-                  default:
-                    - Place
-                  items:
-                    type: string
-                    enum:
-                      - Place
-                address:
-                  title: Postal Address
-                  description: The postal address for an organization or place.
-                  type: object
-                  properties:
-                    type:
-                      type: array
-                      readOnly: true
-                      const:
-                        - PostalAddress
-                      default:
-                        - PostalAddress
-                      items:
-                        type: string
-                        enum:
-                          - PostalAddress
-                    streetAddress:
-                      title: Street Address
-                      description: >-
-                        The street address expressed as free form text. The street address is
-                        printed on paper as the first lines below the name. For example, the name
-                        of the street and the number in the street, or the name of a building.
-                      type: string
-                    addressLocality:
-                      title: Address Locality
-                      description: Text specifying the name of the locality; for example, a city.
-                      type: string
-                    addressRegion:
-                      title: Address Region
-                      description: >-
-                        Text specifying a province or state in abbreviated format; for example,
-                        NJ.
-                      type: string
-                    addressCountry:
-                      title: Address Country
-                      description: >-
-                        The two-letter ISO 3166-1 alpha-2 country code.
-                      type: string
-                    postalCode:
-                      title: Postal Code
-                      description: Text specifying the postal code for an address.
-                      type: string
-                  additionalProperties: false
-                  required:
-                    - type
-          additionalProperties: false
-          required:
-            - type
     additionalProperties: false  
     required:
       - type
       - product
       - exporterDetails
+      - producerDetails
   proof:
     $ref: ../snippets/proof.yml
 additionalProperties: false
@@ -672,9 +678,9 @@ example: |-
     },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2023-06-12T18:28:19Z",
+      "created": "2023-06-20T12:43:35Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..7MIUzG2DupUd1tuyKBCXbas5dnBvqmEWbE7C3ql9WoRQ1t7Lmz_A-JF_LMic1LD7--YJGKLu-zlyZePCQr_vAw"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..hKbZF7CFoqAWdWdjn5pVJjtMuHPzbEt7w4im9jC8UADMpmBR2z2QoVhl6mS6rRK_cpQEPxQLK_UXUOE6bbsyDQ"
     }
   }


### PR DESCRIPTION
Updating the USMCA credential from feedback.

- Added invoice number in cases for a single instance instead of a blanket period
- Changed the order of the credential to closer resemble the paper-version of the document for business users
  - invoice number
  - exporter
  - producer
  - importer
  - product(s)
- removed producer confidential flag
- added various importers flag
- made exporter and producer direct objects instead of optional components