### PR TITLE
Refactor AgProduct and Product schemas

### DIFF
--- a/docs/credentials-with-issuer-dependent-terms.json
+++ b/docs/credentials-with-issuer-dependent-terms.json
@@ -13,7 +13,7 @@
   },
   {
     "type": "USMCACertificationOfOrigin",
-    "count": 10
+    "count": 7
   },
   {
     "type": "ThingCredential",

--- a/docs/openapi/components/schemas/common/AgricultureActivity.yml
+++ b/docs/openapi/components/schemas/common/AgricultureActivity.yml
@@ -131,9 +131,7 @@ example: |-
         "type": [
           "AgricultureProduct"
         ],
-        "upc": "033383401508",
         "plu": "94225",
-        "gtin": "033383401508",
         "product": {
           "type": [
             "Product"
@@ -165,18 +163,13 @@ example: |-
         },
         "scientificName": "Persea americana",
         "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "name": "Avocados",
-        "productImageUrl": "https://img.example.org/102934920857/937/903/",
-        "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       },
       {
         "type": [
           "AgricultureProduct"
         ],
-        "upc": "033383401508",
         "plu": "94225",
-        "gtin": "033383401508",
         "product": {
           "type": [
             "Product"
@@ -208,10 +201,7 @@ example: |-
         },
         "scientificName": "Solanum lycopersicum",
         "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "name": "Avocados",
-        "productImageUrl": "https://img.example.org/102934920857/937/903/",
-        "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       }
     ],
     "observation": [

--- a/docs/openapi/components/schemas/common/AgricultureInspectionGeneric.yml
+++ b/docs/openapi/components/schemas/common/AgricultureInspectionGeneric.yml
@@ -247,9 +247,7 @@ example: |-
               "type": [
                 "AgricultureProduct" 
               ],
-              "upc": "033383401508",
               "plu": "94225",
-              "gtin": "033383401508",
               "product": {
                 "type": [
                   "Product"
@@ -281,10 +279,7 @@ example: |-
               },
               "scientificName": "Persea americana",
               "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-              "name": "Avocados",
-              "productImageUrl": "https://img.example.org/102934920857/937/903/",
-              "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
             }
           ]
         }

--- a/docs/openapi/components/schemas/common/AgriculturePackage.yml
+++ b/docs/openapi/components/schemas/common/AgriculturePackage.yml
@@ -116,9 +116,7 @@ example: |-
         "type": [
           "AgricultureProduct"
         ],
-        "upc": "033383401508",
         "plu": "94225",
-        "gtin": "033383401508",
         "product": {
           "type": [
             "Product"
@@ -150,18 +148,13 @@ example: |-
         },
         "scientificName": "Persea americana",
         "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "name": "Avocados",
-        "productImageUrl": "https://img.example.org/102934920857/937/903/",
-        "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       },
       {
         "type": [
           "AgricultureProduct"
         ],
-        "upc": "033383401508",
         "plu": "94225",
-        "gtin": "033383401508",
         "product": {
           "type": [
             "Product"
@@ -193,10 +186,7 @@ example: |-
         },
         "scientificName": "Persea americana",
         "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "name": "Avocados",
-        "productImageUrl": "https://img.example.org/102934920857/937/903/",
-        "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       }
     ]
   }

--- a/docs/openapi/components/schemas/common/AgricultureParcelDelivery.yml
+++ b/docs/openapi/components/schemas/common/AgricultureParcelDelivery.yml
@@ -250,9 +250,7 @@ example: |-
             "type": [
               "AgricultureProduct"
             ],
-            "upc": "033383401508",
             "plu": "94225",
-            "gtin": "033383401508",
             "product": {
               "type": [
                 "Product"
@@ -284,10 +282,7 @@ example: |-
             },
             "scientificName": "Persea americana",
             "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-            "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-            "name": "Avocados",
-            "productImageUrl": "https://img.example.org/102934920857/937/903/",
-            "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+            "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
         ]
       }

--- a/docs/openapi/components/schemas/common/AgricultureProduct.yml
+++ b/docs/openapi/components/schemas/common/AgricultureProduct.yml
@@ -20,17 +20,6 @@ properties:
       type: string
       enum:
         - AgricultureProduct
-  upc:
-    title: UPC Number
-    description: >-
-      UPC (aka UPC-A) consists of 12 numeric digits that are uniquely assigned
-      to each trade item. Along with the related EAN barcode, the UPC is the
-      barcode mainly used for scanning of trade items at the point of sale, per
-      GS1 specifications.
-    type: string
-    $linkedData:
-      term: upc
-      '@id': https://www.gs1.org/standards/barcodes/ean-upc
   plu:
     title: PLU Number
     description: >-
@@ -41,15 +30,6 @@ properties:
     $linkedData:
       term: plu
       '@id': https://w3id.org/traceability#plu
-  gtin:
-    title: GTIN Code
-    description: >-
-      Global Trade Item Number (GTIN) can be used by a company to uniquely
-      identify all of its trade items.
-    type: string
-    $linkedData:
-      term: gtin
-      '@id': https://www.gs1.org/voc/gtin
   countryOfOrigin:
     title: Country of Origin
     description: The country in which this product originated.
@@ -97,72 +77,64 @@ properties:
     $linkedData:
       term: labelImageHash
       '@id': https://w3id.org/traceability#labelImageHash
-  name:
-    title: Name
-    description: Name of the ag. product.
-    type: string
-    $linkedData:
-      term: name
-      '@id': https://schema.org/name
-  productImageUrl:
-    title: Product Image URL
-    description: Image of the product.
-    type: string
-    $linkedData:
-      term: productImageUrl
-      '@id': https://schema.org/url
-  productImageHash:
-    title: Product Image Hash
-    description: >-
-      Hash value for securely identifying the product image.  More information can
-      be found at the following link: https://cybersecurityglossary.com/hashing
-    type: string
-    $linkedData:
-      term: productImageHash
-      '@id': https://w3id.org/traceability#productImageHash
 additionalProperties: true
 required:
   - type
 example: |-
   {
-    "type": ["AgricultureProduct"],
-    "upc": "033383401508",
+    "type": [
+      "AgricultureProduct"
+    ],
     "plu": "94225",
-    "gtin": "033383401508",
-    "countryOfOrigin": "United States",
     "product": {
-      "type": ["Product"],
+      "type": [
+        "Product"
+      ],
       "manufacturer": {
-        "type": ["Organization"],
-        "name": "Jimbo's Awesome Farm",
-        "description": "Organic fruits & vegetables",
-        "email": "Chloe.Ondricka42@jimbofarm.example.org",
-        "phoneNumber": "+1-302-555-6543",
-        "faxNumber": "+1-436-555-6157"
+        "type": [
+          "Organization"
+        ],
+        "name": "Zemlak - Wyman",
+        "description": "Progressive fault-tolerant task-force",
+        "location": {
+          "type": [
+            "Place"
+          ],
+          "address": {
+            "type": [
+              "PostalAddress"
+            ],
+            "streetAddress": "964 Mikayla Viaduct",
+            "addressLocality": "Runolfsdottirburgh",
+            "addressRegion": "Florida",
+            "postalCode": "48442-9522",
+            "addressCountry": "Barbados"
+          }
+        },
+        "email": "Reyna_Hamill56@example.com",
+        "phoneNumber": "+1-264-555-5427",
+        "faxNumber": "+1-597-555-6162"
       },
-      "name": "Avocados",
-      "description": "Avocados, 4 pack boxes",
+      "countryOfOrigin": "United States",
+      "name": "Handmade Fresh Hat",
+      "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
       "sizeOrAmount": {
         "type": [
           "QuantitativeValue"
         ],
-        "unitCode": "boxes",
-        "value": "893"
+        "unitCode": "sqm",
+        "value": "47"
       },
       "weight": {
         "type": [
           "QuantitativeValue"
         ],
-        "unitCode": "lbs",
-        "value": "1784"
+        "unitCode": "kg",
+        "value": "4890"
       },
-      "sku": "71266019767"
-    },
-    "scientificName": "Persea americana",
-    "plantParts": "fruit",
-    "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-    "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "name": "Avocados",
-    "productImageUrl": "https://img.example.org/102934920857/937/903/",
-    "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+      "upc": "033383401508",
+      "sku": "712120934258",
+      "imageUrl": "https://img.example.org/102934920857/937/903/",
+      "imageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+    }
   }

--- a/docs/openapi/components/schemas/common/AgricultureProduct.yml
+++ b/docs/openapi/components/schemas/common/AgricultureProduct.yml
@@ -132,7 +132,6 @@ example: |-
         "unitCode": "kg",
         "value": "4890"
       },
-      "upc": "033383401508",
       "sku": "712120934258",
       "imageUrl": "https://img.example.org/102934920857/937/903/",
       "imageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"

--- a/docs/openapi/components/schemas/common/AgricultureProduct.yml
+++ b/docs/openapi/components/schemas/common/AgricultureProduct.yml
@@ -29,7 +29,7 @@ properties:
     type: string
     $linkedData:
       term: plu
-      '@id': https://w3id.org/traceability#plu
+      '@id': https://schema.org/identifier
   countryOfOrigin:
     title: Country of Origin
     description: The country in which this product originated.
@@ -76,7 +76,7 @@ properties:
     type: string
     $linkedData:
       term: labelImageHash
-      '@id': https://w3id.org/traceability#labelImageHash
+      '@id': https://schema.org/sha256
 additionalProperties: true
 required:
   - type

--- a/docs/openapi/components/schemas/common/FoodGradeInspection.yml
+++ b/docs/openapi/components/schemas/common/FoodGradeInspection.yml
@@ -245,9 +245,7 @@ example: |-
               "type": [
                 "AgricultureProduct"
               ],
-              "upc": "033383401508",
               "plu": "94225",
-              "gtin": "033383401508",
               "product": {
                 "type": [
                   "Product"
@@ -279,10 +277,7 @@ example: |-
               },
               "scientificName": "Persea americana",
               "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-              "name": "Avocados",
-              "productImageUrl": "https://img.example.org/102934920857/937/903/",
-              "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
             }
           ]
         }
