### PR TITLE
Digital Product Passport links

### DIFF
--- a/docs/openapi/components/schemas/credentials/DigitalProductPassportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DigitalProductPassportCredential.yml
@@ -168,6 +168,31 @@ properties:
           - type
           - name
           - id
+      relatedLinks: 
+        title: Related links
+        description: Additional Digital Product Passport material. 
+        type: array
+        items: 
+          type: object
+          properties:
+            type: 
+              type: array
+              readOnly: true
+              const:
+                - LinkRole
+              default:
+                - LinkRole
+              items:
+                type: string
+                enum:
+                  - LinkRole
+            target: 
+              title: Link Target
+              type: string
+              format: uri
+            linkRelationship: 
+              title: Link Relationship
+              type: string
     required:
       - type
       - product

--- a/docs/openapi/components/schemas/credentials/DigitalProductPassportCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DigitalProductPassportCredential.yml
@@ -244,6 +244,15 @@ example: |-
           "id": "did:web:byacre.com",
           "url": "https://byacre.com"
         }
-      }
+      },
+      "relatedLinks": [
+        {
+          "type": [
+            "LinkRole"
+          ],
+          "target": "https://supplier.example.com/material/reuse-certificate.jsonld",
+          "linkRelationship": "digitalProductPassport"
+        }
+      ]
     }
   }

--- a/docs/openapi/components/schemas/credentials/DigitalProductPassportDataCarrierCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DigitalProductPassportDataCarrierCredential.yml
@@ -163,31 +163,31 @@ properties:
           - type
           - name
           - id
-  relatedLinks: 
-    title: Relted links
-    description: Links to online material including the Digital Product Passport and Control data. 
-    type: array
-    items: 
-      type: object
-      properties:
-        type: 
-          type: array
-          readOnly: true
-          const:
-            - LinkRole
-          default:
-            - LinkRole
-          items:
-            type: string
-            enum:
-              - LinkRole
-        target: 
-          title: Link Target
-          type: string
-          format: uri
-        linkRelationship: 
-          title: Link Relationship
-          type: string
+      relatedLinks: 
+        title: Relted links
+        description: Links to online material including the Digital Product Passport and Control data. 
+        type: array
+        items: 
+          type: object
+          properties:
+            type: 
+              type: array
+              readOnly: true
+              const:
+                - LinkRole
+              default:
+                - LinkRole
+              items:
+                type: string
+                enum:
+                  - LinkRole
+            target: 
+              title: Link Target
+              type: string
+              format: uri
+            linkRelationship: 
+              title: Link Relationship
+              type: string
     required:
       - type
       - product


### PR DESCRIPTION
This adds ability to reference upstream credentials, enabling construction of a full product data graph