### PR TITLE
fix: inversing usmca issuer org-person relationship

### DIFF
--- a/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
+++ b/docs/openapi/components/schemas/credentials/USMCACertificationOfOrigin.yml
@@ -67,137 +67,131 @@ properties:
         type: array
         readOnly: true
         const:
-          - Person
+          - Organization
         default:
-          - Person
+          - Organization
         items:
           type: string
           enum:
-            - Person
+            - Organization
       id: 
         title: Identifier
         description: Identifier of the issuer such as a url or DID
         type: string
         format: uri
-      firstName:
-        title: First Name
-        description: Person's first name.
+      name:
+        title: Name
+        description: Name of the Certifier organization.
         type: string
-      lastName:
-        title: Last Name
-        description: Person's last name.
-        type: string
-      jobTitle:
-        title: Job Title
-        description: Person's job title.
-        type: string
-      email:
-        title: Person's Email Address
-        description: Person's email address.
-        type: string
-      phoneNumber:
-        title: Phone Number
-        description: Person's contact phone number.
-        type: string
-      worksFor:
-        title: Works For
-        description: Company which employs the person.
+      location:
+        title: Location
+        description: The location where, for example, an event is happening, an organization is located, or an action takes place.
         type: object
         properties:
           type:
             type: array
             readOnly: true
             const:
-              - Organization
+              - Place
             default:
-              - Organization
+              - Place
             items:
               type: string
               enum:
-                - Organization
-          id: 
-            title: Identifier
-            description: Organization identifier such as the URL of the homepage
-            type: string
-            format: uri
-          name:
-            title: Name
-            description: Name of the Certifier organization.
-            type: string
-          location:
-            title: Location
-            description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+                - Place
+          address:
+            title: Postal Address
+            description: The postal address for an organization or place.
             type: object
             properties:
               type:
                 type: array
                 readOnly: true
                 const:
-                  - Place
+                  - PostalAddress
                 default:
-                  - Place
+                  - PostalAddress
                 items:
                   type: string
                   enum:
-                    - Place
-              address:
-                title: Postal Address
-                description: The postal address for an organization or place.
-                type: object
-                properties:
-                  type:
-                    type: array
-                    readOnly: true
-                    const:
-                      - PostalAddress
-                    default:
-                      - PostalAddress
-                    items:
-                      type: string
-                      enum:
-                        - PostalAddress
-                  streetAddress:
-                    title: Street Address
-                    description: >-
-                      The street address expressed as free form text. The street address is
-                      printed on paper as the first lines below the name. For example, the name
-                      of the street and the number in the street, or the name of a building.
-                    type: string
-                  addressLocality:
-                    title: Address Locality
-                    description: Text specifying the name of the locality; for example, a city.
-                    type: string
-                  addressRegion:
-                    title: Address Region
-                    description: >-
-                      Text specifying a province or state in abbreviated format; for example,
-                      NJ.
-                    type: string
-                  addressCountry:
-                    title: Address Country
-                    description: >-
-                      The two-letter ISO 3166-1 alpha-2 country code.
-                    type: string
-                  postalCode:
-                    title: Postal Code
-                    description: Text specifying the postal code for an address.
-                    type: string
-                additionalProperties: false
-                required:
-                  - type
+                    - PostalAddress
+              streetAddress:
+                title: Street Address
+                description: >-
+                  The street address expressed as free form text. The street address is
+                  printed on paper as the first lines below the name. For example, the name
+                  of the street and the number in the street, or the name of a building.
+                type: string
+              addressLocality:
+                title: Address Locality
+                description: Text specifying the name of the locality; for example, a city.
+                type: string
+              addressRegion:
+                title: Address Region
+                description: >-
+                  Text specifying a province or state in abbreviated format; for example,
+                  NJ.
+                type: string
+              addressCountry:
+                title: Address Country
+                description: >-
+                  The two-letter ISO 3166-1 alpha-2 country code.
+                type: string
+              postalCode:
+                title: Postal Code
+                description: Text specifying the postal code for an address.
+                type: string
+            additionalProperties: false
+            required:
+              - type
+      employee:
+        title: Certification Manager
+        description: The employee responsible for this certification. 
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Person
+            default:
+              - Person
+            items:
+              type: string
+              enum:
+                - Person
+          firstName:
+            title: First Name
+            description: Person's first name.
+            type: string
+          lastName:
+            title: Last Name
+            description: Person's last name.
+            type: string
+          jobTitle:
+            title: Job Title
+            description: Person's job title.
+            type: string
+          email:
+            title: Person's Email Address
+            description: Person's email address.
+            type: string
+          phoneNumber:
+            title: Phone Number
+            description: Person's contact phone number.
+            type: string
         additionalProperties: false
         required:
           - type
-          - id
+          - firstName
+          - lastName
+          - jobTitle
+          - email
     additionalProperties: false
     required:
       - type
       - id
-      - firstName
-      - lastName
-      - jobTitle
-      - email
-      - worksFor
+      - employee
   credentialSchema:
     type: object
     properties:
@@ -702,34 +696,33 @@ example: |-
     "expirationDate": "2023-12-31T20:29:37+00:00",
     "issuer": {
       "type": [
-        "Person"
+        "Organization"
       ],
-      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
-      "firstName": "John",
-      "lastName": "Doe",
-      "jobTitle": "Legal Assistant",
-      "email": "jdoe@example.com",
-      "phoneNumber": "555-867-5309",
-      "worksFor": {
+      "id": "did:web:prime-steel.example.com",
+      "name": "American Prime Steel Inc.",
+      "employee": {
         "type": [
-          "Organization"
+          "Person"
         ],
-        "id": "https://prime-steel.example.com",
-        "name": "American Prime Steel Inc.",
-        "location": {
+        "firstName": "John",
+        "lastName": "Doe",
+        "jobTitle": "Legal Assistant",
+        "email": "jdoe@example.com",
+        "phoneNumber": "555-867-5309"
+      },
+      "location": {
+        "type": [
+          "Place"
+        ],
+        "address": {
           "type": [
-            "Place"
+            "PostalAddress"
           ],
-          "address": {
-            "type": [
-              "PostalAddress"
-            ],
-            "streetAddress": "1551 Keebler Knoll",
-            "addressLocality": "Vivianeburgh",
-            "addressRegion": "Oregon",
-            "postalCode": "47090",
-            "addressCountry": "US"
-          }
+          "streetAddress": "1551 Keebler Knoll",
+          "addressLocality": "Vivianeburgh",
+          "addressRegion": "Oregon",
+          "postalCode": "47090",
+          "addressCountry": "US"
         }
       }
     },


### PR DESCRIPTION
This doesn't substantially change any content, just inverts the USMCA issuer relationship between person and organization. This makes the issuer the Organization, instead of the Person - aligning it with everything else on trace vocab. 

This should be trivial, so I'm taking the liberty to merge this in out of band (and in my own time zone). 