### PR TITLE
Clean up date and datetime usage

### DIFF
--- a/docs/openapi/components/schemas/common/AgricultureActivity.yml
+++ b/docs/openapi/components/schemas/common/AgricultureActivity.yml
@@ -47,7 +47,8 @@ properties:
     type: string
     $linkedData:
       term: activityDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date     
   activityType:
     title: Activity Type
     description: Type of Activity, e.g., plant, harvest, spray.

--- a/docs/openapi/components/schemas/common/AgricultureInspectionCommonInfo.yml
+++ b/docs/openapi/components/schemas/common/AgricultureInspectionCommonInfo.yml
@@ -61,6 +61,7 @@ properties:
     $linkedData:
       term: inspectionStarted
       '@id': https://schema.org/startDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   inspectionEnded:
     title: Inspection Ended
     description: Date and time inspection ended in ISO 8601 format (e.g. 1970-01-01T00:00Z for UTC, or 1970:01:01T00:00-5:00 for New York on standard time).
@@ -68,6 +69,7 @@ properties:
     $linkedData:
       term: inspectionEnded
       '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
 additionalProperties: false
 required:
   - type

--- a/docs/openapi/components/schemas/common/AgriculturePackage.yml
+++ b/docs/openapi/components/schemas/common/AgriculturePackage.yml
@@ -61,7 +61,8 @@ properties:
     type: string
     $linkedData:
       term: packingDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   harvestDate:
     title: Harvest Date
     description: >-
@@ -69,7 +70,8 @@ properties:
     type: string
     $linkedData:
       term: harvestDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   bestByDate:
     title: Best By Date
     description: >-
@@ -77,7 +79,8 @@ properties:
     type: string
     $linkedData:
       term: bestByDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   labelImageUrl:
     title: Label Image URL
     description: Image of the package label

--- a/docs/openapi/components/schemas/common/AgricultureParcelDelivery.yml
+++ b/docs/openapi/components/schemas/common/AgricultureParcelDelivery.yml
@@ -65,6 +65,7 @@ properties:
     $linkedData:
       term: expectedArrival
       '@id': https://schema.org/expectedArrivalFrom
+      '@type': http://www.w3.org/2001/XMLSchema#date
   specialInstructions:
     title: Special Instructions
     description: Instructions for freight handlers

--- a/docs/openapi/components/schemas/common/CBPEntry.yml
+++ b/docs/openapi/components/schemas/common/CBPEntry.yml
@@ -261,6 +261,7 @@ properties:
     $linkedData:
       term: arrivalDate
       '@id': https://vocabulary.uncefact.org/actualArrivalRelatedDateTime
+      '@type': http://www.w3.org/2001/XMLSchema#date
 additionalProperties: false
 required:
   - type

--- a/docs/openapi/components/schemas/common/CBPEntryLineItem.yml
+++ b/docs/openapi/components/schemas/common/CBPEntryLineItem.yml
@@ -48,7 +48,8 @@ properties:
     type: string
     $linkedData:
       term: freeTradeZoneFilingDate
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   freeTradeZoneStatus:
     title: Free Trade Zone Status
     description: For Entry type 06, select P for Privileged Foreign or N for Non-privileged Foreign. For all other entry types leave blank

--- a/docs/openapi/components/schemas/common/CBPEntrySummary.yml
+++ b/docs/openapi/components/schemas/common/CBPEntrySummary.yml
@@ -58,7 +58,8 @@ properties:
     type: string
     $linkedData:
       term: summaryDate
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   suretyCode:
     title: Surety Code
     description: Provide the surety code. The surety code identifies the surety company, authorized by the Department of the Treasury. 
@@ -86,7 +87,8 @@ properties:
     type: string
     $linkedData:
       term: entryDate
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   importingCarrier:
     title: Importing Carrier
     description: For merchandise arriving in the U.S. by vessel, record the name of the vessel that transported the merchandise from the foreign port of lading to the first U.S. port of unlading. Do not record the vessel identifier code in lieu of the vessel name. Pursuant to General Statistical Note 1 (a) (ii) of the HTS, the reporting of the vessel flag is not required. For merchandise arriving in the U.S. by air, record the two digit IATA alpha code corresponding to the name of the airline which transported the merchandise from the last airport of foreign lading to the first U.S. airport of unlading. If the carrier file does not contain a specific air carrier's code, write the designation "*C" for Canadian airlines, "*F" for other foreign airlines, and "*U" for U.S. airlines. These designations should be used only for unknown charter and private aircraft. When a private aircraft is being entered under its own power (ferried), the designation "**" will be used. For merchandise arriving in the U.S. by means of transportation other than vessel or air, leave blank. Do not record the name of a domestic carrier transporting merchandise after initial lading in the U.S. For merchandise arriving in the customs territory from a U.S. Foreign Trade Zone (FTZ), insert "FTZ" followed by the FTZ number. Use the following format FTZ NNNN.
