### PR TITLE
IPR License credential

### DIFF
--- a/docs/openapi/components/schemas/common/IntellectualPropertyRightsLicense.yml
+++ b/docs/openapi/components/schemas/common/IntellectualPropertyRightsLicense.yml
@@ -1,0 +1,153 @@
+type: object
+title: Intellectual Property Rights License
+description: Licensing of Intellectual Property Ownership or Rights
+$linkedData:
+  term: IntellectualPropertyRightsLicense
+  '@id': https://w3id.org/traceability#IntellectualPropertyRightsLicense
+properties:
+  type:
+    type: array
+    readOnly: true
+    const:
+      - IntellectualPropertyRightsLicense
+    default:
+      - IntellectualPropertyRightsLicense
+    items:
+      type: string
+      enum:
+        - IntellectualPropertyRightsLicense
+  licensee:
+    title: IPR Licensee Organization
+    description: Organization granted licencee intellectual property rights.
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - Organization
+        default:
+          - Organization
+        items:
+          type: string
+          enum:
+            - Organization
+      id: 
+        title: Identifier
+        description: Organization identifier.
+        type: string
+        format: uri
+      name:
+        title: Name
+        description: Name of the organization.
+        type: string
+      location:
+        title: Location
+        description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Place
+            default:
+              - Place
+            items:
+              type: string
+              enum:
+                - Place
+          address:
+            title: Postal Address
+            description: The postal address for an organization or place.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - PostalAddress
+                default:
+                  - PostalAddress
+                items:
+                  type: string
+                  enum:
+                    - PostalAddress
+              name:
+                title: Name
+                description: The name of the entity in text.
+                type: string
+              streetAddress:
+                title: Street Address
+                description: >-
+                  The street address expressed as free form text. The street address is
+                  printed on paper as the first lines below the name. For example, the name
+                  of the street and the number in the street, or the name of a building.
+                type: string
+              addressLocality:
+                title: Address Locality
+                description: Text specifying the name of the locality; for example, a city.
+                type: string
+              addressRegion:
+                title: Address Region
+                description: >-
+                  Text specifying a province or state in abbreviated format; for example,
+                  NJ.
+                type: string
+              addressCountry:
+                title: Address Country
+                description: >-
+                  The two-letter ISO 3166-1 alpha-2 country code.
+                type: string
+              postalCode:
+                title: Postal Code
+                description: Text specifying the postal code for an address.
+                type: string
+            additionalProperties: false
+            required:
+              - type
+    additionalProperties: false
+    required:
+      - type
+      - id
+  intellectualPropertyRightsType:
+    title: Intellectual Property Rights Type
+    description: Type of intellectual property right.
+    type: string
+    enum:
+      - Trademark
+      - Patent
+      - Copyright
+  intellectualPropertyRightsProduct:
+    title: Intellectual Property Rights Product
+    description: Product of which the intellectual property rights are concerned.
+    $ref: ./Product.yml
+  extendsCredential:
+    description: URI of the IPR credential that this IPR license extends.
+    type: string
+    format: uri
+required:
+  - licensee
+  - extendsCredential
+example: |-
+  {
+    "type": [
+      "IntellectualPropertyRightsLicense"
+    ],
+    "licensee": {
+      "type": [
+        "Organization"
+      ],
+      "id": "did:web:plastics-manufacturer.example.com",
+      "name": "Plasticts Mnfg."
+    },
+    "intellectualPropertyRightsType": "Copyright",
+    "intellectualPropertyRightsProduct": {
+      "type": [
+        "Product"
+      ],
+      "name": "Lawn Flamingos",
+      "description": "Classic plastic lawn flamingos, 2pcs"
+    },
+    "extendsCredential": "did:key:z6LSpdSReUHCjYcQb1243aF1vS7sd9ArK585Mm4ktARQxatd"
+  }

