### PR TITLE
Update identifier term descriptions for NAISMA record level identifiers

### DIFF
--- a/docs/openapi/components/schemas/common/NAISMARecordLeveldentifiers.yml
+++ b/docs/openapi/components/schemas/common/NAISMARecordLeveldentifiers.yml
@@ -22,7 +22,7 @@ properties:
     type: string
     $linkedData:
       term: uuid
-      '@id': https://schema.org/identifier
+      '@id': http://rs.tdwg.org/dwc/terms/resourceID
   pid:
     title: Persistent Identifier
     description: A unique identifier that can be assigned to each record, such as a URL or DOI.
@@ -36,7 +36,7 @@ properties:
     type: string
     $linkedData:
       term: catalogNumber
-      '@id': https://schema.org/identifier
+      '@id': http://rs.tdwg.org/dwc/terms/catalogNumber
 additionalProperties: false
 required:
   - type


### PR DESCRIPTION
Updates two `schema.org/identifier` term descriptions to address https://github.com/w3c-ccg/traceability-vocab/issues/571 (duplicate term definitions).