@@ -115,7 +117,8 @@ properties:
     type: string
     $linkedData:
       term: importDate
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   billOfLadingNumber:
     title: Bill of Lading Number
     description: Bill of Lading or Waybill number.
@@ -144,7 +147,8 @@ properties:
     type: string
     $linkedData:
       term: exportDate
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   immediateTransportationNumber: 
     title: Immediate Transportation Number
     description: Record the IT number obtained from the CBP Form 7512, AWB number from the Transit Air Cargo Manifest (TACM), or Automated Manifest System (AMS) master in-bond (MIB) movement number. 
@@ -158,7 +162,8 @@ properties:
     type: string
     $linkedData:
       term: immediateTransportationDate
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   missingDocuments: 
     title: Missing Documents
     description: Record the appropriate document code number(s) to indicate documents not available at the time of filing the entry summary. A maximum of two codes may be used. The bond charge should be made on the entry summary only for those documents required to be filed with the entry summary.

--- a/docs/openapi/components/schemas/common/CTPAT.yml
+++ b/docs/openapi/components/schemas/common/CTPAT.yml
@@ -298,7 +298,8 @@ properties:
     type: string
     $linkedData:
       term: dateOfLastValidation
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   issuingCountry:
     title: Issuing Country
     description: >-

--- a/docs/openapi/components/schemas/common/DCSATransportDocument.yml
+++ b/docs/openapi/components/schemas/common/DCSATransportDocument.yml
@@ -49,6 +49,7 @@ properties:
       term: issueDate
       '@id': >-
         https://vocabulary.uncefact.org/issueDateTime
+      '@type': http://www.w3.org/2001/XMLSchema#date
   shippedOnBoardDate:
     title: Shipped On Board Date
     description: >-
@@ -59,6 +60,7 @@ properties:
       term: shippedOnBoardDate
       '@id': >-
         https://api.swaggerhub.com/domains/dcsaorg/DCSA_DOMAIN/1.0.2#/components/schemas/shippedOnBoardDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   receivedForShipmentDate:
     title: Received For Shipment Date
     description: >-
@@ -70,6 +72,7 @@ properties:
       term: receivedForShipmentDate
       '@id': >-
         https://vocabulary.uncefact.org/availabilityDueDateTime
+      '@type': http://www.w3.org/2001/XMLSchema#date
   termsAndConditions:
     title: Terms And Conditions
     description: Carrier general terms and conditions for this transport document.

--- a/docs/openapi/components/schemas/common/DeliverySchedule.yml
+++ b/docs/openapi/components/schemas/common/DeliverySchedule.yml
@@ -81,6 +81,7 @@ properties:
     $linkedData:
       term: scheduledDate
       '@id': https://schema.org/departureTime
+      '@type': http://www.w3.org/2001/XMLSchema#date
   injectionVolume:
     title: Injection Volume
     description: Volume of the shipped commodities at the begining of the transportation event
@@ -97,6 +98,7 @@ properties:
     $linkedData:
       term: injectionDate
       '@id': https://schema.org/departureTime
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   injectionEndDate:
     title: Injection End Date
     description: The planned time for crude oil injection to end
@@ -104,6 +106,7 @@ properties:
     $linkedData:
       term: injectionEndDate
       '@id': https://schema.org/departureTime
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   deliveryStartDate:
     title: Delivery Start Date
     description: The planned time for crude oil delivery to start
@@ -111,6 +114,7 @@ properties:
     $linkedData:
       term: deliveryDate
       '@id': https://schema.org/arrivalTime
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   deliveryEndDate:
     title: Delivery End Date
     description: The planned time for crude oil delivery to end
@@ -118,6 +122,7 @@ properties:
     $linkedData:
       term: deliveryEndDate
       '@id': https://schema.org/arrivalTime
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   portOfEntry:
     title: Port of Entry
     description: The port where the commodity crosses the border.

--- a/docs/openapi/components/schemas/common/DeliveryStatement.yml
+++ b/docs/openapi/components/schemas/common/DeliveryStatement.yml
@@ -29,7 +29,8 @@ properties:
     type: string
     $linkedData:
       term: deliveredDate
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   deliveredVolume:
     title: deliveredVolume
     description: Volume of the item being delivered