@@ -326,9 +321,7 @@ example: |-
           "type": [
             "AgricultureProduct"
           ],
-          "upc": "033383401508",
           "plu": "94225",
-          "gtin": "033383401508",
           "product": {
             "type": [
               "Product"
@@ -360,10 +353,7 @@ example: |-
           },
           "scientificName": "Persea americana",
           "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-          "name": "Avocados",
-          "productImageUrl": "https://img.example.org/102934920857/937/903/",
-          "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         },
         "lotIdentifier": "Main Lot",
         "numberContainers": 320,

--- a/docs/openapi/components/schemas/common/FoodGradeInspectionLot.yml
+++ b/docs/openapi/components/schemas/common/FoodGradeInspectionLot.yml
@@ -107,9 +107,7 @@ example: |-
       "type": [
         "AgricultureProduct"
       ],
-      "upc": "033383401508",
       "plu": "94225",
-      "gtin": "033383401508",
       "product": {
         "type": [
           "Product"
@@ -141,10 +139,7 @@ example: |-
       },
       "scientificName": "Persea americana",
       "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-      "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "name": "Avocados",
-      "productImageUrl": "https://img.example.org/102934920857/937/903/",
-      "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+      "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
     "lotIdentifier": "Main Lot",
     "numberContainers": 320,

--- a/docs/openapi/components/schemas/common/GAPInspection.yml
+++ b/docs/openapi/components/schemas/common/GAPInspection.yml
@@ -312,9 +312,7 @@ example: |-
         "type": [
           "AgricultureProduct"
         ],
-        "upc": "033383401508",
         "plu": "94225",
-        "gtin": "033383401508",
         "product": {
           "type": [
             "Product"
@@ -346,10 +344,7 @@ example: |-
         },
         "scientificName": "Solanum lycopersicum",
         "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "name": "Avocados",
-        "productImageUrl": "https://img.example.org/102934920857/937/903/",
-        "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       }
     ],
     "totalArea": {

--- a/docs/openapi/components/schemas/common/GAPLocationCertification.yml
+++ b/docs/openapi/components/schemas/common/GAPLocationCertification.yml
@@ -159,9 +159,7 @@ example: |-
           "type": [
             "AgricultureProduct"
           ],
-          "upc": "033383401508",
           "plu": "94225",
-          "gtin": "033383401508",
           "product": {
             "type": [
               "Product"
@@ -193,10 +191,7 @@ example: |-
           },
           "scientificName": "Solanum lycopersicum",
           "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-          "name": "Avocados",
-          "productImageUrl": "https://img.example.org/102934920857/937/903/",
-          "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
       ],
       "totalArea": {

--- a/docs/openapi/components/schemas/common/OrganicProductCertification.yml
+++ b/docs/openapi/components/schemas/common/OrganicProductCertification.yml
@@ -47,9 +47,7 @@ example: |-
       "type": [
         "AgricultureProduct"
       ],
-      "upc": "033383401508",
       "plu": "94225",
-      "gtin": "033383401508",
       "product": {
         "type": [
           "Product"
@@ -81,10 +79,7 @@ example: |-
       },
       "scientificName": "Solanum lycopersicum",
       "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-      "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "name": "Tomatoes",
-      "productImageUrl": "https://img.example.org/102934920857/937/903/",
-      "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+      "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
     "organicCertification": {
       "type": ["OrganicCertification"],

--- a/docs/openapi/components/schemas/common/PlantSystemsInspection.yml
+++ b/docs/openapi/components/schemas/common/PlantSystemsInspection.yml
@@ -171,9 +171,7 @@ example: |-
         "type": [
           "AgricultureProduct"
         ],
-        "upc": "033383401508",
         "plu": "94225",
-        "gtin": "033383401508",
         "product": {
           "type": [
             "Product"
@@ -205,10 +203,7 @@ example: |-
         },
         "scientificName": "Solanum lycopersicum",
         "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "name": "Tomatoes",
-        "productImageUrl": "https://img.example.org/102934920857/937/903/",
-        "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       }
     ],
     "summaryOfDeficiencies": "Some issues observed with cross-contamination of peanut allergens, as well as improper storage of reagents.",

--- a/docs/openapi/components/schemas/common/Product.yml
+++ b/docs/openapi/components/schemas/common/Product.yml
@@ -150,6 +150,15 @@ properties:
     $linkedData:
       term: seller
       '@id': https://vocabulary.uncefact.org/sellerParty
+  images:
+    title: Images of the product
+    description: Images of the product as BLObs (Binary Large Object).
+    type: array
+    items: 
+      type: string
+    $linkedData:
+      term: images
+      '@id': https://schema.org/image
   imageUrl:
     title: Image URL
     description: Image of the product.

--- a/docs/openapi/components/schemas/common/Product.yml
+++ b/docs/openapi/components/schemas/common/Product.yml
@@ -25,10 +25,24 @@ properties:
       '@id': https://schema.org/productID
   gtin:
     title: Global Trade Item Number (GTIN)
+    description: >-
+      Global Trade Item Number (GTIN) can be used by a company to uniquely
+      identify all of its trade items.
     type: string
     $linkedData:
       term: gtin
       '@id': https://schema.org/gtin
+  upc:
+    title: UPC Number
+    description: >-
+      UPC (aka UPC-A) consists of 12 numeric digits that are uniquely assigned
+      to each trade item. Along with the related EAN barcode, the UPC is the
+      barcode mainly used for scanning of trade items at the point of sale, per
+      GS1 specifications.
+    type: string
+    $linkedData:
+      term: upc
+      '@id': https://www.gs1.org/standards/barcodes/ean-upc
   manufacturer:
     title: Manufacturer
     description: The entity manufacturing the product.
@@ -36,6 +50,13 @@ properties:
     $linkedData:
       term: manufacturer
       '@id': https://schema.org/manufacturer
+  countryOfOrigin:
+    title: Country of Origin
+    description: The country in which this product originated.
+    type: string
+    $linkedData:
+      term: countryOfOrigin
+      '@id': https://vocabulary.uncefact.org/originCountry
   name:
     title: Name
     description: Name of the shipment item(s)
@@ -129,14 +150,22 @@ properties:
     $linkedData:
       term: seller
       '@id': https://vocabulary.uncefact.org/sellerParty
-  images:
-    title: Images of the product
-    type: array
-    items: 
-      type: string
+  imageUrl:
+    title: Image URL
+    description: Image of the product.
+    type: string
     $linkedData:
-      term: images
-      '@id': https://schema.org/image
+      term: imageUrl
+      '@id': https://schema.org/url
+  imageHash:
+    title: Image Hash
+    description: >-
+      Hash value for securely identifying the product image.  More information can
+      be found at the following link: https://cybersecurityglossary.com/hashing
+    type: string
+    $linkedData:
+      term: imageHash
+      '@id': https://w3id.org/traceability#imageHash
 additionalProperties: false
 required:
   - type
@@ -162,6 +191,7 @@ example: |-
       "phoneNumber": "+1-264-555-5427",
       "faxNumber": "+1-597-555-6162"
     },
+    "countryOfOrigin": "United States",
     "name": "Handmade Fresh Hat",
     "description": "The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J",
     "sizeOrAmount": {
@@ -174,5 +204,8 @@ example: |-
       "unitCode": "kg",
       "value": "4890"
     },
-    "sku": "712120934258"
+    "upc": "033383401508",
+    "sku": "712120934258",
+    "imageUrl": "https://img.example.org/102934920857/937/903/",
+    "imageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
   }

--- a/docs/openapi/components/schemas/common/Product.yml
+++ b/docs/openapi/components/schemas/common/Product.yml
@@ -165,7 +165,7 @@ properties:
     type: string
     $linkedData:
       term: imageHash
-      '@id': https://w3id.org/traceability#imageHash
+      '@id': https://schema.org/sha256
 additionalProperties: false
 required:
   - type

--- a/docs/openapi/components/schemas/common/Product.yml
+++ b/docs/openapi/components/schemas/common/Product.yml
@@ -32,17 +32,6 @@ properties:
     $linkedData:
       term: gtin
       '@id': https://schema.org/gtin
-  upc:
-    title: UPC Number
-    description: >-
-      UPC (aka UPC-A) consists of 12 numeric digits that are uniquely assigned
-      to each trade item. Along with the related EAN barcode, the UPC is the
-      barcode mainly used for scanning of trade items at the point of sale, per
-      GS1 specifications.
-    type: string
-    $linkedData:
-      term: upc
-      '@id': https://www.gs1.org/standards/barcodes/ean-upc
   manufacturer:
     title: Manufacturer
     description: The entity manufacturing the product.
@@ -213,7 +202,6 @@ example: |-
       "unitCode": "kg",
       "value": "4890"
     },
-    "upc": "033383401508",
     "sku": "712120934258",
     "imageUrl": "https://img.example.org/102934920857/937/903/",
     "imageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"

--- a/docs/openapi/components/schemas/common/USDAPPQ203ForeignSiteInspection.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ203ForeignSiteInspection.yml
@@ -225,9 +225,7 @@ example: |-
               "type": [
                 "AgricultureProduct"
               ],
-              "upc": "033383401508",
               "plu": "94225",
-              "gtin": "033383401508",
               "product": {
                 "type": [
                   "Product"
@@ -259,10 +257,7 @@ example: |-
               },
               "scientificName": "Persea americana",
               "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-              "name": "Avocados",
-              "productImageUrl": "https://img.example.org/102934920857/937/903/",
-              "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
             }
           ]
         }

--- a/docs/openapi/components/schemas/common/USDAPPQ309APestInterceptionRecord.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ309APestInterceptionRecord.yml
@@ -274,9 +274,7 @@ example: |-
           "type": [
             "AgricultureProduct"
           ],
-          "upc": "033383401508",
           "plu": "94225",
-          "gtin": "033383401508",
           "product": {
             "type": [
               "Product"
@@ -308,10 +306,7 @@ example: |-
           },
           "scientificName": "Solanum lycopersicum",
           "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-          "name": "Tomatoes",
-          "productImageUrl": "https://img.example.org/102934920857/937/903/",
-          "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
       ]
     },

