### PR TITLE
Remove unnecessary AgProduct props

### DIFF
--- a/docs/openapi/components/schemas/common/AgricultureProduct.yml
+++ b/docs/openapi/components/schemas/common/AgricultureProduct.yml
@@ -77,22 +77,6 @@ properties:
     $linkedData:
       term: name
       '@id': https://schema.org/name
-  productImageUrl:
-    title: Product Image URL
-    description: Image of the product.
-    type: string
-    $linkedData:
-      term: productImageUrl
-      '@id': https://schema.org/url
-  productImageHash:
-    title: Product Image Hash
-    description: >-
-      Hash value for securely identifying the product image.  More information can
-      be found at the following link: https://cybersecurityglossary.com/hashing
-    type: string
-    $linkedData:
-      term: productImageHash
-      '@id': https://w3id.org/traceability#productImageHash
   variety:
     title: Variety
     description: "Additional details regarding the product. For example, in this case of potatoes, this might include: russet, white, yellow flesh, etc."
@@ -176,8 +160,6 @@ example: |-
     "labelImageUrl": "https://img.example.org/033383401508/640/480/",
     "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "name": "Avocados",
-    "productImageUrl": "https://img.example.org/102934920857/937/903/",
-    "productImageHash": "8kb47j986hklhde4rfh78okjhgjo08765fgu7tfg4t864fy876rfser45thj87f3",
     "variety": "Firm",
     "commodityDesignation": "Whole, fresh",
     "packType": "4-pack boxes"


### PR DESCRIPTION
Removes `productImageUrl` and `productImageHash` properties, which were added to the `Product` schema previously but left here as well by mistake.