### PR TITLE
Fix entry number example missing fields

### DIFF
--- a/docs/openapi/components/schemas/credentials/EntryNumberCredential.yml
+++ b/docs/openapi/components/schemas/credentials/EntryNumberCredential.yml
@@ -106,7 +106,22 @@ example: |-
         "Organization"
       ],
       "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "name": "Onwards A/S"
+      "name": "Onwards A/S",
+      "location": {
+        "type": [
+          "Place"
+        ],
+        "address": {
+          "type": [
+            "PostalAddress"
+          ],
+          "streetAddress": "19 Knox St",
+          "addressLocality": "Toronto",
+          "addressRegion": "ON",
+          "addressCountry": "Canada",
+          "postalCode": "M3B 1A2"
+        }
+      }
     },
     "issuanceDate": "2022-11-01T10:58:45-04:00",
     "credentialSubject": {

--- a/docs/openapi/components/schemas/credentials/EntryNumberCredential.yml
+++ b/docs/openapi/components/schemas/credentials/EntryNumberCredential.yml
@@ -118,7 +118,7 @@ example: |-
           "streetAddress": "19 Knox St",
           "addressLocality": "Toronto",
           "addressRegion": "ON",
-          "addressCountry": "Canada",
+          "addressCountry": "CA",
           "postalCode": "M3B 1A2"
         }
       }


### PR DESCRIPTION
Updates the entry number certificate to include issuer organization location in the example.