--- a/docs/openapi/components/schemas/common/USDAPPQ368NoticeOfArrival.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ368NoticeOfArrival.yml
@@ -154,9 +154,7 @@ example: |-
               "type": [
                 "AgricultureProduct"
               ],
-              "upc": "033383401508",
               "plu": "94225",
-              "gtin": "033383401508",
               "product": {
                 "type": [
                   "Product"
@@ -188,10 +186,7 @@ example: |-
               },
               "scientificName": "Persea americana",
               "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-              "name": "Avocados",
-              "productImageUrl": "https://img.example.org/102934920857/937/903/",
-              "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
             }
           ]
         }

--- a/docs/openapi/components/schemas/common/USDAPPQ429FumigationRecord.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ429FumigationRecord.yml
@@ -448,9 +448,7 @@ example: |-
               "type": [
                 "AgricultureProduct"
               ],
-              "upc": "033383401508",
               "plu": "94225",
-              "gtin": "033383401508",
               "product": {
                 "type": [
                   "Product"
@@ -482,10 +480,7 @@ example: |-
               },
               "scientificName": "Solanum lycopersicum",
               "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-              "name": "Tomatoes",
-              "productImageUrl": "https://img.example.org/102934920857/937/903/",
-              "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
             }
           ]
         }

--- a/docs/openapi/components/schemas/common/USDAPPQ505PlantDeclaration.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ505PlantDeclaration.yml
@@ -114,9 +114,7 @@ example: |-
               "type": [
                 "AgricultureProduct"
               ],
