### PR TITLE
Fix Commercial Invoice Schema

### DIFF
--- a/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/CommercialInvoiceCredential.yml
@@ -458,7 +458,8 @@ properties:
         title: Consignee
         description: The consignee party for this supply chain consignment.
         type: array
-        items: 
+        items:
+          type: object
           properties:
             type:
               type: array


### PR DESCRIPTION
The `consignee` of the commercial invoice does not specify a `type` for it's `items`.