### PR TITLE
delivery_and_injection_end_dates_update

### DIFF
--- a/docs/openapi/components/schemas/common/DeliverySchedule.yml
+++ b/docs/openapi/components/schemas/common/DeliverySchedule.yml
@@ -90,19 +90,33 @@ properties:
     $linkedData:
       term: injectionVolume
       '@id': https://w3id.org/traceability#QuantitativeValue
-  injectionDate:
-    title: Injection Date
+  injectionStartDate:
+    title: Injection Start Date
     description: The planned time for crude oil injection starts
     type: string
     $linkedData:
       term: injectionDate
       '@id': https://schema.org/departureTime
-  deliveryDate:
-    title: Delivery Date
+  injectionEndDate:
+    title: Injection End Date
+    description: The planned time for crude oil injection ends
+    type: string
+    $linkedData:
+      term: injectionEndDate
+      '@id': https://schema.org/departureTime
+  deliveryStartDate:
+    title: Delivery Start Date
     description: The planned time for crude oil delivery starts
     type: string
     $linkedData:
       term: deliveryDate
+      '@id': https://schema.org/arrivalTime
+  deliveryEndDate:
+    title: Delivery End Date
+    description: The planned time for crude oil delivery ends
+    type: string
+    $linkedData:
+      term: deliveryEndDate
       '@id': https://schema.org/arrivalTime
   portOfEntry:
     title: Port of Entry
@@ -247,8 +261,10 @@ example: |-
         "unitCode":"bbl"
       }
     ],
-    "injectionDate":"2022-05-01  10:13:00 PM",
-    "deliveryDate":"2022-05-01  10:13:00 PM",
+    "injectionStartDate":"2022-05-01  10:13:00 PM",
+    "injectionEndDate":"2022-05-01  12:13:00 PM",
+    "deliveryStartDate":"2022-05-10  10:13:00 PM",
+    "deliveryEndDate":"2022-05-10  12:13:00 PM",
     "portOfEntry":{
       "type":[
         "Place"

--- a/docs/openapi/components/schemas/common/DeliverySchedule.yml
+++ b/docs/openapi/components/schemas/common/DeliverySchedule.yml
@@ -113,7 +113,7 @@ properties:
       '@id': https://schema.org/arrivalTime
   deliveryEndDate:
     title: Delivery End Date
-    description: The planned time for crude oil delivery ends
+    description: The planned time for crude oil delivery to end
     type: string
     $linkedData:
       term: deliveryEndDate

--- a/docs/openapi/components/schemas/common/DeliverySchedule.yml
+++ b/docs/openapi/components/schemas/common/DeliverySchedule.yml
@@ -99,7 +99,7 @@ properties:
       '@id': https://schema.org/departureTime
   injectionEndDate:
     title: Injection End Date
-    description: The planned time for crude oil injection ends
+    description: The planned time for crude oil injection to end
     type: string
     $linkedData:
       term: injectionEndDate

--- a/docs/openapi/components/schemas/common/DeliverySchedule.yml
+++ b/docs/openapi/components/schemas/common/DeliverySchedule.yml
@@ -92,7 +92,7 @@ properties:
       '@id': https://w3id.org/traceability#QuantitativeValue
   injectionStartDate:
     title: Injection Start Date
-    description: The planned time for crude oil injection starts
+    description: The planned time for crude oil injection to start
     type: string
     $linkedData:
       term: injectionDate

--- a/docs/openapi/components/schemas/common/DeliverySchedule.yml
+++ b/docs/openapi/components/schemas/common/DeliverySchedule.yml
@@ -106,7 +106,7 @@ properties:
       '@id': https://schema.org/departureTime
   deliveryStartDate:
     title: Delivery Start Date
-    description: The planned time for crude oil delivery starts
+    description: The planned time for crude oil delivery to start
     type: string
     $linkedData:
       term: deliveryDate

--- a/docs/openapi/components/schemas/credentials/DeliveryScheduleCredential.yml
+++ b/docs/openapi/components/schemas/credentials/DeliveryScheduleCredential.yml
@@ -198,8 +198,10 @@ example: |-
           "unitCode": "bbl"
         }
       ],
-      "injectionDate": "2022-05-01  10:13:00 PM",
-      "deliveryDate": "2022-05-01  10:13:00 PM",
+      "injectionStartDate": "2022-05-01  10:13:00 PM",
+      "injectionEndDate": "2022-05-01  12:13:00 PM",
+      "deliveryStartDate": "2022-05-10  10:13:00 PM",
+      "deliveryEndDate": "2022-05-10  12:13:00 PM",
       "portOfEntry": {
         "type": [
           "Place"


### PR DESCRIPTION
Updates in this PR:

Adjust `DeliverySchedule `/ `DeliveryScheduleCredential `to accomodate Injection / Delivery End dates as per industry requirement.

There was no need to update anything in the delivery ticket as it already contains open / close dates.