### PR TITLE
add CredentialStatus to BankAccountCredential

### DIFF
--- a/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
@@ -23,17 +23,14 @@ properties:
     const:
       - https://www.w3.org/2018/credentials/v1
       - https://w3id.org/traceability/v1
-      - https://w3id.org/vc/status-list/2021/v1
     default:
       - https://www.w3.org/2018/credentials/v1
       - https://w3id.org/traceability/v1
-      - https://w3id.org/vc/status-list/2021/v1
     items:
       type: string
       enum:
         - https://www.w3.org/2018/credentials/v1
         - https://w3id.org/traceability/v1
-        - https://w3id.org/vc/status-list/2021/v1
   type:
     type: array
     readOnly: true
@@ -72,8 +69,6 @@ properties:
         const: OpenApiSpecificationValidator2022
   credentialSubject:
     $ref: ../common/BankAccount.yml
-  credentialStatus:
-    type: object
   proof:
     type: object
 additionalProperties: false
@@ -87,15 +82,14 @@ example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/traceability/v1",
-      "https://w3id.org/vc/status-list/2021/v1"
+      "https://w3id.org/traceability/v1"
     ],
-    "id": "did:key:1111111",
+    "id": "https://acmebank.com/credentials/1111111",
     "type": [
       "VerifiableCredential",
       "BankAccountCredential"
     ],
-    "issuer": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+    "issuer": "urn:uuid:11111111-1111-1111-1111-111111111111",
     "issuanceDate": "2022-04-11T16:36:24Z",
     "credentialSubject": {
       "type": [
@@ -105,7 +99,7 @@ example: |-
       "BIC11": "TDOMCATTTOR",
       "familyName": "Smith",
       "givenName": "Alice",
-      "id": "did:key:z6Mk2cd21e9abe57fae7...31073da1b522790e63834fe17a4c2be",
+      "id": "urn:uuid:ba52b172-9422-4879-93b3-03936d169b86",
       "iban": "GB74GSLD04296280001319",
       "routingInfo": {
         "type": [
@@ -124,19 +118,5 @@ example: |-
         "addressCountry": "Canada",
         "postalCode": "M3B 1A2"
       }
-    },
-    "credentialStatus": {
-      "id": "https://example.com/status/362bbbb5-3d9b-4405-82ee-cf1443415351#5",
-      "type": "StatusList2021Entry",
-      "statusPurpose": "revocation",
-      "statusListIndex": "5",
-      "statusListCredential": "https://example.com/status/362bbbb5-3d9b-4405-82ee-cf1443415351"
-    },
-    "proof": {
-      "type": "Ed25519Signature2020",
-      "created": "2023-06-20T19:35:30Z",
-      "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "proofPurpose": "assertionMethod",
-      "proofValue": "z4xTXcWHhZY8oXCXTKS...cSKGK9YcBuKqyqzjbaohmtMZBAenC9huBJ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
@@ -137,6 +137,6 @@ example: |-
       "created": "2023-06-20T19:35:30Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "z4xTXcWHhZY8oXCXTKS...cSKGK9YcBuKqyqzjbaohmtMZBAenC9huBJ"
+      "proofValue": "z4xTXcWHhZY8oXCXTKS...cSKGK9YcBuKqyqzjbaohmtMZBAenC9huBJ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
@@ -23,14 +23,17 @@ properties:
     const:
       - https://www.w3.org/2018/credentials/v1
       - https://w3id.org/traceability/v1
+      - https://w3id.org/vc/status-list/2021/v1
     default:
       - https://www.w3.org/2018/credentials/v1
       - https://w3id.org/traceability/v1
+      - https://w3id.org/vc/status-list/2021/v1
     items:
       type: string
       enum:
         - https://www.w3.org/2018/credentials/v1
         - https://w3id.org/traceability/v1
+        - https://w3id.org/vc/status-list/2021/v1
   type:
     type: array
     readOnly: true
@@ -69,6 +72,8 @@ properties:
         const: OpenApiSpecificationValidator2022
   credentialSubject:
     $ref: ../common/BankAccount.yml
+  credentialStatus:
+    type: object
   proof:
     type: object
 additionalProperties: false
@@ -77,12 +82,13 @@ required:
   - type
   - issuanceDate
   - issuer
-  - credentialSubject    
+  - credentialSubject
 example: |-
   {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/traceability/v1"
+      "https://w3id.org/traceability/v1",
+      "https://w3id.org/vc/status-list/2021/v1"
     ],
     "id": "did:key:1111111",
     "type": [
@@ -119,11 +125,18 @@ example: |-
         "postalCode": "M3B 1A2"
       }
     },
+    "credentialStatus": {
+      "id": "https://example.com/status/362bbbb5-3d9b-4405-82ee-cf1443415351#5",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "5",
+      "statusListCredential": "https://example.com/status/362bbbb5-3d9b-4405-82ee-cf1443415351"
+    },
     "proof": {
       "type": "Ed25519Signature2018",
-      "created": "2022-12-23T23:46:38Z",
+      "created": "2023-06-20T19:35:30Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..4D_1PyHmhl1-JI4oefkAKGrkkwOuEwOMo8pNUoEoJpfQkUH572n1IUEwHQst3c0fmB_SSIMnUPpBxkvy0seFCg"
+      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..CNYSmh9AsCZt0P-QE2hG79EXI2g72HenEGYt1ZbVbk3mGg9vtg-TFvZw__290g2kcHuU2b2TbJz3tqeLlNfJBA"
     }
   }

--- a/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
+++ b/docs/openapi/components/schemas/credentials/BankAccountCredential.yml
@@ -133,10 +133,10 @@ example: |-
       "statusListCredential": "https://example.com/status/362bbbb5-3d9b-4405-82ee-cf1443415351"
     },
     "proof": {
-      "type": "Ed25519Signature2018",
+      "type": "Ed25519Signature2020",
       "created": "2023-06-20T19:35:30Z",
       "verificationMethod": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U#z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
       "proofPurpose": "assertionMethod",
-      "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..CNYSmh9AsCZt0P-QE2hG79EXI2g72HenEGYt1ZbVbk3mGg9vtg-TFvZw__290g2kcHuU2b2TbJz3tqeLlNfJBA"
+      "jws": "z4xTXcWHhZY8oXCXTKS...cSKGK9YcBuKqyqzjbaohmtMZBAenC9huBJ"
     }
   }