-              "upc": "033383401508",
               "plu": "94225",
-              "gtin": "033383401508",
               "product": {
                 "type": [
                   "Product"
@@ -148,10 +146,7 @@ example: |-
               },
               "scientificName": "Persea americana",
               "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-              "name": "Avocados",
-              "productImageUrl": "https://img.example.org/102934920857/937/903/",
-              "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+              "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
             }
           ]
         }

--- a/docs/openapi/components/schemas/common/USDAPPQ587PlantImportApplication.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ587PlantImportApplication.yml
@@ -84,9 +84,7 @@ example: |-
         "type": [
           "AgricultureProduct"
         ],
-        "upc": "033383401508",
         "plu": "94225",
-        "gtin": "033383401508",
         "countryOfOrigin": "United States",
         "product": {
           "type": [
@@ -120,10 +118,7 @@ example: |-
         "plantParts": "fruit",
         "scientificName": "Persea americana",
         "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "name": "Avocados",
-        "productImageUrl": "https://img.example.org/102934920857/937/903/",
-        "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       }
     ],
     "intendedUse": "Fruits and vegetables",

--- a/docs/openapi/components/schemas/common/USDASpecialtyCrops237AForm.yml
+++ b/docs/openapi/components/schemas/common/USDASpecialtyCrops237AForm.yml
@@ -146,9 +146,7 @@ example: |-
         "type": [
           "AgricultureProduct"
         ],
-        "upc": "033383401508",
         "plu": "94225",
-        "gtin": "033383401508",
         "product": {
           "type": [
             "Product"
@@ -180,10 +178,7 @@ example: |-
         },
         "scientificName": "Solanum lycopersicum",
         "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "name": "Avocados",
-        "productImageUrl": "https://img.example.org/102934920857/937/903/",
-        "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+        "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       }
     ],
     "auditProgramsRequested": [

--- a/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/FoodGradeInspectionCredential.yml
@@ -306,9 +306,7 @@ example: |-
                 "type": [
                   "AgricultureProduct"
                 ],
-                "upc": "033383401508",
                 "plu": "94225",
-                "gtin": "033383401508",
                 "product": {
                   "type": [
                     "Product"
@@ -340,10 +338,7 @@ example: |-
                 },
                 "scientificName": "Persea americana",
                 "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-                "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                "name": "Avocados",
-                "productImageUrl": "https://img.example.org/102934920857/937/903/",
-                "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+                "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
               }
             ]
           }
