### PR TITLE
Add support for JSON Patch

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1355,6 +1355,11 @@ had made a mistake in a previous presentation, and corrects the mistake with a r
   ]
 }
           </pre>
+
+          <section
+          data-include="sections/json-patch.html"
+          data-include-replace="true"
+        ></section>
         </section>
       </section>
     </section>

--- a/docs/sections/json-patch.html
+++ b/docs/sections/json-patch.html
@@ -1,0 +1,112 @@
+
+<section>
+  <h2>JSON Patch</h2>
+  <p>
+Instead of presenting a corrected documents, 
+some implementations might wish to communicate 
+only the corrections to a previously submitted JSON document. 
+  </p>
+  
+  <p>
+    JSON Patch supports this operation, here is an example:
+  </p>
+  <pre class="example" title="Presentation with error">
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        {
+          "replaces": {
+            "@id": "https://w3id.org/traceability#replaces",
+            "@type": "@id"
+          },
+          "patch": {
+            "@id": "https://datatracker.ietf.org/doc/rfc6902#section-4",
+            "@type": "@json"
+          },
+          "workflow": {
+            "@context": {
+              "definition": {
+                "@id": "https://w3id.org/traceability#definition",
+                "@type": "@id"
+              },
+              "instance": {
+                "@id": "https://w3id.org/traceability#instance",
+                "@type": "@id"
+              }
+            }
+          }
+        }
+      ],
+      "id": "urn:uuid:1111",
+      "type": [
+        "VerifiablePresentation",
+        "TraceablePresentation"
+      ],
+      "workflow": {
+        "definition": [
+          "urn:definition:steel-import"
+        ],
+        "instance": [
+          "urn:instance:steel-import-from-customs-broker-123"
+        ]
+      },
+      "name": "alcie"
+    }
+  </pre>
+  <pre class="example" title="Presentation with json patch correction">
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        {
+          "replaces": {
+            "@id": "https://w3id.org/traceability#replaces",
+            "@type": "@id"
+          },
+          "patch": {
+            "@id": "https://datatracker.ietf.org/doc/rfc6902#section-4",
+            "@type": "@json"
+          },
+          "workflow": {
+            "@context": {
+              "definition": {
+                "@id": "https://w3id.org/traceability#definition",
+                "@type": "@id"
+              },
+              "instance": {
+                "@id": "https://w3id.org/traceability#instance",
+                "@type": "@id"
+              }
+            }
+          }
+        }
+      ],
+      "id": "urn:uuid:2222",
+      "type": [
+        "VerifiablePresentation",
+        "TraceablePresentation"
+      ],
+      "replaces": {
+        "id": "urn:uuid:1111",
+        "type": [
+          "VerifiablePresentation",
+          "TraceablePresentation"
+        ]
+      },
+      "patch": [
+        {
+          "op": "replace",
+          "path": "/name",
+          "value": "alice"
+        }
+      ]
+    }
+  </pre>
+  <p class="advisement">
+    This approach requires holders to store all presentations they send to verifiers, 
+    AND for verifiers to apply JSON Patches prior to storing claims.
+  </p>
+  <p>
+    Verifiers won't be able to query for corrections unless 
+    they have applied all correction patches to their local state store.
+  </p>
+</section>


### PR DESCRIPTION
Spec text (would need a lot more to safely explain this).

<img width="1520" alt="Screen Shot 2023-06-22 at 10 06 50 AM" src="https://github.com/w3c-ccg/traceability-vocab/assets/8295856/42a79a35-d9f3-4155-8648-e8fa66390bb1">

What a graph that contains operations looks like:

<img width="2207" alt="Screen Shot 2023-06-22 at 9 54 30 AM" src="https://github.com/w3c-ccg/traceability-vocab/assets/8295856/af9a6594-853a-40b2-b08c-25fb14e21cf1">

What the simple solution we already have looks like

<img width="2112" alt="Screen Shot 2023-06-21 at 2 08 07 PM" src="https://github.com/w3c-ccg/traceability-vocab/assets/8295856/a9f32616-2175-43e0-8427-954eee60cf1d">
