### PR TITLE
Misc. schema property cleanup

### DIFF
--- a/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
@@ -52,7 +52,7 @@ properties:
     items: 
       type: string
     $linkedData:
-      term: shippersReferences
+      term: freightForwardersReferences
       '@id': https://service.unece.org/trade/uncefact/vocabulary/uncl1153/#Consignment_identifier_freight_forwarder_assigned
   shipper: 
     title: Shipper
@@ -74,7 +74,7 @@ properties:
     description: The freight forwarder party for this supply chain consignment.
     $ref: ./Organization.yml
     $linkedData:
-      term: notifyParty
+      term: forwardingAgent
       '@id': >-
         https://vocabulary.uncefact.org/freightForwarderParty
   notifyParty:
@@ -134,7 +134,7 @@ properties:
     description: A transshipment location for this supply chain consignment.
     $ref: ./Place.yml
     $linkedData:
-      term: portOfLoading
+      term: transshipmentLocation
       '@id': https://vocabulary.uncefact.org/transshipmentLocation
   placeOfDelivery:
     title: Place of Delivery

--- a/docs/openapi/components/schemas/common/Product.yml
+++ b/docs/openapi/components/schemas/common/Product.yml
@@ -94,9 +94,7 @@ properties:
       '@id': https://schema.org/height
   productPrice:
     title: Product Price
-    description: >-
-      One or more detailed price specifications, indicating the unit price and
-      delivery or payment charges.
+    description: The unit price.
     $ref: ./PriceSpecification.yml
     $linkedData:
       term: productPrice

--- a/docs/openapi/components/schemas/common/TransportEquipment.yml
+++ b/docs/openapi/components/schemas/common/TransportEquipment.yml
@@ -87,7 +87,7 @@ properties:
   isShipperOwned:
     title: Is Shipper Owned
     description: Indicates whether the container is shipper owned (SOC).
-    type: string
+    type: boolean
     $linkedData:
       term: isShipperOwned
       '@id': >-

--- a/docs/openapi/components/schemas/common/TransportEquipment.yml
+++ b/docs/openapi/components/schemas/common/TransportEquipment.yml
@@ -65,15 +65,15 @@ properties:
     description: The unit of measure which can be expressed in imperial or metric terms
     type: number
     $linkedData:
-      term: weightUnit
+      term: tareWeightUnit
       '@id': >-
         https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/weightUnit
   cargoGrossWeight:
     title: Tare Weight
-    description: The weight of an empty container (gross container weight).
+    description: The weight of a container and its cargo (gross container weight).
     type: number
     $linkedData:
-      term: tareWeight
+      term: cargoGrossWeight
       '@id': >-
         https://vocabulary.uncefact.org/grossWeightMeasure
   cargoGrossWeightUnit:
@@ -81,7 +81,7 @@ properties:
     description: The unit of measure which can be expressed in imperial or metric terms
     type: number
     $linkedData:
-      term: weightUnit
+      term: cargoGrossWeightUnit
       '@id': >-
         https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.1#/components/schemas/weightUnit
   isShipperOwned:

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -3104,6 +3104,18 @@ paths:
                 $ref: './components/schemas/workflows/businesscard.yml'
     
 
+  /schemas/workflows/cbp-steel-tech-demo-2023.yml:
+    get:
+      tags:
+      - workflows
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/workflows/cbp-steel-tech-demo-2023.yml'
+    
+
   /schemas/workflows/intent-to-import.yml:
     get:
       tags:
@@ -3114,18 +3126,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/workflows/intent-to-import.yml'
-    
-
-  /schemas/workflows/svip-steel-tech-demo.yml:
-    get:
-      tags:
-      - workflows
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/workflows/svip-steel-tech-demo.yml'
     
 
   /schemas/workflows/us-cbp-entry.yml:

--- a/docs/sections/workflows.html
+++ b/docs/sections/workflows.html
@@ -34,6 +34,106 @@ mermaid: >-
       A->>B: present Verifiable Business Card</pre>
     
 