--- a/docs/openapi/components/schemas/credentials/IntellectualPropertyRightsLicenseCredential.yml
+++ b/docs/openapi/components/schemas/credentials/IntellectualPropertyRightsLicenseCredential.yml
@@ -1,0 +1,332 @@
+$linkedData:
+  term: IntellectualPropertyRightsLicenseCredential
+  '@id': https://w3id.org/traceability#IntellectualPropertyRightsLicenseCredential
+title: Intellectual Property Rights License Credential
+tags:
+  - eCommerce
+description: >-
+    Credential licensing intellectual property rights.
+type: object
+properties:
+  '@context':
+    type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    items:
+      type: string
+      enum:
+        - https://www.w3.org/2018/credentials/v1
+        - https://w3id.org/traceability/v1
+  type:
+    type: array
+    readOnly: true
+    const:
+      - VerifiableCredential
+      - IntellectualPropertyRightsLicenseCredential
+    default:
+      - VerifiableCredential
+      - IntellectualPropertyRightsLicenseCredential
+    items:
+      type: string
+      enum:
+        - VerifiableCredential
+        - IntellectualPropertyRightsLicenseCredential
+  id:
+    type: string
+    format: uri
+  issuanceDate:
+    type: string
+    format: date-time
+  issuer:
+    title: IPR Licensor Organization
+    description: Organization licencing its intellectual property rights.
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - Organization
+        default:
+          - Organization
+        items:
+          type: string
+          enum:
+            - Organization
+      id: 
+        title: Identifier
+        description: Organization identifier.
+        type: string
+        format: uri
+      name:
+        title: Name
+        description: Name of the organization.
+        type: string
+      location:
+        title: Location
+        description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Place
+            default:
+              - Place
+            items:
+              type: string
+              enum:
+                - Place
+          address:
+            title: Postal Address
+            description: The postal address for an organization or place.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - PostalAddress
+                default:
+                  - PostalAddress
+                items:
+                  type: string
+                  enum:
+                    - PostalAddress
+              name:
+                title: Name
+                description: The name of the entity in text.
+                type: string
+              streetAddress:
+                title: Street Address
+                description: >-
+                  The street address expressed as free form text. The street address is
+                  printed on paper as the first lines below the name. For example, the name
+                  of the street and the number in the street, or the name of a building.
+                type: string
+              addressLocality:
+                title: Address Locality
+                description: Text specifying the name of the locality; for example, a city.
+                type: string
+              addressRegion:
+                title: Address Region
+                description: >-
+                  Text specifying a province or state in abbreviated format; for example,
+                  NJ.
+                type: string
+              addressCountry:
+                title: Address Country
+                description: >-
+                  The two-letter ISO 3166-1 alpha-2 country code.
+                type: string
+              postalCode:
+                title: Postal Code
+                description: Text specifying the postal code for an address.
+                type: string
+            additionalProperties: false
+            required:
+              - type
+    additionalProperties: false
+    required:
+      - type
+      - id
+  credentialSchema:
+    type: object
+    properties:
+      id:
+        title: Id
+        description: The url of the schema file to validate the shape of the json object
+        type: string
+        format: uri
+        example: https://w3id.org/traceability/openapi/components/schemas/credentials/IntellectualPropertyRightsLicenseCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/IntellectualPropertyRightsLicenseCredential.yml
+        readOnly: true
+      type:
+        title: Type
+        description: The type of validation to be run against the defined schema
+        const: OpenApiSpecificationValidator2022
+  credentialSubject:
+    type: object
+    title: Intellectual Property Rights Licensing
+    description: Licensing of Intellectual Property Ownership or Rights
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - IntellectualPropertyRightsLicense
+        default:
+          - IntellectualPropertyRightsLicense
+        items:
+          type: string
+          enum:
+            - IntellectualPropertyRightsLicense
+      licensee:
+        title: IPR Licensee Organization
+        description: Organization granted licencee intellectual property rights.
+        type: object
+        properties:
+          type:
+            type: array
+            readOnly: true
+            const:
+              - Organization
+            default:
+              - Organization
+            items:
+              type: string
+              enum:
+                - Organization
+          id: 
+            title: Identifier
+            description: Organization identifier.
+            type: string
+            format: uri
+          name:
+            title: Name
+            description: Name of the organization.
+            type: string
+          location:
+            title: Location
+            description: The location where, for example, an event is happening, an organization is located, or an action takes place.
+            type: object
+            properties:
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - Place
+                default:
+                  - Place
+                items:
+                  type: string
+                  enum:
+                    - Place
+              address:
+                title: Postal Address
+                description: The postal address for an organization or place.
+                type: object
+                properties:
+                  type:
+                    type: array
+                    readOnly: true
+                    const:
+                      - PostalAddress
+                    default:
+                      - PostalAddress
+                    items:
+                      type: string
+                      enum:
+                        - PostalAddress
+                  name:
+                    title: Name
+                    description: The name of the entity in text.
+                    type: string
+                  streetAddress:
+                    title: Street Address
+                    description: >-
+                      The street address expressed as free form text. The street address is
+                      printed on paper as the first lines below the name. For example, the name
+                      of the street and the number in the street, or the name of a building.
+                    type: string
+                  addressLocality:
+                    title: Address Locality
+                    description: Text specifying the name of the locality; for example, a city.
+                    type: string
+                  addressRegion:
+                    title: Address Region
+                    description: >-
+                      Text specifying a province or state in abbreviated format; for example,
+                      NJ.
+                    type: string
+                  addressCountry:
+                    title: Address Country
+                    description: >-
+                      The two-letter ISO 3166-1 alpha-2 country code.
+                    type: string
+                  postalCode:
+                    title: Postal Code
+                    description: Text specifying the postal code for an address.
+                    type: string
+                additionalProperties: false
+                required:
+                  - type
+        additionalProperties: false
+        required:
+          - type
+          - id
+      intellectualPropertyRightsType:
+        title: Intellectual Property Rights Type
+        description: Type of intellectual property right.
+        type: string
+        enum:
+          - Trademark
+          - Patent
+          - Copyright
+      intellectualPropertyRightsProduct:
+        title: Intellectual Property Rights Product
+        description: Product of which the intellectual property rights are concerned.
+        $ref: ../common/Product.yml
+      extendsCredential:
+        description: URI of the IPR credential that this IPR license extends.
+        type: string
+        format: uri
+    required:
+      - licensee
+      - extendsCredential
+  proof:
+    type: object
+additionalProperties: false
+required:
+  - '@context'
+  - type
+  - issuanceDate
+  - issuer
+  - credentialSubject
+example: |-
+  {
+    "type": [
+      "VerifiableCredential",
+      "IntellectualPropertyRightsLicenseCredential"
+    ],
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "urn:uuid:009a4c44-5d3a-4a1f-a1b4-642b9c08f9a5",
+    "issuer": {
+      "type": [
+        "Organization"
+      ],
+      "id": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+      "name": "Everything Garden Stuff"
+    },
+    "issuanceDate": "2022-01-13T09:16:46Z",
+    "credentialSubject": {
+      "type": [
+        "IntellectualPropertyRightsLicense"
+      ],
+      "licensee": {
+        "type": [
+          "Organization"
+        ],
+        "id": "did:web:plastics-manufacturer.example.com",
+        "name": "Plasticts Mnfg."
+      },
+      "intellectualPropertyRightsType": "Copyright",
+      "intellectualPropertyRightsProduct": {
+        "type": [
+          "Product"
+        ],
+        "name": "Lawn Flamingos",
+        "description": "Classic plastic lawn flamingos, 2pcs"
+      },
+      "extendsCredential": "did:key:z6LSpdSReUHCjYcQb1243aF1vS7sd9ArK585Mm4ktARQxatd"
+    }
+  }


### PR DESCRIPTION
This introduces an IPR license credential, allowing an IPR owner to license to a licensee organization, for example a manufacturer. 