### PR TITLE
Remove unneeded legalNameLanguage property

### DIFF
--- a/docs/openapi/components/schemas/common/LEIEntity.yml
+++ b/docs/openapi/components/schemas/common/LEIEntity.yml
@@ -22,12 +22,6 @@ properties:
     $linkedData:
       term: legalName
       '@id': https://schema.org/legalName
-  legalNameLanguage:
-    title: Language
-    type: string
-    $linkedData:
-      term: legalNameLanguage
-      '@id': https://schema.org/Language
   otherNames:
     title: Othernames
     type: array
@@ -141,7 +135,6 @@ example: |-
   {
     "type": ["LEIEntity"],
     "legalName": "Dicki Group",
-    "legalNameLanguage": "cz",
     "otherNames": [
       "Baumbach, Wunsch and Reichel",
       "Kilback, Schaden and Gerhold"

--- a/docs/openapi/components/schemas/common/WebLEI.yml
+++ b/docs/openapi/components/schemas/common/WebLEI.yml
@@ -56,7 +56,6 @@ example: |-
     "entity": {
       "type": ["LEIEntity"],
       "legalName": "Bashirian, Botsford and Hilll",
-      "legalNameLanguage": "tr",
       "otherNames": [
         "Waelchi - Sipes",
         "Goodwin Group"

--- a/docs/openapi/components/schemas/common/WebLEI.yml
+++ b/docs/openapi/components/schemas/common/WebLEI.yml
@@ -55,7 +55,7 @@ example: |-
     "lei": "1GS89XTLP3YKEINUGJM9",
     "entity": {
       "type": ["LEIEntity"],
-      "legalName": "Bashirian, Botsford and Hilll",
+      "legalName": "Bashirian, Botsford, and Hill",
       "otherNames": [
         "Waelchi - Sipes",
         "Goodwin Group"


### PR DESCRIPTION
This PR removes an unneeded property from LEIEntity, as discussed in https://github.com/w3c-ccg/traceability-vocab/issues/947