+      <h3>CBP Steel Tech Demo 2023</h3>
+      <pre class='mermaid'>sequenceDiagram
+  title CBP Steel Tech Demo 2023 Use Case: Steel import into USA from Mexico via road carrier
+  participant A as Steel Buyer
+  participant B as Steel Producer
+  participant C as Customs Broker
+  participant D as SIMA
+  participant E as Road Carrier
+  participant F as CBP
+  A-->>A: issue Purchase Order Credential
+  A->>B: present Purchase Order Credential
+  A-->>A: issue Intent To Import Credential
+  A->>F: present Purchase Order Credential
+  A->>F: present Intent To Import Credential
+  A->>F: present CTPAT Credential
+  B-->>B: issue Commercial Invoice Credential
+  B->>A: present Commercial Invoice Credential
+  B->>F: present Commercial Invoice Credential
+  B-->>B: issue Mill Test Report Credential
+  B->>A: present Mill Test Report Credential
+  B->>F: present Mill Test Report Credential
+  C-->>C: issue SIMA Import License Application Credential
+  C->>D: present SIMA Import License Application Credential
+  D-->>D: issue SIMA Import License Credential
+  D->>F: present SIMA Import License Credential
+  D->>C: present SIMA Import License Credential
+  C->>A: present SIMA Import License Credential
+  E->>F: present CTPAT Credential
+  C-->>C: issue Entry Number Credential
+  C->>F: present Entry Number Credential
+  E-->>E: issue Multimodal Bill Of Lading Credential
+  E->>B: present Multimodal Bill Of Lading Credential
+  B->>C: present Multimodal Bill Of Lading Credential
+  C->>F: present Multimodal Bill Of Lading Credential</pre>
+      <p>CBP Steel Tech Demo 2023</p>
+      <b>Credentials Used:</b>
+      <ol>
+        <li><a href="https://w3id.org/traceability/#PurchaseOrderCredential">Purchase Order Credential</a></li><li><a href="https://w3id.org/traceability/#IntentToImportCredential">Intent To Import Credential</a></li><li><a href="https://w3id.org/traceability/#CTPATCertificate">CTPAT Credential</a></li><li><a href="https://w3id.org/traceability/#CommercialInvoiceCredential">Commercial Invoice Credential</a></li><li><a href="https://w3id.org/traceability/#MillTestReportCredential">Mill Test Report Credential</a></li><li><a href="https://w3id.org/traceability/#SIMASteelImportLicenseApplicationCredential">SIMA Import License Application Credential</a></li><li><a href="https://w3id.org/traceability/#SIMASteelImportLicenseCredential">SIMA Import License Credential</a></li><li><a href="https://w3id.org/traceability/#EntryNumberCredential">Entry Number Credential</a></li><li><a href="https://w3id.org/traceability/#MultiModalBillOfLadingCredential">Multimodal Bill Of Lading Credential</a></li>
+      </ol>
+      <pre class='example yml'>id: https://w3id.org/traceability/#cbp-steel-tech-demo-2023
+title: CBP Steel Tech Demo 2023
+description: >-
+    CBP Steel Tech Demo 2023
+tags: 
+  - Steel
+credentials: 
+  - id: https://w3id.org/traceability/#PurchaseOrderCredential
+    name: Purchase Order Credential
+  - id: https://w3id.org/traceability/#IntentToImportCredential
+    name: Intent To Import Credential
+  - id: https://w3id.org/traceability/#CTPATCertificate
+    name: CTPAT Credential
+  - id: https://w3id.org/traceability/#CommercialInvoiceCredential
+    name: Commercial Invoice Credential
+  - id: https://w3id.org/traceability/#MillTestReportCredential
+    name: Mill Test Report Credential
+  - id: https://w3id.org/traceability/#SIMASteelImportLicenseApplicationCredential
+    name: SIMA Import License Application Credential
+  - id: https://w3id.org/traceability/#SIMASteelImportLicenseCredential
+    name: SIMA Import License Credential
+  - id: https://w3id.org/traceability/#EntryNumberCredential
+    name: Entry Number Credential
+  - id: https://w3id.org/traceability/#MultiModalBillOfLadingCredential
+    name: Multimodal Bill Of Lading Credential
+mermaid: >-
+  sequenceDiagram
+    title CBP Steel Tech Demo 2023 Use Case: Steel import into USA from Mexico via road carrier
+    participant A as Steel Buyer
+    participant B as Steel Producer
+    participant C as Customs Broker
+    participant D as SIMA
+    participant E as Road Carrier
+    participant F as CBP
+    A-->>A: issue Purchase Order Credential
+    A->>B: present Purchase Order Credential
+    A-->>A: issue Intent To Import Credential
+    A->>F: present Purchase Order Credential
+    A->>F: present Intent To Import Credential
+    A->>F: present CTPAT Credential
+    B-->>B: issue Commercial Invoice Credential
+    B->>A: present Commercial Invoice Credential
+    B->>F: present Commercial Invoice Credential
+    B-->>B: issue Mill Test Report Credential
+    B->>A: present Mill Test Report Credential
+    B->>F: present Mill Test Report Credential
+    C-->>C: issue SIMA Import License Application Credential
+    C->>D: present SIMA Import License Application Credential
+    D-->>D: issue SIMA Import License Credential
+    D->>F: present SIMA Import License Credential
+    D->>C: present SIMA Import License Credential
+    C->>A: present SIMA Import License Credential
+    E->>F: present CTPAT Credential
+    C-->>C: issue Entry Number Credential
+    C->>F: present Entry Number Credential
+    E-->>E: issue Multimodal Bill Of Lading Credential
+    E->>B: present Multimodal Bill Of Lading Credential
+    B->>C: present Multimodal Bill Of Lading Credential
+    C->>F: present Multimodal Bill Of Lading Credential</pre>
+    
+
       <h3>Intention to Import Workflow</h3>
       <pre class='mermaid'>sequenceDiagram
     participant A as Importer of Record
