### PR TITLE
feat: replace endDate instances with more specific terms

### DIFF
--- a/docs/openapi/components/schemas/common/AgricultureInspectionCommonInfo.yml
+++ b/docs/openapi/components/schemas/common/AgricultureInspectionCommonInfo.yml
@@ -60,7 +60,7 @@ properties:
     type: string
     $linkedData:
       term: inspectionStarted
-      '@id': https://schema.org/startDate
+      '@id': https://vocabulary.uncefact.org/startDateTime
       '@type': http://www.w3.org/2001/XMLSchema#dateTime
   inspectionEnded:
     title: Inspection Ended
@@ -68,7 +68,7 @@ properties:
     type: string
     $linkedData:
       term: inspectionEnded
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/endDateTime
       '@type': http://www.w3.org/2001/XMLSchema#dateTime
 additionalProperties: false
 required:

--- a/docs/openapi/components/schemas/common/AgriculturePackage.yml
+++ b/docs/openapi/components/schemas/common/AgriculturePackage.yml
@@ -61,7 +61,7 @@ properties:
     type: string
     $linkedData:
       term: packingDate
-      '@id': https://schema.org/endDate
+      '@id': https://www.gs1.org/voc/packagingDate
       '@type': http://www.w3.org/2001/XMLSchema#date
   harvestDate:
     title: Harvest Date
@@ -70,7 +70,7 @@ properties:
     type: string
     $linkedData:
       term: harvestDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/harvestDateTime
       '@type': http://www.w3.org/2001/XMLSchema#date
   bestByDate:
     title: Best By Date
@@ -79,7 +79,7 @@ properties:
     type: string
     $linkedData:
       term: bestByDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/bestBeforeDateTime
       '@type': http://www.w3.org/2001/XMLSchema#date
   labelImageUrl:
     title: Label Image URL

--- a/docs/openapi/components/schemas/common/CBPEntrySummary.yml
+++ b/docs/openapi/components/schemas/common/CBPEntrySummary.yml
@@ -58,7 +58,7 @@ properties:
     type: string
     $linkedData:
       term: summaryDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/submissionDateTime
       '@type': http://www.w3.org/2001/XMLSchema#date
   suretyCode:
     title: Surety Code
@@ -87,7 +87,7 @@ properties:
     type: string
     $linkedData:
       term: entryDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/jurisdictionEntryDateTime
       '@type': http://www.w3.org/2001/XMLSchema#date
   importingCarrier:
     title: Importing Carrier
@@ -117,7 +117,7 @@ properties:
     type: string
     $linkedData:
       term: importDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/arrivalRelatedDateTime
       '@type': http://www.w3.org/2001/XMLSchema#date
   billOfLadingNumber:
     title: Bill of Lading Number
@@ -147,7 +147,7 @@ properties:
     type: string
     $linkedData:
       term: exportDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/departureRelatedDateTime
       '@type': http://www.w3.org/2001/XMLSchema#date
   immediateTransportationNumber: 
     title: Immediate Transportation Number
@@ -162,7 +162,7 @@ properties:
     type: string
     $linkedData:
       term: immediateTransportationDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/actualOccurrenceDateTime
       '@type': http://www.w3.org/2001/XMLSchema#date
   missingDocuments: 
     title: Missing Documents

--- a/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMACreatingCTE.yml
@@ -37,7 +37,7 @@ properties:
     type: string
     $linkedData:
       term: dateCompleted
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/creationDateTime
       '@type': http://www.w3.org/2001/XMLSchema#dateTime
   additionalData:
     title: Additional Data

--- a/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
+++ b/docs/openapi/components/schemas/common/FSMAFirstReceiverData.yml
@@ -40,7 +40,8 @@ properties:
     type: string
     $linkedData:
       term: harvestDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/harvestDateTime
+      '@type': http://www.w3.org/2001/XMLSchema#dateTime
   coolingLocation:
     title: Cooling location
     description: Where the food was cooled.
