### PR TITLE
WebLEI credential

### DIFF
--- a/docs/credentials-with-issuer-dependent-terms.json
+++ b/docs/credentials-with-issuer-dependent-terms.json
@@ -4,6 +4,10 @@
     "count": 17
   },
   {
+    "type": "WebLeiCredential",
+    "count": 28
+  },
+  {
     "type": "VerifiableScorecard",
     "count": 144
   },

--- a/docs/openapi/components/schemas/common/LEIAddress.yml
+++ b/docs/openapi/components/schemas/common/LEIAddress.yml
@@ -86,9 +86,6 @@ properties:
 additionalProperties: false
 required:
   - type
-  - firstAddressLine
-  - city
-  - country
 example: |-
   {
     "type": ["LEIAddress"],

--- a/docs/openapi/components/schemas/common/LEIAuthority.yml
+++ b/docs/openapi/components/schemas/common/LEIAuthority.yml
@@ -36,7 +36,7 @@ properties:
       '@id': https://schema.org/leiCode
   id:
     title: Issuer's Identifier
-    description: Issuing organization identifier, typically a Decentralized Identifier (DID).
+    description: Identifier of the issuing organization , typically a Decentralized Identifier (DID).
     type: string
     format: uri
   name:

--- a/docs/openapi/components/schemas/common/LEIAuthority.yml
+++ b/docs/openapi/components/schemas/common/LEIAuthority.yml
@@ -41,7 +41,7 @@ properties:
     format: uri
   name:
     title: Name
-    description: Issuing organization name.
+    description: Name of the issuing organization.
     type: string
 additionalProperties: false
 required:

--- a/docs/openapi/components/schemas/common/LEIAuthority.yml
+++ b/docs/openapi/components/schemas/common/LEIAuthority.yml
@@ -34,12 +34,18 @@ properties:
     $linkedData:
       term: validationAuthorityEntityID
       '@id': https://schema.org/leiCode
+  id:
+    title: Issuer's Identifier
+    description: Issuing organization identifier, typically a Decentralized Identifier (DID).
+    type: string
+    format: uri
+  name:
+    title: Name
+    description: Issuing organization name.
+    type: string
 additionalProperties: false
 required:
   - type
-  - validationAuthorityID
-  - otherValidationAuthorityID
-  - validationAuthorityEntityID
 example: |-
   {
     "type": ["LEIAuthority"],

--- a/docs/openapi/components/schemas/common/WebLEI.yml
+++ b/docs/openapi/components/schemas/common/WebLEI.yml
@@ -48,7 +48,6 @@ required:
   - lei
   - entity
   - registration
-  - bic
 example: |-
   {
     "type": ["WebLEI"],

--- a/docs/openapi/components/schemas/credentials/QualifiedWebLeiIssuerCredential.yml
+++ b/docs/openapi/components/schemas/credentials/QualifiedWebLeiIssuerCredential.yml
@@ -64,7 +64,7 @@ properties:
             - LEIAuthority
       id:
         title: Issuer's Identifier
-        description: Issuing organization identifier, typically a Decentralized Identifier (DID).
+        description: Identifier of the issuing organization, typically a Decentralized Identifier (DID).
         type: string
         format: uri
       name:

--- a/docs/openapi/components/schemas/credentials/QualifiedWebLeiIssuerCredential.yml
+++ b/docs/openapi/components/schemas/credentials/QualifiedWebLeiIssuerCredential.yml
@@ -1,0 +1,161 @@
+$linkedData:
+  term: WebLEICredential
+  '@id': https://w3id.org/traceability#WebLeiCredential
+title: WebLEI Credential
+tags:
+  - Steel
+  - Pesticides
+description: >-
+  Verifiable Web Legal Entity Identifier.
+type: object
+properties:
+  '@context':
+    type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    items:
+      type: string
+      enum:
+        - https://www.w3.org/2018/credentials/v1
+        - https://w3id.org/traceability/v1
+  type:
+    type: array
+    readOnly: true
+    const:
+      - VerifiableCredential
+      - WebLeiCredential
+    default:
+      - VerifiableCredential
+      - WebLeiCredential
+    items:
+      type: string
+      enum:
+        - VerifiableCredential
+        - WebLeiCredential
+  id:
+    type: string
+    format: uri
+  issuanceDate:
+    type: string
+    format: date-time
+  expirationDate:
+    type: string
+    format: date-time
+  issuer:
+    title: GLEIF Level 1 Authority
+    description: GLEIF LEI Record Level 1 LEI Authority
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - LEIAuthority
+        default:
+          - LEIAuthority
+        items:
+          type: string
+          enum:
+            - LEIAuthority
+      id:
+        title: Issuer's Identifier
+        description: Issuing organization identifier, typically a Decentralized Identifier (DID).
+        type: string
+        format: uri
+      name:
+        title: Name
+        description: Issuing organization name.
+        type: string
+    additionalProperties: false
+    required:
+      - type
+      - id
+  credentialSchema:
+    type: object
+    properties:
+      id:
+        title: Id
+        description: The url of the schema file to validate the shape of the json object
+        type: string
+        format: uri
+        example: https://w3id.org/traceability/openapi/components/schemas/credentials/WebLEICredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/WebLEICredential.yml
+        readOnly: true
+      type:
+        title: Type
+        description: The type of validation to be run against the defined schema
+        const: OpenApiSpecificationValidator2022
+  credentialSubject:
+    title: Qualified WebLEI Issuer
+    description: Qualified GLEIF approved Legal Entity Identifier issuer.
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - LEIAuthority
+        default:
+          - LEIAuthority
+        items:
+          type: string
+          enum:
+            - LEIAuthority
+      id:
+        title: Issuer's Identifier
+        description: Issuing organization identifier, typically a Decentralized Identifier (DID).
+        type: string
+        format: uri
+      name:
+        title: Name
+        description: Issuing organization name.
+        type: string
+    additionalProperties: false
+    required:
+      - type
+      - id
+additionalProperties: false
+required:
+  - '@context'
+  - type
+  - id
+  - issuanceDate
+  - issuer
+  - credentialSubject
+  - credentialSchema
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "http://example.com/dd0c6f9a-5df6-40a3-bb34-863cd1fda606",
+    "credentialSchema": {
+      "type": "OpenApiSpecificationValidator2022",
+      "id": "https://w3id.org/traceability/openapi/components/schemas/credentials/WebLEICredential.yml"
+    },
+    "type": [
+      "VerifiableCredential",
+      "WebLeiCredential"
+    ],
+    "issuer": {
+      "type": [
+        "LEIAuthority"
+      ],
+      "id": "did:web:gleif.example.org",
+      "name": "GLEIF"
+    },
+    "issuanceDate": "2022-11-01T10:58:45-04:00",
+    "credentialSubject": {
+      "type": [
+        "LEIAuthority"
+      ],
+      "id": "did:web:qualified-organization.example.com",
+      "name": "United FinSec Corp."
+    }
+  }

--- a/docs/openapi/components/schemas/credentials/QualifiedWebLeiIssuerCredential.yml
+++ b/docs/openapi/components/schemas/credentials/QualifiedWebLeiIssuerCredential.yml
@@ -69,7 +69,7 @@ properties:
         format: uri
       name:
         title: Name
-        description: Issuing organization name.
+        description: Name of the issuing organization.
         type: string
     additionalProperties: false
     required:

--- a/docs/openapi/components/schemas/credentials/QualifiedWebLeiIssuerCredential.yml
+++ b/docs/openapi/components/schemas/credentials/QualifiedWebLeiIssuerCredential.yml
@@ -6,7 +6,7 @@ tags:
   - Steel
   - Pesticides
 description: >-
-  Level 1 Authority granting a Qualified WebLEI Issuer authority to issued WebLEI credentials.
+  Level 1 Authority granting the authority to issue WebLEI credentials to a Qualified WebLEI Issuer.
 type: object
 properties:
   '@context':

--- a/docs/openapi/components/schemas/credentials/QualifiedWebLeiIssuerCredential.yml
+++ b/docs/openapi/components/schemas/credentials/QualifiedWebLeiIssuerCredential.yml
@@ -1,12 +1,12 @@
 $linkedData:
-  term: WebLEICredential
-  '@id': https://w3id.org/traceability#WebLeiCredential
-title: WebLEI Credential
+  term: QualifiedWebLEIIssuerCredential
+  '@id': https://w3id.org/traceability#QualifiedWebLEIIssuerCredential
+title: Qualified WebLEI Issuer Credential
 tags:
   - Steel
   - Pesticides
 description: >-
-  Verifiable Web Legal Entity Identifier.
+  Level 1 Authority granting a Qualified WebLEI Issuer authority to issued WebLEI credentials.
 type: object
 properties:
   '@context':
@@ -28,15 +28,15 @@ properties:
     readOnly: true
     const:
       - VerifiableCredential
-      - WebLeiCredential
+      - QualifiedWebLeiIssuerCredential
     default:
       - VerifiableCredential
-      - WebLeiCredential
+      - QualifiedWebLeiIssuerCredential
     items:
       type: string
       enum:
         - VerifiableCredential
-        - WebLeiCredential
+        - QualifiedWebLeiIssuerCredential
   id:
     type: string
     format: uri
@@ -141,7 +141,7 @@ example: |-
     },
     "type": [
       "VerifiableCredential",
-      "WebLeiCredential"
+      "QualifiedWebLeiIssuerCredential"
     ],
     "issuer": {
       "type": [

--- a/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
+++ b/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
@@ -48,7 +48,7 @@ properties:
     format: date-time
   issuer:
     title: Qualified LEI Issuer
-    description: Qualified GLEIF approved Legal Entity Identifier issuer.
+    description: Qualified GLEIF-approved issuer of Legal Entity Identifiers.
     type: object
     properties:
       type:

--- a/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
+++ b/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
@@ -88,7 +88,7 @@ properties:
         readOnly: true
       type:
         title: Type
-        description: The type of validation to be run against the defined schema
+        description: The type of validation to be run against the defined schema.
         const: OpenApiSpecificationValidator2022
   credentialSubject:
     title: WebLei

--- a/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
+++ b/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
@@ -64,7 +64,7 @@ properties:
             - LEIAuthority
       id:
         title: Issuer's Identifier
-        description: Issuing organization identifier, typically a Decentralized Identifier (DID).
+        description: Identifier of the issuing organization, typically a Decentralized Identifier (DID).
         type: string
         format: uri
       name:

--- a/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
+++ b/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
@@ -80,7 +80,7 @@ properties:
     properties:
       id:
         title: Id
-        description: The url of the schema file to validate the shape of the json object
+        description: The URL of the schema file to be used to validate the shape of the JSON object.
         type: string
         format: uri
         example: https://w3id.org/traceability/openapi/components/schemas/credentials/WebLEICredential.yml

--- a/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
+++ b/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
@@ -1,0 +1,355 @@
+$linkedData:
+  term: WebLEICredential
+  '@id': https://w3id.org/traceability#WebLeiCredential
+title: WebLEI Credential
+tags:
+  - Steel
+  - Pesticides
+description: >-
+  Verifiable Web Legal Entity Identifier.
+type: object
+properties:
+  '@context':
+    type: array
+    readOnly: true
+    const:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    default:
+      - https://www.w3.org/2018/credentials/v1
+      - https://w3id.org/traceability/v1
+    items:
+      type: string
+      enum:
+        - https://www.w3.org/2018/credentials/v1
+        - https://w3id.org/traceability/v1
+  type:
+    type: array
+    readOnly: true
+    const:
+      - VerifiableCredential
+      - WebLeiCredential
+    default:
+      - VerifiableCredential
+      - WebLeiCredential
+    items:
+      type: string
+      enum:
+        - VerifiableCredential
+        - WebLeiCredential
+  id:
+    type: string
+    format: uri
+  issuanceDate:
+    type: string
+    format: date-time
+  expirationDate:
+    type: string
+    format: date-time
+  issuer:
+    title: Qualified LEI Issuer
+    description: Qualified GLEIF approved Legal Entity Identifier issuer.
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - LEIAuthority
+        default:
+          - LEIAuthority
+        items:
+          type: string
+          enum:
+            - LEIAuthority
+      id:
+        title: Issuer's Identifier
+        description: Issuing organization identifier, typically a Decentralized Identifier (DID).
+        type: string
+        format: uri
+      name:
+        title: Name
+        description: Issuing organization name.
+        type: string
+    additionalProperties: false
+    required:
+      - type
+      - id
+  credentialSchema:
+    type: object
+    properties:
+      id:
+        title: Id
+        description: The url of the schema file to validate the shape of the json object
+        type: string
+        format: uri
+        example: https://w3id.org/traceability/openapi/components/schemas/credentials/WebLEICredential.yml
+        default: https://w3id.org/traceability/openapi/components/schemas/credentials/WebLEICredential.yml
+        readOnly: true
+      type:
+        title: Type
+        description: The type of validation to be run against the defined schema
+        const: OpenApiSpecificationValidator2022
+  credentialSubject:
+    title: WebLei
+    description: Verifiable Legal Entity Identifier
+    type: object
+    properties:
+      type:
+        type: array
+        readOnly: true
+        const:
+          - WebLei
+        default:
+          - WebLei
+        items:
+          type: string
+          enum:
+            - WebLei
+      id:
+        title: Identifier
+        description: Decentralized Identifier (DID)
+        type: string
+      lei:
+        title: LEI Code
+        description: 20-digit LEI code.
+        type: string
+      entity: 
+        title: Entity 
+        type: object 
+        properties: 
+          type:
+            type: array
+            readOnly: true
+            const:
+              - LEIEntity
+            default:
+              - LEIEntity
+            items:
+              type: string
+              enum:
+                - LEIEntity
+          legalName:
+            title: Legalname
+            type: string
+          legalAddress:
+            title: LegalAddress
+            type: object
+            properties: 
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - LEIAddress
+                default:
+                  - LEIAddress
+                items:
+                  type: string
+                  enum:
+                    - LEIAddress
+              language:
+                title: Language
+                type: string
+              firstAddressLine:
+                title: First Address Line
+                type: string
+              additionalAddressLines:
+                title: Additional Address Lines
+                type: array
+                items:
+                  type: string      
+              addressNumber:
+                title: Address Number
+                type: string
+              addressNumberWithinBuilding:
+                title: Address Number Within Building
+                type: string
+              mailRouting:
+                title: Mail Routing
+                type: string
+              city:
+                title: City
+                type: string
+              region:
+                title: Region
+                type: string
+              country:
+                title: Country
+                type: string
+              postalCode:
+                title: Postalcode
+                type: string
+            additionalProperties: false
+          headquartersAddress:
+            title: HeadquartersAddress
+            type: object
+            properties: 
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - LEIAddress
+                default:
+                  - LEIAddress
+                items:
+                  type: string
+                  enum:
+                    - LEIAddress
+              language:
+                title: Language
+                type: string
+              firstAddressLine:
+                title: First Address Line
+                type: string
+              additionalAddressLines:
+                title: Additional Address Lines
+                type: array
+                items:
+                  type: string      
+              addressNumber:
+                title: Address Number
+                type: string
+              addressNumberWithinBuilding:
+                title: Address Number Within Building
+                type: string
+              mailRouting:
+                title: Mail Routing
+                type: string
+              city:
+                title: City
+                type: string
+              region:
+                title: Region
+                type: string
+              country:
+                title: Country
+                type: string
+              postalCode:
+                title: Postalcode
+                type: string
+            additionalProperties: false
+          registration:
+            title: Registration
+            type: object
+            properties: 
+              type:
+                type: array
+                readOnly: true
+                const:
+                  - LEIRegistration
+                default:
+                  - LEIRegistration
+                items:
+                  type: string
+                  enum:
+                    - LEIRegistration
+              initialRegistrationDate:
+                title: Initial Registration Date
+                type: string
+                format: date
+              lastUpdateDate:
+                title: Last Update Date
+                type: string
+                format: date
+              status:
+                title: Status
+                type: string
+              nextRenewalDate:
+                title: Next Renewal Date
+                type: string
+                format: date
+    required:
+      - type
+      - id
+      - lei
+additionalProperties: false
+required:
+  - '@context'
+  - type
+  - id
+  - validFrom
+  - issuer
+  - credentialSubject
+  - credentialSchema
+example: |-
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/traceability/v1"
+    ],
+    "id": "http://example.com/dd0c6f9a-5df6-40a3-bb34-863cd1fda606",
+    "credentialSchema": {
+      "type": "JsonSchema",
+      "id": "https://platform.transmute.industries/templates/urn:transmute:template:web-lei-credential"
+    },
+    "type": [
+      "VerifiableCredential",
+      "WebLeiCredential"
+    ],
+    "issuer": {
+      "type": [
+        "LEIAuthority"
+      ],
+      "id": "did:web:qualified-organization.example.com",
+      "name": "United FinSec Corp."
+    },
+    "issuanceDate": "2022-11-01T10:58:45-04:00",
+    "credentialSubject": {
+      "type": [
+        "WebLei"
+      ],
+      "id": "did:web:organization.example.com",
+      "lei": "12345678901011121314",
+      "entity": {
+        "type": [
+          "LEIEntity"
+        ],
+        "legalName": "Bashirian, Botsford, and Hill",
+        "legalAddress": {
+          "type": [
+            "LEIAddress"
+          ],
+          "language": "en",
+          "firstAddressLine": "330 N Brand Blvd",
+          "additionalAddressLines": [
+            "C/O C T Corporation System",
+            "Suite 700"
+          ],
+          "addressNumber": "5",
+          "addressNumberWithinBuilding": "5",
+          "mailRouting": "633 Padberg Roads, 75463",
+          "city": "East Morris",
+          "region": "Bedfordshire",
+          "country": "Saint Helena",
+          "postalCode": "56041-9807"
+        },
+        "headquartersAddress": {
+          "type": [
+            "LEIAddress"
+          ],
+          "language": "en",
+          "firstAddressLine": "29723 Dare Radial",
+          "additionalAddressLines": [
+            "Cormier - Quigley",
+            "25974 Meda Valley"
+          ],
+          "addressNumber": "105",
+          "addressNumberWithinBuilding": "4",
+          "mailRouting": "539 Spencer Unions, 81768-3826",
+          "city": "Banská Bystrica",
+          "region": "Buckinghamshire",
+          "country": "Yemen",
+          "postalCode": "98342-0463"
+        },
+        "registration": {
+          "type": [
+            "LEIRegistration"
+          ],
+          "initialRegistrationDate": "2020-01-01",
+          "lastUpdateDate": "2020-01-01",
+          "status": "IN PROGRESS",
+          "nextRenewalDate": "2021-02-02"
+        }
+      }
+    }
+  }

--- a/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
+++ b/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
@@ -69,7 +69,7 @@ properties:
         format: uri
       name:
         title: Name
-        description: Issuing organization name.
+        description: Name of the issuing organization.
         type: string
     additionalProperties: false
     required:

--- a/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
+++ b/docs/openapi/components/schemas/credentials/WebLeiCredential.yml
@@ -99,13 +99,13 @@ properties:
         type: array
         readOnly: true
         const:
-          - WebLei
+          - WebLEI
         default:
-          - WebLei
+          - WebLEI
         items:
           type: string
           enum:
-            - WebLei
+            - WebLEI
       id:
         title: Identifier
         description: Decentralized Identifier (DID)
@@ -267,7 +267,7 @@ required:
   - '@context'
   - type
   - id
-  - validFrom
+  - issuanceDate
   - issuer
   - credentialSubject
   - credentialSchema
@@ -279,8 +279,8 @@ example: |-
     ],
     "id": "http://example.com/dd0c6f9a-5df6-40a3-bb34-863cd1fda606",
     "credentialSchema": {
-      "type": "JsonSchema",
-      "id": "https://platform.transmute.industries/templates/urn:transmute:template:web-lei-credential"
+      "type": "OpenApiSpecificationValidator2022",
+      "id": "https://w3id.org/traceability/openapi/components/schemas/credentials/WebLEICredential.yml"
     },
     "type": [
       "VerifiableCredential",
@@ -296,7 +296,7 @@ example: |-
     "issuanceDate": "2022-11-01T10:58:45-04:00",
     "credentialSubject": {
       "type": [
-        "WebLei"
+        "WebLEI"
       ],
       "id": "did:web:organization.example.com",
       "lei": "12345678901011121314",


### PR DESCRIPTION
This adds a schema for a WebLEI credential, mainly wrapping the VC data model around the existing 3+ years old LEI classes: WebLEI for subject, LEIAuthority as issuer. 