--- a/docs/openapi/components/schemas/common/EDDShape.yml
+++ b/docs/openapi/components/schemas/common/EDDShape.yml
@@ -72,6 +72,7 @@ properties:
     $linkedData:
       term: observationDate
       '@id': http://rs.tdwg.org/dwc/terms/eventDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   dateEntered:
     title: Date Entered
     description: Date record is entered into the database.
@@ -79,6 +80,7 @@ properties:
     $linkedData:
       term: dateEntered
       '@id': http://rs.tdwg.org/dwc/terms/eventDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   dateUpdated:
     title: Date Updated
     description: Date record information was updated.
@@ -86,6 +88,7 @@ properties:
     $linkedData:
       term: dateUpdated
       '@id': http://rs.tdwg.org/dwc/terms/eventDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   location:
     title: Location
     description: County, State, and Country in which the subject was recorded.
@@ -256,6 +259,7 @@ properties:
     $linkedData:
       term: uuid
       '@id': http://rs.tdwg.org/dwc/terms/dateIdentified
+      '@type': http://www.w3.org/2001/XMLSchema#date
   reviewer:
     title: Reviewer
     description: Name of Reviewer.

--- a/docs/openapi/components/schemas/common/Event.yml
+++ b/docs/openapi/components/schemas/common/Event.yml
@@ -52,7 +52,8 @@ properties:
     type: string
     $linkedData:
       term: eventTime
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endTime
+      '@type': http://www.w3.org/2001/XMLSchema#time     
   products:
     title: Products
     description: The products referenced by the event in hashlinks.

--- a/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
@@ -38,6 +38,7 @@ properties:
     $linkedData:
       term: dateCompleted
       '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
+++ b/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
@@ -55,6 +55,7 @@ properties:
     $linkedData:
       term: coolingDate
       '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   packingLocation:
     title: Packing Location
     description: Where the food was packed.
@@ -69,6 +70,7 @@ properties:
     $linkedData:
       term: packingDate
       '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
@@ -33,6 +33,7 @@ properties:
     $linkedData:
       term: dateReceived
       '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FSMAShippingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAShippingCTE.yml
@@ -33,6 +33,7 @@ properties:
     $linkedData:
       term: dateShipped
       '@id': https://schema.org/startDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
@@ -47,6 +47,7 @@ properties:
     $linkedData:
       term: dateCompleted
       '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   additionalData:
     title: Additional Data
     description: Additional Key Data Elements (KDEs).

--- a/docs/openapi/components/schemas/common/FoodDefenseDeficiency.yml
+++ b/docs/openapi/components/schemas/common/FoodDefenseDeficiency.yml
@@ -37,6 +37,7 @@ properties:
     $linkedData:
       term: proposedCorrectionDate
       '@id': https://vocabulary.uncefact.org/occurrenceDateTime
+      '@type': http://www.w3.org/2001/XMLSchema#date
   dateCorrected:
     title: Date Corrected
     description: The actual date corrected.
@@ -44,6 +45,7 @@ properties:
     $linkedData:
       term: dateCorrected
       '@id': https://vocabulary.uncefact.org/occurrenceDateTime
+      '@type': http://www.w3.org/2001/XMLSchema#date
 additionalProperties: false
 required:
   - type

--- a/docs/openapi/components/schemas/common/GAPInspection.yml
+++ b/docs/openapi/components/schemas/common/GAPInspection.yml
@@ -185,6 +185,7 @@ properties:
     $linkedData:
       term: dateReviewed
       '@id': https://www.gs1.org/voc/certificationAuditDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   meetsCriteria:
     title: Meets Criteria
     description: Audit Results meets USDA Acceptance Criteria

--- a/docs/openapi/components/schemas/common/IATAAirWaybill.yml
+++ b/docs/openapi/components/schemas/common/IATAAirWaybill.yml
@@ -175,7 +175,7 @@ properties:
     $linkedData:
       term: requestedDate
       '@id': https://w3id.org/traceability#requestDate
-      '@type': http://www.w3.org/2001/XMLSchema#dateTime     
+      '@type': http://www.w3.org/2001/XMLSchema#date
   accountingInformation:
     title: Accounting Information
     description: >-

--- a/docs/openapi/components/schemas/common/Inbond.yml
+++ b/docs/openapi/components/schemas/common/Inbond.yml
@@ -113,7 +113,8 @@ properties:
     type: string
     $linkedData:
       term: expectedDeliveryDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date     
   valuePerItem:
     title: Value Per Item
     description: Total Value Per Item

--- a/docs/openapi/components/schemas/common/IntentToImport.yml
+++ b/docs/openapi/components/schemas/common/IntentToImport.yml
@@ -53,6 +53,7 @@ properties:
     $linkedData:
       term: declarationDate
       '@id': https://schema.org/startDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
 additionalProperties: false
 required:
   - type

