### PR TITLE
Tsca certification

### DIFF
--- a/docs/credentials-with-issuer-dependent-terms.json
+++ b/docs/credentials-with-issuer-dependent-terms.json
@@ -20,16 +20,16 @@
     "count": 0
   },
   {
+    "type": "TSCACertificationCredential",
+    "count": 0
+  },
+  {
     "type": "SoftwareBillofMaterialsCredential",
     "count": 200
   },
   {
     "type": "ShippingInstructionsCredential",
     "count": 0
-  },
-  {
-    "type": "SellerRegistrationCredential",
-    "count": 10
   },
   {
     "type": "SeaCargoManifestCredential",
@@ -49,6 +49,10 @@
   },
   {
     "type": "ProductRegistrationCredential",
+    "count": 0
+  },
+  {
+    "type": "PowerOfAttorneyCredential",
     "count": 0
   },
   {
@@ -85,7 +89,7 @@
   },
   {
     "type": "MonthlyAdvanceManifestCredential",
-    "count": 14
+    "count": 26
   },
   {
     "type": "MillTestReportCredential",
@@ -106,6 +110,10 @@
   {
     "type": "IntentToImportCredential",
     "count": 2
+  },
+  {
+    "type": "IntellectualPropertyRightsLicenseCredential",
+    "count": 8
   },
   {
     "type": "IntellectualPropertyRightsCredential",
@@ -153,10 +161,6 @@
   },
   {
     "type": "GAPInspectionCredential",
-    "count": 0
-  },
-  {
-    "type": "FulfillmentRegistrationCredential",
     "count": 0
   },
   {
@@ -208,12 +212,24 @@
     "count": 0
   },
   {
+    "type": "EPA35401PesticidesPart3Credential",
+    "count": 6
+  },
+  {
+    "type": "EPA35401PesticidesPart2Credential",
+    "count": 6
+  },
+  {
+    "type": "EPA35401PesticidesCredential",
+    "count": 42
+  },
+  {
     "type": "DigitalProductPassportDataCarrierCredential",
     "count": 6
   },
   {
     "type": "DigitalProductPassportCredential",
-    "count": 5
+    "count": 7
   },
   {
     "type": "DeliveryStatementCredential",
@@ -221,7 +237,7 @@
   },
   {
     "type": "DeliveryScheduleCredential",
-    "count": 8
+    "count": 12
   },
   {
     "type": "DCSATransportDocumentCredential",
@@ -237,22 +253,6 @@
   },
   {
     "type": "CertificationOfOrigin",
-    "count": 0
-  },
-  {
-    "type": "CTPATEIPSellerCredential",
-    "count": 0
-  },
-  {
-    "type": "CTPATEIPMarketplaceCredential",
-    "count": 0
-  },
-  {
-    "type": "CTPATEIPFulfillmentCredential",
-    "count": 0
-  },
-  {
-    "type": "CTPATEIPApplicationCredential",
     "count": 0
   },
   {

--- a/docs/openapi/components/schemas/common/TSCACertification.yml
+++ b/docs/openapi/components/schemas/common/TSCACertification.yml
@@ -16,13 +16,6 @@ properties:
       type: string
       enum:
         - TSCACertification
-  role:
-    title: Role
-    description: >-
-      Importer's declaration for compliance with the Toxic
-      Substances Control Act (TSCA) regulations
-    enum:
-      - Importer
   certificationType:
     title: Certification Type
     description: >-
@@ -33,9 +26,6 @@ properties:
     enum:
       - Positive
       - Negative
-    $linkedData:
-      term: role
-      '@id': https://w3id.org/traceability#certifierRole
   certifierDetails:
     title: Certifier's Details
     description: >-
@@ -48,13 +38,11 @@ properties:
 additionalProperties: true
 required: 
   - type
-  - role
   - certificationType
   - certifierDetails
 example: |-
   {
     "type": ["TSCACertification"],
-    "role": "Importer",
     "certificationType": "Positive" 
     "certifierDetails": {
       "type": ["Organization"],

--- a/docs/openapi/components/schemas/common/TSCACertification.yml
+++ b/docs/openapi/components/schemas/common/TSCACertification.yml
@@ -1,0 +1,78 @@
+$linkedData:
+  term: TSCACertification
+  '@id': https://w3id.org/traceability/TSCACertification
+title: TSCA Certification
+description: TSCA Import Certification Statement
+type: object
+properties:
+  type:
+    type: array
+    readOnly: true
+    const:
+      - TSCACertification
+    default:
+      - TSCACertification
+    items:
+      type: string
+      enum:
+        - TSCACertification
+  role:
+    title: Role
+    description: >-
+      Importer's declaration for compliance with the Toxic
+      Substances Control Act (TSCA) regulations
+    enum:
+      - Importer
+  certificationType:
+    title: Certification Type
+    description: >-
+      The type of TSCA certification. This can be either 'Positive' to certify 
+      compliance with all applicable TSCA rules and orders, or 'Negative' to 
+      certify that the chemical shipment is not subject to TSCA.
+    type: string
+    enum:
+      - Positive
+      - Negative
+    $linkedData:
+      term: role
+      '@id': https://w3id.org/traceability#certifierRole
+  certifierDetails:
+    title: Certifier's Details
+    description: >-
+      Provide the certifier’s name, title, address (including country), telephone 
+      number and email address.
+    $ref: ./Organization.yml
+    $linkedData:
+      term: certifierDetails
+      '@id': https://w3id.org/traceability#certifierDetails
+additionalProperties: true
+required: 
+  - type
+  - role
+  - certificationType
+  - certifierDetails
+example: |-
+  {
+    "type": ["TSCACertification"],
+    "role": "Importer",
+    "certificationType": "Positive" 
+    "certifierDetails": {
+      "type": ["Organization"],
+      "id": "did:key:z6MkjR12D3456sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",
+      "name": "Chemical Import Co",
+      "description": "Specialist in importing and distributing chemical products",
+      "location": {
+        "type": ["Place"],
+        "address": {
+          "type": ["PostalAddress"],
+          "streetAddress": "123 Industry Blvd",
+          "addressLocality": "Chemtown",
+          "addressRegion": "CA",
+          "postalCode": "90001",
+          "addressCountry": "USA"
+        }
+      },
+      "email": "contact@chemicalimportco.com",
+      "phoneNumber": "+1-555-123-4567"
+    }
+  }

--- a/docs/openapi/components/schemas/common/TSCACertification.yml
+++ b/docs/openapi/components/schemas/common/TSCACertification.yml
@@ -27,8 +27,8 @@ properties:
       - Positive
       - Negative
     $linkedData:
-      term: role
-      '@id': https://w3id.org/traceability#certifierRole
+      term: certificationType
+      '@id': https://schema.org/DefinedTerm
   certifierDetails:
     title: Certifier's Details
     description: >-
@@ -46,7 +46,7 @@ required:
 example: |-
   {
     "type": ["TSCACertification"],
-    "certificationType": "Positive" 
+    "certificationType": "Positive", 
     "certifierDetails": {
       "type": ["Organization"],
       "id": "did:key:z6MkjR12D3456sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",

--- a/docs/openapi/components/schemas/common/TSCACertification.yml
+++ b/docs/openapi/components/schemas/common/TSCACertification.yml
@@ -26,6 +26,9 @@ properties:
     enum:
       - Positive
       - Negative
+    $linkedData:
+      term: role
+      '@id': https://w3id.org/traceability#certifierRole
   certifierDetails:
     title: Certifier's Details
     description: >-

--- a/docs/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
+++ b/docs/openapi/components/schemas/credentials/MonthlyAdvanceManifestCredential.yml
@@ -103,21 +103,25 @@ example: |-
       "scheduledDeliveries": [
         {
           "portCode": "3901",
-          "portOfArrival": 
-          {
-            "type": ["Place"],
+          "portOfArrival": {
+            "type": [
+              "Place"
+            ],
             "locationName": "Morgan",
             "usPortCode": "3319"
           },
-          "portOfDestination": 
-          {
-            "type": ["Place"],
+          "portOfDestination": {
+            "type": [
+              "Place"
+            ],
             "locationName": "Pembina ND",
             "usPortCode": "3401"
           },
           "transporter": {
-          "type": ["Organization"],
-          "name": "Gas Transmission Northwest (GTN)"
+            "type": [
+              "Organization"
+            ],
+            "name": "Gas Transmission Northwest (GTN)"
           },
           "deliveryLocation": "Chicago",
           "sumOfScheduledDeliveries": [

--- a/docs/openapi/components/schemas/credentials/TSCACertificationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/TSCACertificationCredential.yml
@@ -96,7 +96,6 @@ example: |-
       "type": [
         "TSCACertification"
       ],
-      "role": "Importer",
       "certifierDetails": {
         "type": ["Organization"],
         "id": "did:key:z6MkjR12D3456sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",

--- a/docs/openapi/components/schemas/credentials/TSCACertificationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/TSCACertificationCredential.yml
@@ -96,7 +96,7 @@ example: |-
       "type": [
         "TSCACertification"
       ],
-      "certificationType": "Positive", 
+      "certificationType": "Positive",
       "certifierDetails": {
         "type": [
           "Organization"

--- a/docs/openapi/components/schemas/credentials/TSCACertificationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/TSCACertificationCredential.yml
@@ -1,0 +1,119 @@
+$linkedData:
+  term: TSCACertificationCredential
+  '@id': https://w3id.org/traceability#TSCACertificationCredential
+title: TSCA Certification Credential
+tags:
+  - Environmental Compliance
+description: A credential for compliance with the Toxic Substances Control Act (TSCA) regulations
+type: object
+properties:
+  '@context':
+    type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    items:
+      type: string
+      enum:
+        - https://www.w3.org/2018/credentials/v1
+        - https://w3id.org/traceability/v1
+  type:
+    type: array
+    readOnly: true
+    const:
+      - VerifiableCredential
+      - TSCACertificationCredential
+    default:
+      - VerifiableCredential
+      - TSCACertificationCredential
+    items:
+      type: string
+      enum:
+        - VerifiableCredential
+        - TSCACertificationCredential
+  id:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  issuanceDate:
+    type: string
+  expirationDate:
+    type: string
+  issuer:
+    type: string
+  credentialSchema:
+    type: object
+    properties:
+      id:
+        title: Id
+        description: The URL of the schema file to validate the shape of the JSON object
+        type: string
+        format: uri
+        example: https://w3id.org/traceability/openapi/components/schemas/credentials/TSCACertificationCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/TSCACertificationCredential.yml
+        readOnly: true
+      type:
+        title: Type
+        description: The type of validation to be run against the defined schema
+        const: OpenApiSpecificationValidator2022
+  credentialSubject:
+    $ref: ../common/TSCACertification.yml
+  proof:
+    $ref: ../snippets/proof.yml
+  relatedLink:
+    title: Related Link
+    description: Links related to this verifiable credential
+    type: array
+    items:
+      $ref: ../common/LinkRole.yml
+additionalProperties: false
+required:
+  - '@context'
+  - type
+  - issuanceDate
+  - issuer
+  - credentialSubject
+example: |- 
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "http://example.org/credentials/",
+    "type": [
+      "VerifiableCredential",
+      "TSCACertificationCredential"
+    ],
+    "issuanceDate": "2024-01-04T20:29:37+00:00",
+    "issuer": "did:key:z6MktHQo3fRRohk44dsbE76CuiTpBmyMWq2VVjvV6aBSeE3U",
+    "credentialSubject": {
+      "type": [
+        "TSCACertification"
+      ],
+      "role": "Importer",
+      "certifierDetails": {
+        "type": ["Organization"],
+        "id": "did:key:z6MkjR12D3456sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",
+        "name": "Chemical Import Co",
+        "description": "Specialist in importing and distributing chemical products",
+        "location": {
+          "type": ["Place"],
+          "address": {
+            "type": ["PostalAddress"],
+            "streetAddress": "123 Industry Blvd",
+            "addressLocality": "Chemtown",
+            "addressRegion": "CA",
+            "postalCode": "90001",
+            "addressCountry": "USA"
+          }
+        },
+        "email": "contact@chemicalimportco.com",
+        "phoneNumber": "+1-555-123-4567"
+      }
+    }

--- a/docs/openapi/components/schemas/credentials/TSCACertificationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/TSCACertificationCredential.yml
@@ -115,4 +115,5 @@ example: |-
         "email": "contact@chemicalimportco.com",
         "phoneNumber": "+1-555-123-4567"
       }
-    }
+    } 
+  }

--- a/docs/openapi/components/schemas/credentials/TSCACertificationCredential.yml
+++ b/docs/openapi/components/schemas/credentials/TSCACertificationCredential.yml
@@ -96,15 +96,22 @@ example: |-
       "type": [
         "TSCACertification"
       ],
+      "certificationType": "Positive", 
       "certifierDetails": {
-        "type": ["Organization"],
+        "type": [
+          "Organization"
+        ],
         "id": "did:key:z6MkjR12D3456sn2yBAyqj5gqckDjvyAbNSusehsxtkvknfa",
         "name": "Chemical Import Co",
         "description": "Specialist in importing and distributing chemical products",
         "location": {
-          "type": ["Place"],
+          "type": [
+            "Place"
+          ],
           "address": {
-            "type": ["PostalAddress"],
+            "type": [
+              "PostalAddress"
+            ],
             "streetAddress": "123 Industry Blvd",
             "addressLocality": "Chemtown",
             "addressRegion": "CA",
@@ -115,5 +122,5 @@ example: |-
         "email": "contact@chemicalimportco.com",
         "phoneNumber": "+1-555-123-4567"
       }
-    } 
+    }
   }

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -128,6 +128,30 @@ paths:
                 $ref: './components/schemas/common/BusinessRegistrationAffirmation.yml'
     
 
+  /schemas/common/CargoItem.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CargoItem.yml'
+    
+
+  /schemas/common/CargoLineItem.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CargoLineItem.yml'
+    
+
   /schemas/common/CBPEntry.yml:
     get:
       tags:
@@ -210,66 +234,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/CBPImporterOfRecord.yml'
-    
-
-  /schemas/common/CTPAT.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/CTPAT.yml'
-    
-
-  /schemas/common/CTPATEIPApplication.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/CTPATEIPApplication.yml'
-    
-
-  /schemas/common/CTPATMember.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/CTPATMember.yml'
-    
-
-  /schemas/common/CargoItem.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/CargoItem.yml'
-    
-
-  /schemas/common/CargoLineItem.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/CargoLineItem.yml'
     
 
   /schemas/common/ChargeDeclaration.yml:
@@ -356,6 +320,42 @@ paths:
                 $ref: './components/schemas/common/ContactPoint.yml'
     
 
+  /schemas/common/CTPAT.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CTPAT.yml'
+    
+
+  /schemas/common/CTPATEIPApplication.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CTPATEIPApplication.yml'
+    
+
+  /schemas/common/CTPATMember.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CTPATMember.yml'
+    
+
   /schemas/common/Customer.yml:
     get:
       tags:
@@ -392,18 +392,6 @@ paths:
                 $ref: './components/schemas/common/DCSATransportDocument.yml'
     
 
-  /schemas/common/DeMinimisShipment.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/DeMinimisShipment.yml'
-    
-
   /schemas/common/DeliverySchedule.yml:
     get:
       tags:
@@ -426,6 +414,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/DeliveryStatement.yml'
+    
+
+  /schemas/common/DeMinimisShipment.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/DeMinimisShipment.yml'
     
 
   /schemas/common/EDDShape.yml:
@@ -498,126 +498,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/ExternalResource.yml'
-    
-
-  /schemas/common/FSMAAbstractKDE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAAbstractKDE.yml'
-    
-
-  /schemas/common/FSMACreatingCTE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMACreatingCTE.yml'
-    
-
-  /schemas/common/FSMAFirstReceiverData.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAFirstReceiverData.yml'
-    
-
-  /schemas/common/FSMAGrowingCTE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAGrowingCTE.yml'
-    
-
-  /schemas/common/FSMAProduct.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAProduct.yml'
-    
-
-  /schemas/common/FSMAReceivingCTE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAReceivingCTE.yml'
-    
-
-  /schemas/common/FSMAShipment.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAShipment.yml'
-    
-
-  /schemas/common/FSMAShippingCTE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAShippingCTE.yml'
-    
-
-  /schemas/common/FSMATraceabilityLot.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMATraceabilityLot.yml'
-    
-
-  /schemas/common/FSMATransformingCTE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMATransformingCTE.yml'
     
 
   /schemas/common/FoodDefenseDeficiency.yml:
@@ -750,6 +630,126 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/FreightManifest.yml'
+    
+
+  /schemas/common/FSMAAbstractKDE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAAbstractKDE.yml'
+    
+
+  /schemas/common/FSMACreatingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMACreatingCTE.yml'
+    
+
+  /schemas/common/FSMAFirstReceiverData.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAFirstReceiverData.yml'
+    
+
+  /schemas/common/FSMAGrowingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAGrowingCTE.yml'
+    
+
+  /schemas/common/FSMAProduct.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAProduct.yml'
+    
+
+  /schemas/common/FSMAReceivingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAReceivingCTE.yml'
+    
+
+  /schemas/common/FSMAShipment.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAShipment.yml'
+    
+
+  /schemas/common/FSMAShippingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAShippingCTE.yml'
+    
+
+  /schemas/common/FSMATraceabilityLot.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMATraceabilityLot.yml'
+    
+
+  /schemas/common/FSMATransformingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMATransformingCTE.yml'
     
 
   /schemas/common/GAPCorrectiveActionReport.yml:
@@ -920,6 +920,18 @@ paths:
                 $ref: './components/schemas/common/IntellectualPropertyRightsAffirmation.yml'
     
 
+  /schemas/common/IntellectualPropertyRightsLicense.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/IntellectualPropertyRightsLicense.yml'
+    
+
   /schemas/common/IntentToImport.yml:
     get:
       tags:
@@ -942,6 +954,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/Invoice.yml'
+    
+
+  /schemas/common/LaceyActProductDeclaration.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/LaceyActProductDeclaration.yml'
     
 
   /schemas/common/LEIaddress.yml:
@@ -1002,18 +1026,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/LEIregistration.yml'
-    
-
-  /schemas/common/LaceyActProductDeclaration.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/LaceyActProductDeclaration.yml'
     
 
   /schemas/common/LinkRole.yml:
@@ -1364,30 +1376,6 @@ paths:
                 $ref: './components/schemas/common/Organization.yml'
     
 
-  /schemas/common/PGAShipmentStatus.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/PGAShipmentStatus.yml'
-    
-
-  /schemas/common/PGAShipmentStatusList.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/PGAShipmentStatusList.yml'
-    
-
   /schemas/common/Package.yml:
     get:
       tags:
@@ -1470,6 +1458,30 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/PestSample.yml'
+    
+
+  /schemas/common/PGAShipmentStatus.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/PGAShipmentStatus.yml'
+    
+
+  /schemas/common/PGAShipmentStatusList.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/PGAShipmentStatusList.yml'
     
 
   /schemas/common/Phytosanitary.yml:
@@ -1652,30 +1664,6 @@ paths:
                 $ref: './components/schemas/common/RoutingInfo.yml'
     
 
-  /schemas/common/SIMASteelImportLicense.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/SIMASteelImportLicense.yml'
-    
-
-  /schemas/common/SIMASteelImportProductSpecifier.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/SIMASteelImportProductSpecifier.yml'
-    
-
   /schemas/common/Scorecard.yml:
     get:
       tags:
@@ -1746,6 +1734,30 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/ShippingInstructions.yml'
+    
+
+  /schemas/common/SIMASteelImportLicense.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/SIMASteelImportLicense.yml'
+    
+
+  /schemas/common/SIMASteelImportProductSpecifier.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/SIMASteelImportProductSpecifier.yml'
     
 
   /schemas/common/SoftwareBillOfMaterials.yml:
@@ -1916,6 +1928,18 @@ paths:
                 $ref: './components/schemas/common/TransportEvent.yml'
     
 
+  /schemas/common/TSCACertification.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/TSCACertification.yml'
+    
+
   /schemas/common/USDAPPQ203ForeignSiteInspection.yml:
     get:
       tags:
@@ -2036,6 +2060,18 @@ paths:
                 $ref: './components/schemas/common/USDAPPQ587PlantImportPermit.yml'
     
 
+  /schemas/common/UsdaSc6.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/UsdaSc6.yml'
+    
+
   /schemas/common/USDASpecialtyCrops237AForm.yml:
     get:
       tags:
@@ -2082,18 +2118,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/USMCAProduct.yml'
-    
-
-  /schemas/common/UsdaSc6.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/UsdaSc6.yml'
     
 
   /schemas/credentials/ActivityPubActorCard.yml:
@@ -2192,66 +2216,6 @@ paths:
                 $ref: './components/schemas/credentials/CBPSection321DeMinimisCredential.yml'
     
 
-  /schemas/credentials/CTPATCertificate.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/CTPATCertificate.yml'
-    
-
-  /schemas/credentials/CTPATEIPApplicationCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/CTPATEIPApplicationCredential.yml'
-    
-
-  /schemas/credentials/CTPATEIPFulfillmentCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/CTPATEIPFulfillmentCredential.yml'
-    
-
-  /schemas/credentials/CTPATEIPMarketplaceCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/CTPATEIPMarketplaceCredential.yml'
-    
-
-  /schemas/credentials/CTPATEIPSellerCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/CTPATEIPSellerCredential.yml'
-    
-
   /schemas/credentials/CertificationOfOrigin.yml:
     get:
       tags:
@@ -2274,6 +2238,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/CommercialInvoiceCredential.yml'
+    
+
+  /schemas/credentials/CTPATCertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/CTPATCertificate.yml'
     
 
   /schemas/credentials/DCSAShippingInstructionCredential.yml:
@@ -2360,6 +2336,42 @@ paths:
                 $ref: './components/schemas/credentials/EntryNumberCredential.yml'
     
 
+  /schemas/credentials/EPA35401PesticidesCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/EPA35401PesticidesCredential.yml'
+    
+
+  /schemas/credentials/EPA35401PesticidesPart2Credential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/EPA35401PesticidesPart2Credential.yml'
+    
+
+  /schemas/credentials/EPA35401PesticidesPart3Credential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/EPA35401PesticidesPart3Credential.yml'
+    
+
   /schemas/credentials/EventCredential.yml:
     get:
       tags:
@@ -2382,6 +2394,42 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/ExampleCredentialWithStatus.yml'
+    
+
+  /schemas/credentials/FoodDefenseInspectionCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FoodDefenseInspectionCredential.yml'
+    
+
+  /schemas/credentials/FoodGradeInspectionCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FoodGradeInspectionCredential.yml'
+    
+
+  /schemas/credentials/FreightManifestCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FreightManifestCredential.yml'
     
 
   /schemas/credentials/FSMACreatingCTECredential.yml:
@@ -2454,54 +2502,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/FSMATransformingCTECredential.yml'
-    
-
-  /schemas/credentials/FoodDefenseInspectionCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/FoodDefenseInspectionCredential.yml'
-    
-
-  /schemas/credentials/FoodGradeInspectionCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/FoodGradeInspectionCredential.yml'
-    
-
-  /schemas/credentials/FreightManifestCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/FreightManifestCredential.yml'
-    
-
-  /schemas/credentials/FulfillmentRegistrationCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/FulfillmentRegistrationCredential.yml'
     
 
   /schemas/credentials/GAPInspectionCredential.yml:
@@ -2648,6 +2648,18 @@ paths:
                 $ref: './components/schemas/credentials/IntellectualPropertyRightsCredential.yml'
     
 
+  /schemas/credentials/IntellectualPropertyRightsLicenseCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/IntellectualPropertyRightsLicenseCredential.yml'
+    
+
   /schemas/credentials/IntentToImportCredential.yml:
     get:
       tags:
@@ -2780,18 +2792,6 @@ paths:
                 $ref: './components/schemas/credentials/OrganicCertificateCredential.yml'
     
 
-  /schemas/credentials/PGAShipmentStatusCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/PGAShipmentStatusCredential.yml'
-    
-
   /schemas/credentials/PackingListCredential.yml:
     get:
       tags:
@@ -2804,6 +2804,18 @@ paths:
                 $ref: './components/schemas/credentials/PackingListCredential.yml'
     
 
+  /schemas/credentials/PGAShipmentStatusCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/PGAShipmentStatusCredential.yml'
+    
+
   /schemas/credentials/PlantSystemsInspectionCredential.yml:
     get:
       tags:
@@ -2814,6 +2826,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/PlantSystemsInspectionCredential.yml'
+    
+
+  /schemas/credentials/PowerOfAttorneyCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/PowerOfAttorneyCredential.yml'
     
 
   /schemas/credentials/ProductRegistrationCredential.yml:
@@ -2840,6 +2864,30 @@ paths:
                 $ref: './components/schemas/credentials/PurchaseOrderCredential.yml'
     
 
+  /schemas/credentials/SeaCargoManifestCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/SeaCargoManifestCredential.yml'
+    
+
+  /schemas/credentials/ShippingInstructionsCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/ShippingInstructionsCredential.yml'
+    
+
   /schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml:
     get:
       tags:
@@ -2864,42 +2912,6 @@ paths:
                 $ref: './components/schemas/credentials/SIMASteelImportLicenseCredential.yml'
     
 
-  /schemas/credentials/SeaCargoManifestCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/SeaCargoManifestCredential.yml'
-    
-
-  /schemas/credentials/SellerRegistrationCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/SellerRegistrationCredential.yml'
-    
-
-  /schemas/credentials/ShippingInstructionsCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/ShippingInstructionsCredential.yml'
-    
-
   /schemas/credentials/SoftwareBillofMaterialsCredential.yml:
     get:
       tags:
@@ -2922,6 +2934,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/ThingCredential.yml'
+    
+
+  /schemas/credentials/TSCACertificationCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/TSCACertificationCredential.yml'
     
 
   /schemas/credentials/USMCACertificationOfOrigin.yml:
@@ -2984,6 +3008,30 @@ paths:
                 $ref: './components/schemas/snippets/BuyerParty.yml'
     
 
+  /schemas/snippets/carrier.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/carrier.yml'
+    
+
+  /schemas/snippets/consignee.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/consignee.yml'
+    
+
   /schemas/snippets/ConsigneeParty.yml:
     get:
       tags:
@@ -2994,6 +3042,30 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/snippets/ConsigneeParty.yml'
+    
+
+  /schemas/snippets/consignor.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/consignor.yml'
+    
+
+  /schemas/snippets/forwarder.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/forwarder.yml'
     
 
   /schemas/snippets/IntentToImportOrganization.yml:
@@ -3044,78 +3116,6 @@ paths:
                 $ref: './components/schemas/snippets/ManufacturerParty.yml'
     
 
-  /schemas/snippets/SellerParty.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/SellerParty.yml'
-    
-
-  /schemas/snippets/ShipToParty.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/ShipToParty.yml'
-    
-
-  /schemas/snippets/carrier.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/carrier.yml'
-    
-
-  /schemas/snippets/consignee.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/consignee.yml'
-    
-
-  /schemas/snippets/consignor.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/consignor.yml'
-    
-
-  /schemas/snippets/forwarder.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/forwarder.yml'
-    
-
   /schemas/snippets/notify.yml:
     get:
       tags:
@@ -3138,6 +3138,30 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/snippets/proof.yml'
+    
+
+  /schemas/snippets/SellerParty.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/SellerParty.yml'
+    
+
+  /schemas/snippets/ShipToParty.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/ShipToParty.yml'
     
 
   /schemas/workflows/businesscard.yml:

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -128,30 +128,6 @@ paths:
                 $ref: './components/schemas/common/BusinessRegistrationAffirmation.yml'
     
 
-  /schemas/common/CargoItem.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/CargoItem.yml'
-    
-
-  /schemas/common/CargoLineItem.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/CargoLineItem.yml'
-    
-
   /schemas/common/CBPEntry.yml:
     get:
       tags:
@@ -234,6 +210,66 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/CBPImporterOfRecord.yml'
+    
+
+  /schemas/common/CTPAT.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CTPAT.yml'
+    
+
+  /schemas/common/CTPATEIPApplication.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CTPATEIPApplication.yml'
+    
+
+  /schemas/common/CTPATMember.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CTPATMember.yml'
+    
+
+  /schemas/common/CargoItem.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CargoItem.yml'
+    
+
+  /schemas/common/CargoLineItem.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/CargoLineItem.yml'
     
 
   /schemas/common/ChargeDeclaration.yml:
@@ -320,42 +356,6 @@ paths:
                 $ref: './components/schemas/common/ContactPoint.yml'
     
 
-  /schemas/common/CTPAT.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/CTPAT.yml'
-    
-
-  /schemas/common/CTPATEIPApplication.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/CTPATEIPApplication.yml'
-    
-
-  /schemas/common/CTPATMember.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/CTPATMember.yml'
-    
-
   /schemas/common/Customer.yml:
     get:
       tags:
@@ -392,6 +392,18 @@ paths:
                 $ref: './components/schemas/common/DCSATransportDocument.yml'
     
 
+  /schemas/common/DeMinimisShipment.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/DeMinimisShipment.yml'
+    
+
   /schemas/common/DeliverySchedule.yml:
     get:
       tags:
@@ -414,18 +426,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/DeliveryStatement.yml'
-    
-
-  /schemas/common/DeMinimisShipment.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/DeMinimisShipment.yml'
     
 
   /schemas/common/EDDShape.yml:
@@ -498,6 +498,126 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/ExternalResource.yml'
+    
+
+  /schemas/common/FSMAAbstractKDE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAAbstractKDE.yml'
+    
+
+  /schemas/common/FSMACreatingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMACreatingCTE.yml'
+    
+
+  /schemas/common/FSMAFirstReceiverData.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAFirstReceiverData.yml'
+    
+
+  /schemas/common/FSMAGrowingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAGrowingCTE.yml'
+    
+
+  /schemas/common/FSMAProduct.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAProduct.yml'
+    
+
+  /schemas/common/FSMAReceivingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAReceivingCTE.yml'
+    
+
+  /schemas/common/FSMAShipment.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAShipment.yml'
+    
+
+  /schemas/common/FSMAShippingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMAShippingCTE.yml'
+    
+
+  /schemas/common/FSMATraceabilityLot.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMATraceabilityLot.yml'
+    
+
+  /schemas/common/FSMATransformingCTE.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/FSMATransformingCTE.yml'
     
 
   /schemas/common/FoodDefenseDeficiency.yml:
@@ -630,126 +750,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/FreightManifest.yml'
-    
-
-  /schemas/common/FSMAAbstractKDE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAAbstractKDE.yml'
-    
-
-  /schemas/common/FSMACreatingCTE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMACreatingCTE.yml'
-    
-
-  /schemas/common/FSMAFirstReceiverData.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAFirstReceiverData.yml'
-    
-
-  /schemas/common/FSMAGrowingCTE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAGrowingCTE.yml'
-    
-
-  /schemas/common/FSMAProduct.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAProduct.yml'
-    
-
-  /schemas/common/FSMAReceivingCTE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAReceivingCTE.yml'
-    
-
-  /schemas/common/FSMAShipment.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAShipment.yml'
-    
-
-  /schemas/common/FSMAShippingCTE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMAShippingCTE.yml'
-    
-
-  /schemas/common/FSMATraceabilityLot.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMATraceabilityLot.yml'
-    
-
-  /schemas/common/FSMATransformingCTE.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/FSMATransformingCTE.yml'
     
 
   /schemas/common/GAPCorrectiveActionReport.yml:
@@ -956,18 +956,6 @@ paths:
                 $ref: './components/schemas/common/Invoice.yml'
     
 
-  /schemas/common/LaceyActProductDeclaration.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/LaceyActProductDeclaration.yml'
-    
-
   /schemas/common/LEIaddress.yml:
     get:
       tags:
@@ -1026,6 +1014,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/LEIregistration.yml'
+    
+
+  /schemas/common/LaceyActProductDeclaration.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/LaceyActProductDeclaration.yml'
     
 
   /schemas/common/LinkRole.yml:
@@ -1376,6 +1376,30 @@ paths:
                 $ref: './components/schemas/common/Organization.yml'
     
 
+  /schemas/common/PGAShipmentStatus.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/PGAShipmentStatus.yml'
+    
+
+  /schemas/common/PGAShipmentStatusList.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/PGAShipmentStatusList.yml'
+    
+
   /schemas/common/Package.yml:
     get:
       tags:
@@ -1458,30 +1482,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/PestSample.yml'
-    
-
-  /schemas/common/PGAShipmentStatus.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/PGAShipmentStatus.yml'
-    
-
-  /schemas/common/PGAShipmentStatusList.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/PGAShipmentStatusList.yml'
     
 
   /schemas/common/Phytosanitary.yml:
@@ -1664,6 +1664,30 @@ paths:
                 $ref: './components/schemas/common/RoutingInfo.yml'
     
 
+  /schemas/common/SIMASteelImportLicense.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/SIMASteelImportLicense.yml'
+    
+
+  /schemas/common/SIMASteelImportProductSpecifier.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/SIMASteelImportProductSpecifier.yml'
+    
+
   /schemas/common/Scorecard.yml:
     get:
       tags:
@@ -1736,30 +1760,6 @@ paths:
                 $ref: './components/schemas/common/ShippingInstructions.yml'
     
 
-  /schemas/common/SIMASteelImportLicense.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/SIMASteelImportLicense.yml'
-    
-
-  /schemas/common/SIMASteelImportProductSpecifier.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/SIMASteelImportProductSpecifier.yml'
-    
-
   /schemas/common/SoftwareBillOfMaterials.yml:
     get:
       tags:
@@ -1782,6 +1782,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/SteelProduct.yml'
+    
+
+  /schemas/common/TSCACertification.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/TSCACertification.yml'
     
 
   /schemas/common/Taxonomy.yml:
@@ -1928,18 +1940,6 @@ paths:
                 $ref: './components/schemas/common/TransportEvent.yml'
     
 
-  /schemas/common/TSCACertification.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/TSCACertification.yml'
-    
-
   /schemas/common/USDAPPQ203ForeignSiteInspection.yml:
     get:
       tags:
@@ -2060,18 +2060,6 @@ paths:
                 $ref: './components/schemas/common/USDAPPQ587PlantImportPermit.yml'
     
 
-  /schemas/common/UsdaSc6.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/UsdaSc6.yml'
-    
-
   /schemas/common/USDASpecialtyCrops237AForm.yml:
     get:
       tags:
@@ -2118,6 +2106,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/USMCAProduct.yml'
+    
+
+  /schemas/common/UsdaSc6.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/UsdaSc6.yml'
     
 
   /schemas/credentials/ActivityPubActorCard.yml:
@@ -2216,6 +2216,18 @@ paths:
                 $ref: './components/schemas/credentials/CBPSection321DeMinimisCredential.yml'
     
 
+  /schemas/credentials/CTPATCertificate.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/CTPATCertificate.yml'
+    
+
   /schemas/credentials/CertificationOfOrigin.yml:
     get:
       tags:
@@ -2238,18 +2250,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/CommercialInvoiceCredential.yml'
-    
-
-  /schemas/credentials/CTPATCertificate.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/CTPATCertificate.yml'
     
 
   /schemas/credentials/DCSAShippingInstructionCredential.yml:
@@ -2324,18 +2324,6 @@ paths:
                 $ref: './components/schemas/credentials/DigitalProductPassportDataCarrierCredential.yml'
     
 
-  /schemas/credentials/EntryNumberCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/EntryNumberCredential.yml'
-    
-
   /schemas/credentials/EPA35401PesticidesCredential.yml:
     get:
       tags:
@@ -2372,6 +2360,18 @@ paths:
                 $ref: './components/schemas/credentials/EPA35401PesticidesPart3Credential.yml'
     
 
+  /schemas/credentials/EntryNumberCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/EntryNumberCredential.yml'
+    
+
   /schemas/credentials/EventCredential.yml:
     get:
       tags:
@@ -2394,42 +2394,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/ExampleCredentialWithStatus.yml'
-    
-
-  /schemas/credentials/FoodDefenseInspectionCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/FoodDefenseInspectionCredential.yml'
-    
-
-  /schemas/credentials/FoodGradeInspectionCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/FoodGradeInspectionCredential.yml'
-    
-
-  /schemas/credentials/FreightManifestCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/FreightManifestCredential.yml'
     
 
   /schemas/credentials/FSMACreatingCTECredential.yml:
@@ -2502,6 +2466,42 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/FSMATransformingCTECredential.yml'
+    
+
+  /schemas/credentials/FoodDefenseInspectionCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FoodDefenseInspectionCredential.yml'
+    
+
+  /schemas/credentials/FoodGradeInspectionCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FoodGradeInspectionCredential.yml'
+    
+
+  /schemas/credentials/FreightManifestCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/FreightManifestCredential.yml'
     
 
   /schemas/credentials/GAPInspectionCredential.yml:
@@ -2792,18 +2792,6 @@ paths:
                 $ref: './components/schemas/credentials/OrganicCertificateCredential.yml'
     
 
-  /schemas/credentials/PackingListCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/PackingListCredential.yml'
-    
-
   /schemas/credentials/PGAShipmentStatusCredential.yml:
     get:
       tags:
@@ -2814,6 +2802,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/PGAShipmentStatusCredential.yml'
+    
+
+  /schemas/credentials/PackingListCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/PackingListCredential.yml'
     
 
   /schemas/credentials/PlantSystemsInspectionCredential.yml:
@@ -2864,30 +2864,6 @@ paths:
                 $ref: './components/schemas/credentials/PurchaseOrderCredential.yml'
     
 
-  /schemas/credentials/SeaCargoManifestCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/SeaCargoManifestCredential.yml'
-    
-
-  /schemas/credentials/ShippingInstructionsCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/ShippingInstructionsCredential.yml'
-    
-
   /schemas/credentials/SIMASteelImportLicenseApplicationCredential.yml:
     get:
       tags:
@@ -2912,6 +2888,30 @@ paths:
                 $ref: './components/schemas/credentials/SIMASteelImportLicenseCredential.yml'
     
 
+  /schemas/credentials/SeaCargoManifestCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/SeaCargoManifestCredential.yml'
+    
+
+  /schemas/credentials/ShippingInstructionsCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/ShippingInstructionsCredential.yml'
+    
+
   /schemas/credentials/SoftwareBillofMaterialsCredential.yml:
     get:
       tags:
@@ -2924,18 +2924,6 @@ paths:
                 $ref: './components/schemas/credentials/SoftwareBillofMaterialsCredential.yml'
     
 
-  /schemas/credentials/ThingCredential.yml:
-    get:
-      tags:
-      - credentials
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/credentials/ThingCredential.yml'
-    
-
   /schemas/credentials/TSCACertificationCredential.yml:
     get:
       tags:
@@ -2946,6 +2934,18 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/credentials/TSCACertificationCredential.yml'
+    
+
+  /schemas/credentials/ThingCredential.yml:
+    get:
+      tags:
+      - credentials
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/credentials/ThingCredential.yml'
     
 
   /schemas/credentials/USMCACertificationOfOrigin.yml:
@@ -3008,30 +3008,6 @@ paths:
                 $ref: './components/schemas/snippets/BuyerParty.yml'
     
 
-  /schemas/snippets/carrier.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/carrier.yml'
-    
-
-  /schemas/snippets/consignee.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/consignee.yml'
-    
-
   /schemas/snippets/ConsigneeParty.yml:
     get:
       tags:
@@ -3042,30 +3018,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/snippets/ConsigneeParty.yml'
-    
-
-  /schemas/snippets/consignor.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/consignor.yml'
-    
-
-  /schemas/snippets/forwarder.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/forwarder.yml'
     
 
   /schemas/snippets/IntentToImportOrganization.yml:
@@ -3116,30 +3068,6 @@ paths:
                 $ref: './components/schemas/snippets/ManufacturerParty.yml'
     
 
-  /schemas/snippets/notify.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/notify.yml'
-    
-
-  /schemas/snippets/proof.yml:
-    get:
-      tags:
-      - snippets
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/snippets/proof.yml'
-    
-
   /schemas/snippets/SellerParty.yml:
     get:
       tags:
@@ -3162,6 +3090,78 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/snippets/ShipToParty.yml'
+    
+
+  /schemas/snippets/carrier.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/carrier.yml'
+    
+
+  /schemas/snippets/consignee.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/consignee.yml'
+    
+
+  /schemas/snippets/consignor.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/consignor.yml'
+    
+
+  /schemas/snippets/forwarder.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/forwarder.yml'
+    
+
+  /schemas/snippets/notify.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/notify.yml'
+    
+
+  /schemas/snippets/proof.yml:
+    get:
+      tags:
+      - snippets
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/snippets/proof.yml'
     
 
   /schemas/workflows/businesscard.yml:


### PR DESCRIPTION
This PR introduces a new credential TSCA Certification which is a requirement for imports of chemical substances to the US:

**Quote**:
Imports of chemical substances, mixtures or articles that contain a chemical substance or mixture must comply with the Toxic Substances Control Act (TSCA) in order to enter the U.S. Importers must certify that imported chemicals either comply with TSCA ([positive certification](https://www.epa.gov/tsca-import-export-requirements/tsca-requirements-importing-chemicals#positive)) or, if not otherwise clearly identified as a chemical excluded from TSCA, are not subject to TSCA ([negative certification](https://www.epa.gov/tsca-import-export-requirements/tsca-requirements-importing-chemicals#negative)).
**Unquote**

Ref: https://www.epa.gov/tsca-import-export-requirements/tsca-requirements-importing-chemicals

The VC reflects the required structure of the certification. 