@@ -67,115 +167,6 @@ mermaid: >-
       participant B as US Customs and Border Protection
       A-->>A: issue Intent to Import Credential
       A->>B: present Intent to Import Credential</pre>
-    
-
-      <h3>SVIP Steel Tech Demo</h3>
-      <pre class='mermaid'>sequenceDiagram
-  title SVIP Steel Tech Demo Use Case: Steel import into USA from Mexico via road carrier
-  participant A as Steel Buyer
-  participant B as Steel Producer
-  participant C as Customs Broker
-  participant D as SIMA
-  participant E as Road Carrier
-  participant F as CBP
-  A-->>A: issue Purchase Order Credential
-  A->>B: present Purchase Order Credential
-  A-->>A: issue Intent To Import Credential
-  A->>F: present Purchase Order Credential
-  A->>F: present Intent To Import Credential
-  A->>F: present CTPAT Credential
-  B-->>B: issue Commercial Invoice Credential
-  B->>A: present Commercial Invoice Credential
-  B->>F: present Commercial Invoice Credential
-  B-->>B: issue Mill Test Report Credential
-  B->>A: present Mill Test Report Credential
-  B->>F: present Mill Test Report Credential
-  C-->>C: issue SIMA Import License Application Credential
-  C->>D: present SIMA Import License Application Credential
-  D-->>D: issue SIMA Import License Credential
-  D->>F: present SIMA Import License Credential
-  D->>C: present SIMA Import License Credential
-  C->>A: present SIMA Import License Credential
-  E->>F: present CTPAT Credential
-  C-->>C: issue Entry Number Credential
-  C->>F: present Entry Number Credential
-  E-->>E: issue Multimodal Bill Of Lading Credential
-  E->>B: present Multimodal Bill Of Lading Credential
-  B->>C: present Multimodal Bill Of Lading Credential
-  C->>F: present Multimodal Bill Of Lading Credential</pre>
-      <p>SVIP Steel Tech Demo</p>
-      <b>Credentials Used:</b>
-      <ol>
-        <li><a href="https://w3id.org/traceability/#MillTestReportCredential">Purchase Order Credential</a></li><li><a href="https://w3id.org/traceability/#MillTestReportCredential">Intent To Import Credential</a></li><li><a href="https://w3id.org/traceability/#MillTestReportCredential">CTPAT Credential</a></li><li><a href="https://w3id.org/traceability/#MillTestReportCredential">Commercial Invoice Credential</a></li><li><a href="https://w3id.org/traceability/#MillTestReportCredential">Mill Test Report Credential</a></li><li><a href="https://w3id.org/traceability/#SIMASteelImportLicenseApplicationCredential">SIMA Import License Application Credential</a></li><li><a href="https://w3id.org/traceability/#SIMASteelImportLicenseCredential">SIMA Import License Credential</a></li><li><a href="https://w3id.org/traceability/#EntryNumberCredential">Entry Number Credential</a></li><li><a href="https://w3id.org/traceability/#MultiModalBillOfLadingCredential">Multimodal Bill Of Lading Credential</a></li>
-      </ol>
-      <pre class='example yml'>id: https://w3id.org/traceability/#svip-steel-tech-demo
-title: SVIP Steel Tech Demo
-description: >-
-    SVIP Steel Tech Demo
-tags: 
-  - Steel
-credentials: 
-  - 
-    id: https://w3id.org/traceability/#MillTestReportCredential
-    name: Purchase Order Credential
-  - 
-    id: https://w3id.org/traceability/#MillTestReportCredential
-    name: Intent To Import Credential
-  - 
-    id: https://w3id.org/traceability/#MillTestReportCredential
-    name: CTPAT Credential
-  - 
-    id: https://w3id.org/traceability/#MillTestReportCredential
-    name: Commercial Invoice Credential
-  - 
-    id: https://w3id.org/traceability/#MillTestReportCredential
-    name: Mill Test Report Credential
-  - 
-    id: https://w3id.org/traceability/#SIMASteelImportLicenseApplicationCredential
-    name: SIMA Import License Application Credential
-  - 
-    id: https://w3id.org/traceability/#SIMASteelImportLicenseCredential
-    name: SIMA Import License Credential
-  - 
-    id: https://w3id.org/traceability/#EntryNumberCredential
-    name: Entry Number Credential
-  - 
-    id: https://w3id.org/traceability/#MultiModalBillOfLadingCredential
-    name: Multimodal Bill Of Lading Credential
-mermaid: >-
-  sequenceDiagram
-    title SVIP Steel Tech Demo Use Case: Steel import into USA from Mexico via road carrier
-    participant A as Steel Buyer
-    participant B as Steel Producer
-    participant C as Customs Broker
-    participant D as SIMA
-    participant E as Road Carrier
-    participant F as CBP
-    A-->>A: issue Purchase Order Credential
-    A->>B: present Purchase Order Credential
-    A-->>A: issue Intent To Import Credential
-    A->>F: present Purchase Order Credential
-    A->>F: present Intent To Import Credential
-    A->>F: present CTPAT Credential
-    B-->>B: issue Commercial Invoice Credential
-    B->>A: present Commercial Invoice Credential
-    B->>F: present Commercial Invoice Credential
-    B-->>B: issue Mill Test Report Credential
-    B->>A: present Mill Test Report Credential
-    B->>F: present Mill Test Report Credential
-    C-->>C: issue SIMA Import License Application Credential
-    C->>D: present SIMA Import License Application Credential
-    D-->>D: issue SIMA Import License Credential
-    D->>F: present SIMA Import License Credential
-    D->>C: present SIMA Import License Credential
-    C->>A: present SIMA Import License Credential
-    E->>F: present CTPAT Credential
-    C-->>C: issue Entry Number Credential
-    C->>F: present Entry Number Credential
-    E-->>E: issue Multimodal Bill Of Lading Credential
-    E->>B: present Multimodal Bill Of Lading Credential
-    B->>C: present Multimodal Bill Of Lading Credential
-    C->>F: present Multimodal Bill Of Lading Credential</pre>
     
 
       <h3>US CBP Entry</h3>


### PR DESCRIPTION
This PR cleans up a few small issues I've come across:
- `Product.productPrice` has a vague definition pulled directly from schema.org, whereas I'm pretty sure it should be the unit price
- `TransportEquipment.isShipperOwned` should be a boolean, not a string
- `MultiModalBoL` has a handful of copy/pasted terms that needed fixing
- `TransportEquipment` also has some issues with copy/pasted values