--- a/docs/openapi/components/schemas/common/Invoice.yml
+++ b/docs/openapi/components/schemas/common/Invoice.yml
@@ -89,6 +89,7 @@ properties:
     $linkedData:
       term: invoiceDate
       '@id': https://vocabulary.uncefact.org/invoiceDateTime
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   purchaseDate:
     title: Purchase Date
     description: The date that payment is made.

--- a/docs/openapi/components/schemas/common/LEIentity.yml
+++ b/docs/openapi/components/schemas/common/LEIentity.yml
@@ -98,6 +98,7 @@ properties:
     $linkedData:
       term: expirationDate
       '@id': https://schema.org/expires
+      '@type': http://www.w3.org/2001/XMLSchema#date
   expirationReason:
     title: ExpirationReason
     type: string

--- a/docs/openapi/components/schemas/common/LEIregistration.yml
+++ b/docs/openapi/components/schemas/common/LEIregistration.yml
@@ -22,12 +22,14 @@ properties:
     $linkedData:
       term: initialRegistrationDate
       '@id': https://schema.org/dateIssued
+      '@type': http://www.w3.org/2001/XMLSchema#date
   lastUpdateDate:
     title: Lastupdatedate
     type: string
     $linkedData:
       term: lastUpdateDate
       '@id': https://schema.org/dateModified
+      '@type': http://www.w3.org/2001/XMLSchema#date
   status:
     title: Status
     type: string
@@ -40,6 +42,7 @@ properties:
     $linkedData:
       term: nextRenewalDate
       '@id': https://schema.org/validThrough
+      '@type': http://www.w3.org/2001/XMLSchema#date
   managingLou:
     title: Managinglou
     type: string

--- a/docs/openapi/components/schemas/common/MasterBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MasterBillOfLading.yml
@@ -202,7 +202,8 @@ properties:
     type: string
     $linkedData:
       term: shippedOnBoardDate
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   termsAndConditions:
     title: Terms And Conditions
     description: Carrier general terms and conditions for this transport document.

--- a/docs/openapi/components/schemas/common/MonthlyAdvanceManifest.yml
+++ b/docs/openapi/components/schemas/common/MonthlyAdvanceManifest.yml
@@ -22,7 +22,8 @@ properties:
     type: string
     $linkedData:
       term: date
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   scheduledDeliveries:
     title: scheduledDeliveries
     description: Scheduled deliveries for the upcoming month

--- a/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
+++ b/docs/openapi/components/schemas/common/MultiModalBillOfLading.yml
@@ -204,7 +204,8 @@ properties:
     type: string
     $linkedData:
       term: shippedOnBoardDate
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   termsAndConditions:
     title: Terms And Conditions
     description: Carrier general terms and conditions for this transport document.

--- a/docs/openapi/components/schemas/common/NAISMADateTime.yml
+++ b/docs/openapi/components/schemas/common/NAISMADateTime.yml
@@ -22,7 +22,8 @@ properties:
     type: string
     $linkedData:
       term: collectionDate
-      '@id': http://rs.tdwg.org/dwc/terms/eventDate
+      '@id': http://rs.tdwg.org/dwc/terms/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   dateAccuracyDays:
     title: Date Accuracy in Days
     description: The range of days within which the data was collected.

--- a/docs/openapi/components/schemas/common/Observation.yml
+++ b/docs/openapi/components/schemas/common/Observation.yml
@@ -39,6 +39,7 @@ properties:
     $linkedData:
       term: date
       '@id': https://schema.org/observationDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
 additionalProperties: false
 required:
   - type

--- a/docs/openapi/components/schemas/common/OilAndGasDeliveryTicket.yml
+++ b/docs/openapi/components/schemas/common/OilAndGasDeliveryTicket.yml
@@ -24,6 +24,7 @@ properties:
     $linkedData:
       term: createdDate
       '@id': https://schema.org/dateIssued
+      '@type': http://www.w3.org/2001/XMLSchema#date
   openDate:
     title: Open Date
     description: Starting date of the oil delivery process
@@ -31,6 +32,7 @@ properties:
     $linkedData:
       term: openDate
       '@id': https://schema.org/startDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   closeDate:
     title: Close Date
     description: Date of ending the oil delivery process
@@ -38,6 +40,7 @@ properties:
     $linkedData:
       term: closeDate
       '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   carrier:
     title: Carrier
     description: >-

