### PR TITLE
Postal adress inlining

### DIFF
--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
@@ -237,10 +237,6 @@ properties:
             title: URL
             description: URL of the consignor.
             type: string
-          description:
-            title: Description
-            description: Description of the consignor.
-            type: string
           email:
             title: Email Address
             description: Consignor's primary email address.
@@ -267,8 +263,47 @@ properties:
                     - Place
               address:
                 title: Postal Address
-                description: The postal address for an organization or place.
-                $ref: ../common/PostalAddress.yml
+                description: Shipper's postal address.
+                type: object
+                properties:
+                  type:
+                    type: array
+                    readOnly: true
+                    const:
+                      - PostalAddress
+                    default:
+                      - PostalAddress
+                    items:
+                      type: string
+                      enum:
+                        - PostalAddress
+                  streetAddress:
+                    title: Street Address
+                    description: >-
+                      The street address expressed as free form text. The street address is
+                      printed on paper as the first lines below the name. For example, the name
+                      of the street and the number in the street, or the name of a building.
+                    type: string
+                  addressLocality:
+                    title: City
+                    description: Text specifying the name of the locality; for example, a city.
+                    type: string
+                  addressRegion:
+                    title: State
+                    description: >-
+                      Text specifying a province or state in abbreviated format; for example,
+                      NJ.
+                    type: string
+                  postalCode:
+                    title: Postal Code
+                    description: Text specifying the postal code for an address.
+                    type: string
+                  addressCountry:
+                    title: Country
+                    description: >-
+                      The two-letter ISO 3166-1 alpha-2 country code.
+                    type: string
+                additionalProperties: false
         additionalProperties: false
         required:
           - type
@@ -301,10 +336,6 @@ properties:
             title: URL
             description: URL of the consignee.
             type: string
-          description:
-            title: Description
-            description: Description of the consignee.
-            type: string
           email:
             title: Email Address
             description: Consignee's primary email address.
@@ -331,8 +362,47 @@ properties:
                     - Place
               address:
                 title: Postal Address
-                description: The postal address for an organization or place.
-                $ref: ../common/PostalAddress.yml
+                description: Consignee's postal address.
+                type: object
+                properties:
+                  type:
+                    type: array
+                    readOnly: true
+                    const:
+                      - PostalAddress
+                    default:
+                      - PostalAddress
+                    items:
+                      type: string
+                      enum:
+                        - PostalAddress
+                  streetAddress:
+                    title: Street Address
+                    description: >-
+                      The street address expressed as free form text. The street address is
+                      printed on paper as the first lines below the name. For example, the name
+                      of the street and the number in the street, or the name of a building.
+                    type: string
+                  addressLocality:
+                    title: City
+                    description: Text specifying the name of the locality; for example, a city.
+                    type: string
+                  addressRegion:
+                    title: State
+                    description: >-
+                      Text specifying a province or state in abbreviated format; for example,
+                      NJ.
+                    type: string
+                  postalCode:
+                    title: Postal Code
+                    description: Text specifying the postal code for an address.
+                    type: string
+                  addressCountry:
+                    title: Country
+                    description: >-
+                      The two-letter ISO 3166-1 alpha-2 country code.
+                    type: string
+                additionalProperties: false
         additionalProperties: false
         required:
           - type
@@ -365,10 +435,6 @@ properties:
             title: URL
             description: URL of the freight forwarder.
             type: string
-          description:
-            title: Description
-            description: Description of the freight forwarder.
-            type: string
           email:
             title: Email Address
             description: Freight forwarder's primary email address.
@@ -395,8 +461,47 @@ properties:
                     - Place
               address:
                 title: Postal Address
-                description: The postal address for an organization or place.
-                $ref: ../common/PostalAddress.yml
+                description: Freight forwarder's postal address.
+                type: object
+                properties:
+                  type:
+                    type: array
+                    readOnly: true
+                    const:
+                      - PostalAddress
+                    default:
+                      - PostalAddress
+                    items:
+                      type: string
+                      enum:
+                        - PostalAddress
+                  streetAddress:
+                    title: Street Address
+                    description: >-
+                      The street address expressed as free form text. The street address is
+                      printed on paper as the first lines below the name. For example, the name
+                      of the street and the number in the street, or the name of a building.
+                    type: string
+                  addressLocality:
+                    title: City
+                    description: Text specifying the name of the locality; for example, a city.
+                    type: string
+                  addressRegion:
+                    title: State
+                    description: >-
+                      Text specifying a province or state in abbreviated format; for example,
+                      NJ.
+                    type: string
+                  postalCode:
+                    title: Postal Code
+                    description: Text specifying the postal code for an address.
+                    type: string
+                  addressCountry:
+                    title: Country
+                    description: >-
+                      The two-letter ISO 3166-1 alpha-2 country code.
+                    type: string
+                additionalProperties: false
         additionalProperties: false
         required:
           - type
@@ -433,10 +538,6 @@ properties:
               title: URL
               description: URL of the notify party.
               type: string
-            description:
-              title: Description
-              description: Description of the notify party.
-              type: string
             email:
               title: Email Address
               description: notify party's primary email address.
@@ -463,8 +564,47 @@ properties:
                       - Place
                 address:
                   title: Postal Address
-                  description: The postal address for an organization or place.
-                  $ref: ../common/PostalAddress.yml
+                  description: Notify party's postal address.
+                  type: object
+                  properties:
+                    type:
+                      type: array
+                      readOnly: true
+                      const:
+                        - PostalAddress
+                      default:
+                        - PostalAddress
+                      items:
+                        type: string
+                        enum:
+                          - PostalAddress
+                    streetAddress:
+                      title: Street Address
+                      description: >-
+                        The street address expressed as free form text. The street address is
+                        printed on paper as the first lines below the name. For example, the name
+                        of the street and the number in the street, or the name of a building.
+                      type: string
+                    addressLocality:
+                      title: City
+                      description: Text specifying the name of the locality; for example, a city.
+                      type: string
+                    addressRegion:
+                      title: State
+                      description: >-
+                        Text specifying a province or state in abbreviated format; for example,
+                        NJ.
+                      type: string
+                    postalCode:
+                      title: Postal Code
+                      description: Text specifying the postal code for an address.
+                      type: string
+                    addressCountry:
+                      title: Country
+                      description: >-
+                        The two-letter ISO 3166-1 alpha-2 country code.
+                      type: string
+                  additionalProperties: false
           additionalProperties: false
           required:
             - type
@@ -1210,7 +1350,6 @@ example: |-
           "Organization"
         ],
         "name": "Prosumer Coffee Supplies, Ltd.",
-        "description": "Coffee Machine Imports",
         "location": {
           "type": [
             "Place"
@@ -1233,7 +1372,6 @@ example: |-
             "Organization"
           ],
           "name": "Prosumer Coffee Supplies, Ltd.",
-          "description": "Coffee Machine Imports",
           "location": {
             "type": [
               "Place"


### PR DESCRIPTION
1. This fixes missing inlining of postal addresses
2. Removes description from Party 