### PR TITLE
fix: end quote

### DIFF
--- a/docs/openapi/components/schemas/credentials/DigitalProductPassportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DigitalProductPassportCredential.yml
@@ -206,7 +206,7 @@ example: |-
         "type": [
           "Product"
         ],
-        "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==,
+        "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
         "name": "Nordic Pioneer",
         "description": "Versatile, light weight and eco-friendly rollator",
         "id": "https://www.byacre.com/nordic-pioneer/",


### PR DESCRIPTION
@brownoxford's dot image on https://github.com/w3c-ccg/traceability-vocab/pull/883 was missing and end quote.