### PR TITLE
Remove one reference sizeOrAmount

### DIFF
--- a/docs/openapi/components/schemas/common/TradeLineItem.yml
+++ b/docs/openapi/components/schemas/common/TradeLineItem.yml
@@ -140,10 +140,6 @@ properties:
         title: Category
         description: A category for the item.
         type: string
-      sizeOrAmount:
-        title: Size or Amount
-        description: The size or amount of the product
-        $ref: ./QuantitativeValue.yml
       weight:
         title: Weight
         description: Weight of the product.


### PR DESCRIPTION
This removes one reference to `sizeOrAmount` as pointed out on https://github.com/w3c-ccg/traceability-vocab/pull/629. 

However, I can't remove the actual definition on Product.yml because it is heavily references by Agri and Oil examples - beyond what I feel I should be PR'ing. I do encourage getting rid of these, though, so we can remove the poorly defined `sizeOrAmount` from Product altogether. 