### PR TITLE
JSON Schema for status list 2021

### DIFF
--- a/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
+++ b/docs/openapi/components/schemas/credentials/CTPATCertificate.yml
@@ -83,18 +83,21 @@ properties:
   credentialSubject:
     $ref: ../common/CTPAT.yml
   credentialStatus:
+    title: Status List 2021 Entry
     type: object
     properties:
       id:
         type: string
-      type:
-        type: string
+        format: uri
+      statusPurpose:
         enum:
-          - RevocationList2020Status
-      revocationListIndex:
+          - suspension
+          - revocation 
+      statusListIndex:
         type: number
-      revocationListCredential:
+      statusListCredential:
         type: string
+        format: url
   proof:
     $ref: ../snippets/proof.yml
   relatedLink:


### PR DESCRIPTION
Does this look sensible as a schema for referencing status list 2021?

Highlighting `format: url` which is a little unconventional. We don't use that anywhere else. I'd prefer to make it precise, but `format: uri` might be better for support/adoption?

SL2021 schemas will need to be added elsewhere, but wanted to start on just a single credential to get agreement on the shape.