### PR TITLE
Rename USDA SC-6 form

### DIFF
--- a/docs/openapi/components/schemas/common/USDASC6ExemptCommodity.yml
+++ b/docs/openapi/components/schemas/common/USDASC6ExemptCommodity.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: UsdaSc6
-  '@id': https://w3id.org/traceability#UsdaSc6
-title: USDA Form SC-6
+  term: USDASC6ExemptCommodityForm
+  '@id': https://w3id.org/traceability#USDASC6ExemptCommodityForm
+title: USDA SC-6 Exempt Commodity Form
 description: >-
   Importer's Exempt Commodity Form (SC-6) to declare the intent to import an
   agricultural commodity exempt from grade requirements for the commodity.
@@ -13,9 +13,9 @@ properties:
         items:
           type: string
           enum:
-            - UsdaSc6
+            - USDASC6ExemptCommodityForm
       - type: string
-        const: UsdaSc6
+        const: USDASC6ExemptCommodityForm
   serialNumber:
     title: Serial Number
     description: Serial number of the form.
@@ -137,7 +137,7 @@ required:
   - type
 example: |-
   {
-    "type": "UsdaSc6",
+    "type": "USDASC6ExemptCommodityForm",
     "facility": {
       "type": [
         "Place"

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -2060,6 +2060,18 @@ paths:
                 $ref: './components/schemas/common/USDAPPQ587PlantImportPermit.yml'
     
 
+  /schemas/common/USDASC6ExemptCommodity.yml:
+    get:
+      tags:
+      - common
+      responses:
+        '200':
+          content:
+            application/yml:
+              schema:
+                $ref: './components/schemas/common/USDASC6ExemptCommodity.yml'
+    
+
   /schemas/common/USDASpecialtyCrops237AForm.yml:
     get:
       tags:
@@ -2106,18 +2118,6 @@ paths:
             application/yml:
               schema:
                 $ref: './components/schemas/common/USMCAProduct.yml'
-    
-
-  /schemas/common/UsdaSc6.yml:
-    get:
-      tags:
-      - common
-      responses:
-        '200':
-          content:
-            application/yml:
-              schema:
-                $ref: './components/schemas/common/UsdaSc6.yml'
     
 
   /schemas/credentials/ActivityPubActorCard.yml:


### PR DESCRIPTION
The previous credential name, `UsdaSc6`, was uninformative and unconventional.