### PR TITLE
Feat/value cleanup

### DIFF
--- a/docs/openapi/components/schemas/common/AgricultureActivity.yml
+++ b/docs/openapi/components/schemas/common/AgricultureActivity.yml
@@ -54,7 +54,7 @@ properties:
     type: string
     $linkedData:
       term: activityType
-      '@id': https://schema.org/value
+      '@id': https://schema.org/description
   agricultureProduct:
     title: Product List
     description: Agricultural Product the Activity was performed on if known

--- a/docs/openapi/components/schemas/common/AgricultureInspectionGeneric.yml
+++ b/docs/openapi/components/schemas/common/AgricultureInspectionGeneric.yml
@@ -82,7 +82,7 @@ properties:
     type: boolean
     $linkedData:
       term: inspectorCounted
-      '@id': https://schema.org/value
+      '@id': https://vocabulary.uncefact.org/applicableSpecifiedAction
 additionalProperties: false
 required:
   - type

--- a/docs/openapi/components/schemas/common/EDDShape.yml
+++ b/docs/openapi/components/schemas/common/EDDShape.yml
@@ -234,7 +234,7 @@ properties:
     type: number
     $linkedData:
       term: dateUncertaintyDays
-      '@id': https://schema.org/value
+      '@id': http://rs.tdwg.org/dwc/terms/measurementAccuracy
   visitType:
     title: Visit Type
     description: Purpose of visit to area for collected data.

--- a/docs/openapi/components/schemas/common/EDDShape.yml
+++ b/docs/openapi/components/schemas/common/EDDShape.yml
@@ -57,7 +57,7 @@ properties:
     type: string
     $linkedData:
       term: occurrenceStatus
-      '@id': https://schema.org/value
+      '@id': http://rs.tdwg.org/dwc/iri/measurementValue
   status:
     title: Status
     description: Status of the population at time of recording.

--- a/docs/openapi/components/schemas/common/EDDShapeMeta.yml
+++ b/docs/openapi/components/schemas/common/EDDShapeMeta.yml
@@ -246,7 +246,7 @@ properties:
     $ref: ./QuantitativeValue.yml
     $linkedData:
       term: treatmentArea
-      '@id': https://schema.org/value
+      '@id': http://rs.tdwg.org/dwc/iri/measurementValue
   plantsTreated:
     title: Plants Treated
     description: Number of plants treated to control invasive population.

--- a/docs/openapi/components/schemas/common/FSMAProduct.yml
+++ b/docs/openapi/components/schemas/common/FSMAProduct.yml
@@ -33,14 +33,14 @@ properties:
     type: number
     $linkedData:
       term: quantity
-      '@id': https://schema.org/value
+      '@id': https://vocabulary.uncefact.org/applicableQuantity
   unit:
     title: Unit
     description: The unit of measure used to describe this product.
     type: string
     $linkedData:
       term: unit
-      '@id': https://schema.org/unitText
+      '@id': https://vocabulary.uncefact.org/applicableQuantityUnitTypeCode
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FoodGradeInspectionSample.yml
+++ b/docs/openapi/components/schemas/common/FoodGradeInspectionSample.yml
@@ -22,14 +22,14 @@ properties:
     type: number
     $linkedData:
       term: sampleSizeValue
-      '@id': https://schema.org/value
+      '@id': https://vocabulary.uncefact.org/applicableQuantity
   sampleSizeUnits:
     title: Sample Size Units
     description: Units used, e.g. "items", "lbs", "kg".
     type: string
     $linkedData:
       term: sampleSizeUnits
-      '@id': https://schema.org/unitText
+      '@id': https://vocabulary.uncefact.org/applicableQuantityUnitTypeCode
   sampleProperties:
     title: Sample Properties
     description: Properties of the current sample, indicating information such as "25 green/breakers", "4 percent decay or soft", "0 percent off-size".

--- a/docs/openapi/components/schemas/common/FoodGradeInspectionSampleProperty.yml
+++ b/docs/openapi/components/schemas/common/FoodGradeInspectionSampleProperty.yml
@@ -22,14 +22,14 @@ properties:
     type: string
     $linkedData:
       term: propertyName
-      '@id': https://schema.org/name
+      '@id': https://vocabulary.uncefact.org/parameterValue
   propertyValue:
     title: Property Value
     description: Value of the sample property observed (e.g. "0", "SIL CT", "Yes").
     type: string
     $linkedData:
       term: propertyValue
-      '@id': https://schema.org/value
+      '@id': https://vocabulary.uncefact.org/measuredValue
 additionalProperties: false
 required:
   - type

--- a/docs/openapi/components/schemas/common/NAISMADateTime.yml
+++ b/docs/openapi/components/schemas/common/NAISMADateTime.yml
@@ -29,7 +29,7 @@ properties:
     type: number
     $linkedData:
       term: dateAccuracyDays