--- a/docs/openapi/components/schemas/credentials/ExampleCredentialWithStatus.yml
+++ b/docs/openapi/components/schemas/credentials/ExampleCredentialWithStatus.yml
@@ -1,0 +1,100 @@
+title: Example Credential
+tags:
+  - Example
+description: >-
+  A sample credential showing how a status list can be added
+type: object
+properties:
+  '@context':
+    type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+      - https://w3id.org/vc/status-list/2021/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+      - https://w3id.org/vc/status-list/2021/v1
+    items:
+      type: string
+      enum:
+        - https://www.w3.org/2018/credentials/v1
+        - https://w3id.org/traceability/v1
+        - https://w3id.org/vc/status-list/2021/v1
+  type:
+    type: array
+    readOnly: true
+    const:
+      - VerifiableCredential
+      - ExampleCredential
+    default:
+      - VerifiableCredential
+      - ExampleCredential
+    items:
+      type: string
+      enum:
+        - VerifiableCredential
+        - ExampleCredential
+  id:
+    type: string
+
+  issuer:
+    type: string
+  issuanceDate:
+    type: string
+  credentialSchema:
+    type: object
+    properties:
+      id:
+        title: Id
+        description: The url of the schema file to validate the shape of the json object
+        type: string
+        format: uri
+        example: https://w3id.org/traceability/openapi/components/schemas/credentials/ExampleCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/ExampleCredential.yml
+        readOnly: true
+      type:
+        title: Type
+        description: The type of validation to be run against the defined schema
+        const: OpenApiSpecificationValidator2022
+  credentialSubject:
+    type: object
+  credentialStatus:
+    type: object
+  proof:
+    type: object
+additionalProperties: false
+required:
+  - '@context'
+  - type
+  - issuanceDate
+  - issuer
+  - credentialSubject
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1",
+      "https://w3id.org/vc/status-list/2021/v1"
+    ],
+    "id": "urn:uuid:ba52b172-9422-4879-93b3-03936d169b86",
+    "type": [
+      "VerifiableCredential",
+      "ExampleCredential"
+    ],
+    "issuer": "urn:uuid:11111111-1111-1111-1111-111111111111",
+    "issuanceDate": "2023-04-11T16:36:24Z",
+    "credentialSubject": {
+      "type": [
+        "Example"
+      ]
+    },
+    "credentialStatus": {
+      "id": "https://example.com/status/362bbbb5-3d9b-4405-82ee-cf1443415351#5",
+      "type": "StatusList2021Entry",
+      "statusPurpose": "revocation",
+      "statusListIndex": "5",
+      "statusListCredential": "https://example.com/status/362bbbb5-3d9b-4405-82ee-cf1443415351"
+    }
+  }


### PR DESCRIPTION
<img width="1042" alt="image" src="https://github.com/w3c-ccg/traceability-vocab/assets/2683171/63909a07-9026-4180-8588-1184179d9b8f">


This PR updates the BankAccount example to include the credentialStatus as defined through StatusList2021Entry