--- a/docs/openapi/components/schemas/common/OilAndGasProduct.yml
+++ b/docs/openapi/components/schemas/common/OilAndGasProduct.yml
@@ -43,7 +43,8 @@ properties:
     type: string
     $linkedData:
       term: productionDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date     
   observation:
     title: Observation List
     description: >-

--- a/docs/openapi/components/schemas/common/OrganicCertificate.yml
+++ b/docs/openapi/components/schemas/common/OrganicCertificate.yml
@@ -44,6 +44,7 @@ properties:
     $linkedData:
       term: effectiveDate
       '@id': https://www.gs1.org/voc/certificationStartDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   issueDate:
     title: Applicant Certification Number
     description: When the certifying agent issued the organic certificate.
@@ -51,6 +52,7 @@ properties:
     $linkedData:
       term: issueDate
       '@id': https://www.gs1.org/voc/initialCertificationDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   anniversaryDate:
     title: Applicant Certification Number
     description: When the certified operation must submit its annual update.
@@ -58,6 +60,7 @@ properties:
     $linkedData:
       term: anniversaryDate
       '@id': https://www.gs1.org/voc/certificationEndDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   operationCategory:
     title: Operation Category
     description: Options are "crops", "wild crops", "livestock", and "handling/processing".

--- a/docs/openapi/components/schemas/common/Phytosanitary.yml
+++ b/docs/openapi/components/schemas/common/Phytosanitary.yml
@@ -114,7 +114,8 @@ properties:
     type: string
     $linkedData:
       term: signatureDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date     
   facility:
     title: Facility
     description: Information on the inspection facility.
@@ -161,7 +162,8 @@ properties:
     type: string
     $linkedData:
       term: inspectionDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date     
   inspectionType:
     title: Inspection Type
     description: Type of Inspection.

--- a/docs/openapi/components/schemas/common/SeaCargoManifest.yml
+++ b/docs/openapi/components/schemas/common/SeaCargoManifest.yml
@@ -50,14 +50,16 @@ properties:
     type: string
     $linkedData:
       term: plannedDepartureDateTime
-      '@id': https://schema.org/Date
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   plannedArrivalDateTime:
     title: Planned Arrival Date and Time
     description: The planned date and time of arrival.
     type: string
     $linkedData:
       term: plannedArrivalDateTime
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   portOfDeparture:
     title: Port of Departure
     $ref: ./Place.yml

--- a/docs/openapi/components/schemas/common/USDASC6ExemptCommodity.yml
+++ b/docs/openapi/components/schemas/common/USDASC6ExemptCommodity.yml
@@ -105,13 +105,15 @@ properties:
     $linkedData:
       term: importerSignatureDate
       '@id': https://w3id.org/traceability#importerSignatureDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   inspectionDate:
     title: Inspection Date
     description: Date of the completed inspection.
     type: string
     $linkedData:
       term: inspectionDate
-      '@id': https://schema.org/DateTime
+      '@id': https://schema.org/endDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   intendedUse:
     title: Intended Use
     description: >-

--- a/docs/openapi/components/schemas/common/USDASpecialtyCrops237AForm.yml
+++ b/docs/openapi/components/schemas/common/USDASpecialtyCrops237AForm.yml
@@ -23,6 +23,7 @@ properties:
     $linkedData:
       term: requestDate
       '@id': https://vocabulary.uncefact.org/reportSubmissionDateTime
+      '@type': http://www.w3.org/2001/XMLSchema#date
   anticipatedAuditDate:
     title: Anticipated Audit Date
     description: Anticipated date of the audit.
@@ -30,6 +31,7 @@ properties:
     $linkedData:
       term: anticipatedAuditDate
       '@id': https://www.gs1.org/voc/certificationAuditDate
+      '@type': http://www.w3.org/2001/XMLSchema#date
   auditee:
     title: Auditee
     description: The party to be audited.


### PR DESCRIPTION
This PR updates term IDs which refer to date/datetime/time as discussed in https://github.com/w3c-ccg/traceability-vocab/issues/593, and also adds appropriate XSD datatypes for additional clarity (as in many cases otherwise relevant term IDs aren't good indicators of the actual type expected) as suggested in https://github.com/w3c-ccg/traceability-vocab/issues/213.

NOTE: in a lot of cases I used https://schema.org/endDate as the term ID. There isn't a property https://schema.org/date, and I think it's fine to have the implication that, in any case where an activity takes some significant duration of time (like harvesting or inspection), the relevant date/datetime should be when the activity is finished. In a few cases where it's clear the property refers to a start of an activity I used https://schema.org/startDate.

Further discussion of XSD datatypes:
https://github.com/schemaorg/schemaorg/issues/1781
https://github.com/schemaorg/schemaorg/issues/1748