### PR TITLE
Set max locations for CTPAT locations

### DIFF
--- a/docs/openapi/components/schemas/common/CTPAT.yml
+++ b/docs/openapi/components/schemas/common/CTPAT.yml
@@ -133,6 +133,7 @@ properties:
         title: Location
         description: The location where, for example, an event is happening, an organization is located, or an action takes place.
         type: array
+        maxItems: 100
         items:
           type: object
           properties:


### PR DESCRIPTION
CTPAT locations should not be allowed to have an indefinite amount of locations. Capping at 100, which should be more than enough. 