@@ -54,7 +55,7 @@ properties:
     type: string
     $linkedData:
       term: coolingDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/actualOccurrenceDateTime
       '@type': http://www.w3.org/2001/XMLSchema#dateTime
   packingLocation:
     title: Packing Location
@@ -69,7 +70,7 @@ properties:
     type: string
     $linkedData:
       term: packingDate
-      '@id': https://schema.org/endDate
+      '@id': https://www.gs1.org/voc/packagingDate
       '@type': http://www.w3.org/2001/XMLSchema#dateTime
   additionalData:
     title: Additional Data

--- a/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMAReceivingCTE.yml
@@ -32,7 +32,7 @@ properties:
     type: string
     $linkedData:
       term: dateReceived
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/receivedDateTime
       '@type': http://www.w3.org/2001/XMLSchema#dateTime
   additionalData:
     title: Additional Data

--- a/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
+++ b/docs/openapi/components/schemas/common/FSMATransformingCTE.yml
@@ -46,7 +46,7 @@ properties:
     type: string
     $linkedData:
       term: dateCompleted
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/occurrenceDateTime
       '@type': http://www.w3.org/2001/XMLSchema#dateTime
   additionalData:
     title: Additional Data

--- a/docs/openapi/components/schemas/common/Phytosanitary.yml
+++ b/docs/openapi/components/schemas/common/Phytosanitary.yml
@@ -114,7 +114,7 @@ properties:
     type: string
     $linkedData:
       term: signatureDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/signedDateTime
       '@type': http://www.w3.org/2001/XMLSchema#date     
   facility:
     title: Facility
@@ -162,7 +162,7 @@ properties:
     type: string
     $linkedData:
       term: inspectionDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/inspectionDateTime
       '@type': http://www.w3.org/2001/XMLSchema#date     
   inspectionType:
     title: Inspection Type

--- a/docs/openapi/components/schemas/common/SeaCargoManifest.yml
+++ b/docs/openapi/components/schemas/common/SeaCargoManifest.yml
@@ -50,7 +50,7 @@ properties:
     type: string
     $linkedData:
       term: plannedDepartureDateTime
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/scheduledDepartureRelatedDateTime
       '@type': http://www.w3.org/2001/XMLSchema#dateTime
   plannedArrivalDateTime:
     title: Planned Arrival Date and Time
@@ -58,7 +58,7 @@ properties:
     type: string
     $linkedData:
       term: plannedArrivalDateTime
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/scheduledArrivalRelatedDateTime
       '@type': http://www.w3.org/2001/XMLSchema#dateTime
   portOfDeparture:
     title: Port of Departure

--- a/docs/openapi/components/schemas/common/USDAPPQ449RTemperatureCalibration.yml
+++ b/docs/openapi/components/schemas/common/USDAPPQ449RTemperatureCalibration.yml
@@ -36,7 +36,7 @@ properties:
     type: string
     $linkedData:
       term: inspectionDate
-      '@id': https://vocabulary.uncefact.org/performanceDateTime
+      '@id': https://vocabulary.uncefact.org/inspectionDateTime
   inspectionPoint:
     title: Point of Inspection
     description: The location at which the inspection occurs.

--- a/docs/openapi/components/schemas/common/USDASC6ExemptCommodity.yml
+++ b/docs/openapi/components/schemas/common/USDASC6ExemptCommodity.yml
@@ -112,7 +112,7 @@ properties:
     type: string
     $linkedData:
       term: inspectionDate
-      '@id': https://schema.org/endDate
+      '@id': https://vocabulary.uncefact.org/inspectionDateTime
       '@type': http://www.w3.org/2001/XMLSchema#date
   intendedUse:
     title: Intended Use


### PR DESCRIPTION
This PR addresses the concerns raised in https://github.com/w3c-ccg/traceability-vocab/issues/892

Note that this leaves a number of`http://schema.org/endDate` instances where they are not in conflict with other `endDate` terms IDs within the same schema. I did try to replace `endDate` where I found a more fitting/specific term, though.