### PR TITLE
Mandatory id on JSON Schemas

### DIFF
--- a/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/CertificationOfOrigin.yml
@@ -91,6 +91,7 @@ additionalProperties: false
 required:
   - '@context'
   - type
+  - id
   - issuanceDate
   - issuer
   - credentialSubject

--- a/docs/openapi/components/schemas/credentials/EntryNumberCredential.yml
+++ b/docs/openapi/components/schemas/credentials/EntryNumberCredential.yml
@@ -87,6 +87,7 @@ additionalProperties: false
 required:
   - '@context'
   - type
+  - id
   - issuanceDate
   - issuer
   - credentialSubject

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -1045,6 +1045,7 @@ example: |-
       "VerifiableCredential",
       "MillTestReportCredential"
     ],
+    "id": "urn:uuid:2e604860-b308-4ada-n1s3-4a22635befea",
     "issuer": {
       "type": [
         "Organization"

--- a/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MillTestReportCredential.yml
@@ -1031,6 +1031,7 @@ additionalProperties: false
 required:
   - '@context'
   - type
+  - id
   - issuanceDate
   - issuer
   - credentialSubject

--- a/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MultiModalBillOfLadingCredential.yml
@@ -1276,6 +1276,7 @@ additionalProperties: false
 required:
   - '@context'
   - type
+  - id
   - issuanceDate
   - issuer
   - credentialSubject

--- a/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PurchaseOrderCredential.yml
@@ -1012,6 +1012,7 @@ additionalProperties: false
 required:
   - '@context'
   - type
+  - id
   - issuanceDate
   - issuer
   - credentialSubject


### PR DESCRIPTION
Enforcing the requirements from https://w3c-ccg.github.io/traceability-interop/draft/#credentials on the JSON Schemas. 

If y'all agree, then we should do this across the board on all schemas. 