@@ -395,9 +390,7 @@ example: |-
             "type": [
               "AgricultureProduct"
             ],
-            "upc": "033383401508",
             "plu": "94225",
-            "gtin": "033383401508",
             "product": {
               "type": [
                 "Product"
@@ -429,10 +422,7 @@ example: |-
             },
             "scientificName": "Persea americana",
             "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-            "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-            "name": "Avocados",
-            "productImageUrl": "https://img.example.org/102934920857/937/903/",
-            "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+            "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           },
           "lotIdentifier": "Main Lot",
           "numberContainers": 320,

--- a/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/GAPInspectionCredential.yml
@@ -249,9 +249,7 @@ example: |-
           "type": [
             "AgricultureProduct"
           ],
-          "upc": "033383401508",
           "plu": "94225",
-          "gtin": "033383401508",
           "product": {
             "type": [
               "Product"
@@ -283,10 +281,7 @@ example: |-
           },
           "scientificName": "Solanum lycopersicum",
           "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-          "name": "Avocados",
-          "productImageUrl": "https://img.example.org/102934920857/937/903/",
-          "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
       ],
       "totalArea": {

--- a/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
+++ b/docs/openapi/components/schemas/credentials/PlantSystemsInspectionCredential.yml
@@ -246,9 +246,7 @@ example: |-
           "type": [
             "AgricultureProduct"
           ],
-          "upc": "033383401508",
           "plu": "94225",
-          "gtin": "033383401508",
           "product": {
             "type": [
               "Product"
@@ -280,10 +278,7 @@ example: |-
           },
           "scientificName": "Solanum lycopersicum",
           "labelImageUrl": "https://img.example.org/033383401508/640/480/",
-          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-          "name": "Tomatoes",
-          "productImageUrl": "https://img.example.org/102934920857/937/903/",
-          "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3"
+          "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
       ],
       "summaryOfDeficiencies": "Some issues observed with cross-contamination of peanut allergens, as well as improper storage of reagents.",


### PR DESCRIPTION
This PR resolves https://github.com/w3c-ccg/traceability-vocab/issues/278 by moving non-ag properties from AgricultureProduct to Product, as well as https://github.com/w3c-ccg/traceability-vocab/issues/281 by removing UPC.