-      '@id': https://schema.org/value
+      '@id': http://rs.tdwg.org/dwc/iri/measurementMethod
 additionalProperties: false  
 required:
   - type

--- a/docs/openapi/components/schemas/common/Phytosanitary.yml
+++ b/docs/openapi/components/schemas/common/Phytosanitary.yml
@@ -168,7 +168,7 @@ properties:
     type: string
     $linkedData:
       term: inspectionType
-      '@id': https://schema.org/value
+      '@id': https://vocabulary.uncefact.org/inspectionStandard
   notes:
     title: Inspection Notes
     description: >-

--- a/docs/openapi/components/schemas/common/TemperatureReading.yml
+++ b/docs/openapi/components/schemas/common/TemperatureReading.yml
@@ -22,7 +22,7 @@ properties:
     type: string
     $linkedData:
       term: bulbNumber
-      '@id': https://schema.org/identifier
+      '@id': https://vocabulary.uncefact.org/identification
   tests:
     title: Tests
     description: A list of temperature readings at 0 C (32 F).
@@ -31,7 +31,7 @@ properties:
       type: number
     $linkedData:
       term: tests
-      '@id': https://schema.org/value
+      '@id': https://vocabulary.uncefact.org/actualMeasure
 additionalProperties: false
 required:
   - type

--- a/docs/openapi/components/schemas/common/USDAPPQ449RTemperatureCalibration.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ449RTemperatureCalibration.yml
@@ -64,7 +64,7 @@ properties:
     type: string
     $linkedData:
       term: flagCode
-      '@id': https://schema.org/value
+      '@id': https://vocabulary.uncefact.org/identification
   shipsOfficer:
     title: Ship's Officer
     description: The ship's officer.

--- a/docs/openapi/components/schemas/common/USDASpecialtyCrops237AForm.yml
+++ b/docs/openapi/components/schemas/common/USDASpecialtyCrops237AForm.yml
@@ -91,7 +91,7 @@ properties:
     type: boolean
     $linkedData:
       term: countByInspector
-      '@id': https://schema.org/values
+      '@id': https://vocabulary.uncefact.org/applicableSpecifiedAction
   additionalRemarks:
     title: Additional Remarks
     description: Any additional remarks regarding the application.

--- a/docs/openapi/components/schemas/credentials/MexicoEInvoiceCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MexicoEInvoiceCredential.yml
@@ -897,7 +897,7 @@ example: |-
         "Invoice"
       ],
       "taxIdNumber": "88800012345",
-      "relatedDocuments" : [
+      "relatedDocuments": [
         {
           "type": "LinkedDocument",
           "documentId": "a5d1ca6c-2c06-4039-9ff9-a75d7a695c8d",
@@ -936,9 +936,11 @@ example: |-
           }
         }
       },
-      "itemsShipped" : [
+      "itemsShipped": [
         {
-          "type": ["TradeLineItem"],
+          "type": [
+            "TradeLineItem"
+          ],
           "name": "Rebar",
           "description": "Round Rebar used for Construction",
           "productIdentifier": "rn19082-a",
@@ -951,7 +953,7 @@ example: |-
         }
       ],
       "shipment": {
-        "type" : [
+        "type": [
           "Shipment"
         ],
         "termsOfDelivery": "full payment before shipment",
@@ -1000,16 +1002,20 @@ example: |-
           "priceCurrency": "USD",
           "discounts": [
             {
-              "type": ["Discount"],
+              "type": [
+                "Discount"
+              ],
               "appliedTo": "subtotal",
               "discount": "10%",
               "reason": "First time customer"
             }
           ]
         },
-        "paymentDetails" : [
+        "paymentDetails": [
           {
-            "type":["PaymentDetails"],
+            "type": [
+              "PaymentDetails"
+            ],
             "beneficiaryName": "American Prime Steel Inc.",
             "beneficiaryAddress": {
               "type": [

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -2660,6 +2660,18 @@ paths:
                 $ref: './components/schemas/credentials/MasterBillOfLadingCredential.yml'
     
 
+  /schemas/credentials/MexicoEInvoiceCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/MexicoEInvoiceCredential.yml'
+    
+
   /schemas/credentials/MillTestReportCredential.yml:
     get:
       tags:


### PR DESCRIPTION
Addresses issue with multiple value terms (specifically in Ag schemas), as discussed in https://github.com/w3c-ccg/traceability-vocab/issues/575 and described in https://github.com/w3c-ccg/traceability-vocab/issues/894

This PR also replaces most uses of `schema.org/value` with more descriptive alternatives, as in many places `value` was used as a catchall for when another term couldn't easily be found