### PR TITLE
Rename organic certification to certificate

### DIFF
--- a/docs/openapi/components/schemas/common/OrganicCertificate.yml
+++ b/docs/openapi/components/schemas/common/OrganicCertificate.yml
@@ -1,6 +1,6 @@
 $linkedData:
-  term: OrganicCertification
-  '@id': https://w3id.org/traceability#OrganicCertification
+  term: OrganicCertificate
+  '@id': https://w3id.org/traceability#OrganicCertificate
 title: Organic Certificate
 description: Information regarding the organic certificate.
 type: object
@@ -9,13 +9,13 @@ properties:
     type: array
     readOnly: true
     const:
-      - OrganicCertification
+      - OrganicCertificate
     default:
-      - OrganicCertification
+      - OrganicCertificate
     items:
       type: string
       enum:
-        - OrganicCertification
+        - OrganicCertificate
   countryOfIssuance:
     title: Country of Issuance
     description: The country issuing the organic certificate. This value should be a two letter country code as defined in ISO 3166 (e.g., "US" for United States, "CA" for Canada).
@@ -79,7 +79,7 @@ required:
   - type
 example: |-
   {
-    "type": ["OrganicCertification"],
+    "type": ["OrganicCertificate"],
     "countryOfIssuance": "US",
     "certifiedOperation": {
       "type": ["Organization"],

--- a/docs/openapi/components/schemas/common/OrganicProductCertificate.yml
+++ b/docs/openapi/components/schemas/common/OrganicProductCertificate.yml
@@ -1,7 +1,7 @@
 $linkedData:
-  term: OrganicProductCertification
-  '@id': https://w3id.org/traceability#OrganicProductCertification
-title: Organic Product Certification
+  term: OrganicProductCertificate
+  '@id': https://w3id.org/traceability#OrganicProductCertificate
+title: Organic Product Certificate
 description: Information regarding an agriculture product's organic certification status.
 type: object
 properties:
@@ -9,13 +9,13 @@ properties:
     type: array
     readOnly: true
     const:
-      - OrganicProductCertification
+      - OrganicProductCertificate
     default:
-      - OrganicProductCertification
+      - OrganicProductCertificate
     items:
       type: string
       enum:
-        - OrganicProductCertification
+        - OrganicProductCertificate
   agricultureProduct:
     title: Agriculture Product
     description: The product certified as organic.
@@ -23,12 +23,12 @@ properties:
     $linkedData:
       term: agricultureProduct
       '@id': https://www.gs1.org/voc/certificationSubject
-  organicCertification:
+  organicCertificate:
     title: Organic Certificate
-    description: The product's organic certification.
-    $ref: ./OrganicCertification.yml
+    description: The product's organic certificate.
+    $ref: ./OrganicCertificate.yml
     $linkedData:
-      term: organicCertification
+      term: organicCertificate
       '@id': https://www.gs1.org/voc/certification
   isCertified:
     title: Is Certified
@@ -42,7 +42,7 @@ required:
   - type
 example: |-
   {
-    "type": ["OrganicProductCertification"],
+    "type": ["OrganicProductCertificate"],
     "agricultureProduct": {
       "type": [
         "AgricultureProduct"
@@ -81,8 +81,8 @@ example: |-
       "labelImageUrl": "https://img.example.org/033383401508/640/480/",
       "labelImageHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
-    "organicCertification": {
-      "type": ["OrganicCertification"],
+    "organicCertificate": {
+      "type": ["OrganicCertificate"],
       "certifiedOperation": {
         "type": ["Organization"],
         "name": "John's Produce",

--- a/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
+++ b/docs/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
@@ -1,6 +1,6 @@
 $linkedData:
-  term: OrganicCertificationCredential
-  '@id': https://w3id.org/traceability#OrganicCertificationCredential
+  term: OrganicCertificateCredential
+  '@id': https://w3id.org/traceability#OrganicCertificateCredential
 title: Organic Certificate Credential
 tags:
   - Agriculture
@@ -35,15 +35,15 @@ properties:
     readOnly: true
     const:
       - VerifiableCredential
-      - OrganicCertificationCredential
+      - OrganicCertificateCredential
     default:
       - VerifiableCredential
-      - OrganicCertificationCredential
+      - OrganicCertificateCredential
     items:
       type: string
       enum:
         - VerifiableCredential
-        - OrganicCertificationCredential
+        - OrganicCertificateCredential
   id:
     type: string
   name:
@@ -64,15 +64,15 @@ properties:
         description: The url of the schema file to validate the shape of the json object
         type: string
         format: uri
-        example: https://w3id.org/traceability/openapi/components/schemas/credentials/OrganicCertificationCredential.yml
-        default: https://w3id.org/traceability/openapi/components/schemas/credentials/OrganicCertificationCredential.yml
+        example: https://w3id.org/traceability/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/OrganicCertificateCredential.yml
         readOnly: true
       type:
         title: Type
         description: The type of validation to be run against the defined schema
         const: OpenApiSpecificationValidator2022
   credentialSubject:
-    $ref: ../common/OrganicCertification.yml
+    $ref: ../common/OrganicCertificate.yml
   proof:
     $ref: ../snippets/proof.yml
   relatedLink:
@@ -97,7 +97,7 @@ example: |-
     "id": "https://example.com/credential/123",
     "type": [
       "VerifiableCredential",
-      "OrganicCertificationCredential"
+      "OrganicCertificateCredential"
     ],
     "name": "Organic Certificate Credential",
     "issuanceDate": "2021-12-11T03:50:55Z",
@@ -129,7 +129,7 @@ example: |-
     },
     "credentialSubject": {
       "type": [
-        "OrganicCertification"
+        "OrganicCertificate"
       ],
       "countryOfIssuance": "US",
       "certifiedOperation": {

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -1304,7 +1304,7 @@ paths:
                 $ref: './components/schemas/common/OrderItem.yml'
     
 
-  /schemas/common/OrganicCertification.yml:
+  /schemas/common/OrganicCertificate.yml:
     get:
       tags:
       - common
@@ -1313,7 +1313,7 @@ paths:
           content:
             application/yml:
               schema:
-                $ref: './components/schemas/common/OrganicCertification.yml'
+                $ref: './components/schemas/common/OrganicCertificate.yml'
     
 
   /schemas/common/OrganicInspection.yml:
@@ -1340,7 +1340,7 @@ paths:
                 $ref: './components/schemas/common/OrganicOSPSectionReview.yml'
     
 
-  /schemas/common/OrganicProductCertification.yml:
+  /schemas/common/OrganicProductCertificate.yml:
     get:
       tags:
       - common
@@ -1349,7 +1349,7 @@ paths:
           content:
             application/yml:
               schema:
-                $ref: './components/schemas/common/OrganicProductCertification.yml'
+                $ref: './components/schemas/common/OrganicProductCertificate.yml'
     
 
   /schemas/common/OrganicReview.yml:


### PR DESCRIPTION
* OrganicCertification to OrganicCertificate
* OrganicProductCertification to OrganicProductCertificate

There are some cases where it's less certain whether certificate or certification is appropriate, but in general I believe it makes more sense to use certificate when referring to credentials:
* Consistent with most use cases within vocab
* In general "certification" = act of certifying, "certificate" = proof of certification